### PR TITLE
install dep as required for operator-sdk

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -27,6 +27,15 @@ RUN yum install epel-release -y \
 
 ENV PATH=$PATH:$GOPATH/bin
 
+# install dep
+RUN mkdir -p $GOPATH/bin && chmod a+rwx $GOPATH \
+    && curl -L -s https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -o dep \
+    && echo "7479cca72da0596bb3c23094d363ea32b7336daa5473fa785a2099be28ecd0e3  dep" > dep-linux-amd64.sha256 \
+    && sha256sum -c dep-linux-amd64.sha256 \
+    && rm dep-linux-amd64.sha256 \
+    && chmod +x ./dep \
+    && mv dep $GOPATH/bin/dep
+
 # download, verify and install openshift client tools (oc and kubectl)
 WORKDIR /tmp
 RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -o openshift-origin-client-tools.tar.gz \


### PR DESCRIPTION
Initially I tried to remove `dep` as we already moved to go modules. but looks like to install operator-sdk, we still need dep to be installed.

You can find failed build logs at https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_release/4034/rehearse-4034-pull-ci-codeready-toolchain-member-operator-master-test/2