### PR TITLE
chore: fix make targets and install operator-sdk by curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ include ./make/format.mk
 include ./make/lint.mk
 include ./make/test.mk
 
+GO111MODULE?=on
+export GO111MODULE
+
 .PHONY: build
 ## Build the operator
 build: ./out/operator

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -13,7 +13,7 @@ lint: lint-go-code lint-yaml
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 .PHONY: lint-yaml
 ## runs yamllint on all yaml files
-lint-yaml: ./vendor ${YAML_FILES}
+lint-yaml: ${YAML_FILES}
 	$(Q)yamllint -c .yamllint $(YAML_FILES)
 
 .PHONY: lint-go-code

--- a/make/test.mk
+++ b/make/test.mk
@@ -7,7 +7,7 @@ include ./make/out.mk
 
 .PHONY: test
 ## Runs Go package tests and stops when the first one fails
-test: ./vendor
+test:
 	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -failfast
 
 .PHONY: test-coverage
@@ -16,10 +16,10 @@ test-coverage: ./out/cover.out
 
 .PHONY: test-coverage-html
 ## Gather (if needed) coverage information and show it in your browser
-test-coverage-html: ./vendor ./out/cover.out
+test-coverage-html: ./out/cover.out
 	$(Q)go tool cover -html=./out/cover.out
 
-./out/cover.out: ./vendor
+./out/cover.out:
 	$(Q)go test ${V_FLAG} -race $(shell go list ./... | grep -v /test/e2e) -failfast -coverprofile=cover.out -covermode=atomic -outputdir=./out
 
 

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -27,6 +27,15 @@ RUN yum install epel-release -y \
 
 ENV PATH=$PATH:$GOPATH/bin
 
+# install dep
+RUN mkdir -p $GOPATH/bin && chmod a+rwx $GOPATH \
+    && curl -L -s https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -o dep \
+    && echo "7479cca72da0596bb3c23094d363ea32b7336daa5473fa785a2099be28ecd0e3  dep" > dep-linux-amd64.sha256 \
+    && sha256sum -c dep-linux-amd64.sha256 \
+    && rm dep-linux-amd64.sha256 \
+    && chmod +x ./dep \
+    && mv dep $GOPATH/bin/dep
+
 # download, verify and install openshift client tools (oc and kubectl)
 WORKDIR /tmp
 RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -o openshift-origin-client-tools.tar.gz \

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,12 +1,16 @@
 FROM centos:7 as build-tools
-LABEL maintainer "Devtools <devtools@redhat.com>"
-LABEL author "Devtools <devtools@redhat.com>"
-ENV LANG=en_US.utf8
-ENV GOPATH /tmp/go
-ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/member-operator
 
-ENV GIT_COMMITTER_NAME devtools
-ENV GIT_COMMITTER_EMAIL devtools@redhat.com
+LABEL maintainer "Devtools <devtools@redhat.com>" \
+      author "Devtools <devtools@redhat.com>"
+
+ENV LANG=en_US.utf8 \
+    GOPATH=/tmp/go \
+    PATH=$PATH:$GOPATH/bin \
+    GIT_COMMITTER_NAME=devtools \
+    GIT_COMMITTER_EMAIL=devtools@redhat.com \
+    OPERATOR_SDK_VERSION=v0.8.1
+
+ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/member-operator
 
 RUN yum install epel-release -y \
     && yum install --enablerepo=centosplus install -y --quiet \
@@ -24,18 +28,6 @@ RUN yum install epel-release -y \
     python36-virtualenv \
     && yum clean all
 
-
-ENV PATH=$PATH:$GOPATH/bin
-
-# install dep
-RUN mkdir -p $GOPATH/bin && chmod a+rwx $GOPATH \
-    && curl -L -s https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -o dep \
-    && echo "7479cca72da0596bb3c23094d363ea32b7336daa5473fa785a2099be28ecd0e3  dep" > dep-linux-amd64.sha256 \
-    && sha256sum -c dep-linux-amd64.sha256 \
-    && rm dep-linux-amd64.sha256 \
-    && chmod +x ./dep \
-    && mv dep $GOPATH/bin/dep
-
 # download, verify and install openshift client tools (oc and kubectl)
 WORKDIR /tmp
 RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -o openshift-origin-client-tools.tar.gz \
@@ -47,13 +39,14 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
     && rm -rf ./openshift* \
     && oc version
 
-# install operator-sdk (from git with no history and only the tag)
-RUN mkdir -p $GOPATH/src/github.com/operator-framework \
-    && cd $GOPATH/src/github.com/operator-framework \
-    && git clone --depth 1 -b v0.8.1 https://github.com/operator-framework/operator-sdk \
-    && cd operator-sdk \
-    && make dep \
-    && make install
+# download, verify and install operator-sdk
+RUN curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk \
+    && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc \
+    && gpg --recv-key 90D2B445 \
+    && gpg --verify operator-sdk.asc \
+    && chmod +x operator-sdk \
+    && cp operator-sdk /usr/bin/operator-sdk \
+    && rm operator-sdk
 
 RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/
 


### PR DESCRIPTION
*Changes proposed in this PR*
- removes not-exist make target `/vendor`
- install operator-sdk by curl
- reduce number of caching layer by adding `LABEL` and `ENV` in single dir.
- exporting  `GO111MODULE=on` 