### PR TITLE
move author under another LABEL instruction

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,7 +1,7 @@
 FROM centos:7 as build-tools
 
-LABEL maintainer "Devtools <devtools@redhat.com>" \
-      author "Devtools <devtools@redhat.com>"
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
 
 ENV LANG=en_US.utf8 \
     GOPATH=/tmp/go \


### PR DESCRIPTION
openshift CI failing to use build using git source strategy. 

Logs 
- https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/4034/rehearse-4034-pull-ci-codeready-toolchain-member-operator-master-lint/4/build-log.txt
- http://pastebin.test.redhat.com/771467