### PR TITLE
chore: add keyserver to import gpg keys

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -42,7 +42,7 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
 # download, verify and install operator-sdk
 RUN curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk \
     && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc \
-    && gpg --recv-key 90D2B445 \
+    && gpg --keyserver keyserver.ubuntu.com --recv-key 90D2B445 \
     && gpg --verify operator-sdk.asc \
     && chmod +x operator-sdk \
     && cp operator-sdk /usr/bin/operator-sdk \


### PR DESCRIPTION
Looks like build is failing as missing keyserver. You can find build logs at https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/4034/rehearse-4034-pull-ci-codeready-toolchain-member-operator-master-build/7/build-log.txt

However you can find documentation about how can you configure keyserver for operator-sdk https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md#verify-the-downloaded-release-binary