### PR TITLE
chore: remove dep from require executables

### DIFF
--- a/make/find-tools.mk
+++ b/make/find-tools.mk
@@ -2,7 +2,7 @@ ifndef FIND_TOOLS_MK
 FIND_TOOLS_MK:=# Prevent repeated "-include".
 
 # Check all required tools are accessible
-REQUIRED_EXECUTABLES = go gofmt dep git oc operator-sdk sed yamllint find grep python3
+REQUIRED_EXECUTABLES = go gofmt git oc operator-sdk sed yamllint find grep python3
 # If we're running e.g. "make docker-build", nothing but docker is required
 # because all the above build tools are supposed to be included in the docker
 # image.


### PR DESCRIPTION
We don't need to verify that `dep` is installed or not as we are using `mod`. this is why removing it.