### PR TITLE
change GOCACHE under /tmp/.cache

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -5,6 +5,7 @@ LABEL author "Devtools <devtools@redhat.com>"
 
 ENV LANG=en_US.utf8 \
     GOPATH=/tmp/go \
+    GOCACHE=/tmp/.cache \
     PATH=$PATH:$GOPATH/bin \
     GIT_COMMITTER_NAME=devtools \
     GIT_COMMITTER_EMAIL=devtools@redhat.com \


### PR DESCRIPTION
*Changes Proposed in this PR*

- Change `GOCACHE` to `/tmp/.cache` directory where we have permission to create it.

CI build is failing - https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/4034/rehearse-4034-pull-ci-codeready-toolchain-member-operator-master-build/9/build-log.txt