### PR TITLE
download golangci-lint using go get

### DIFF
--- a/make/lint.mk
+++ b/make/lint.mk
@@ -1,8 +1,6 @@
 ifndef LINT_MK
 LINT_MK:=# Prevent repeated "-include".
 
-GOLANGCI_LINT_BIN=./out/golangci-lint
-
 include ./make/verbose.mk
 include ./make/go.mk
 
@@ -19,12 +17,10 @@ lint-yaml: ${YAML_FILES}
 .PHONY: lint-go-code
 ## Checks the code with golangci-lint
 lint-go-code: $(GOLANGCI_LINT_BIN)
-	# This is required for OpenShift CI enviroment
-	# Ref: https://github.com/openshift/release/pull/3438#issuecomment-482053250
-	$(Q)GOCACHE=$(shell pwd)/out/gocache ./out/golangci-lint ${V_FLAG} run --deadline=10m
+	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run --deadline=10m
 
 $(GOLANGCI_LINT_BIN):
-	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.17.1
+	$(Q)go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 endif
 


### PR DESCRIPTION
Build is failing https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/4034/rehearse-4034-pull-ci-codeready-toolchain-member-operator-master-lint/10/build-log.txt