### PR TITLE
change operator location as it's copied from bin container

### DIFF
--- a/openshift-ci/Dockerfile.deploy
+++ b/openshift-ci/Dockerfile.deploy
@@ -5,7 +5,7 @@ LABEL author "Devtools <devtools@redhat.com>"
 
 ENV LANG=en_US.utf8
 
-COPY out/operator /usr/local/bin/member-operator
+COPY operator /usr/local/bin/member-operator
 USER 10001
 
 ENTRYPOINT [ "/usr/local/bin/member-operator" ]


### PR DESCRIPTION
Currently we are trying to use same dockerfile for local development and ci setup. But looks like CI setup is expecting it only `operator` not `out/operator` as it's copied from `bin` container