### PR TITLE
revert Dockerfile as symbolic link is not working for operator-sdk build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,1 +1,16 @@
-openshift-ci/Dockerfile.deploy
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+
+ENV OPERATOR=/usr/local/bin/member-operator \
+    USER_UID=1001 \
+    USER_NAME=member-operator
+
+ # install operator binary
+COPY build/_output/bin/member-operator ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+# This is documented here:
+# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
+
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-app-operator}:x:$(id -u):$(id -g):${USER_NAME:-app-operator} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec ${OPERATOR} $@

--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+mkdir -p ${HOME}
+chown ${USER_UID}:0 ${HOME}
+chmod ug+rwx ${HOME}
+
+# runtime user will need to be able to self-insert in /etc/passwd
+chmod g+rw /etc/passwd
+
+# no need for this script to remain in the image after running
+rm $0


### PR DESCRIPTION
If we try to build operator using `operator-sdk build quay.io/codeready-toolchain/member-operator`, then it's failing due to symbolic link and missing `bin` directory 