### PR TITLE
fix: add toolchain.dev.openshift.com group to member-operator role

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -39,3 +39,10 @@ rules:
   - member-operator
   verbs:
   - "update"
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - nstemplatesets
+  - useraccounts
+  verbs:
+  - '*'


### PR DESCRIPTION
add toolchain.dev.openshift.com group to member-operator role so the ServiceAccount can watch these CRs