### PR TITLE
reorg makefiles and setup codecov

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -17,19 +17,19 @@ coverage:
     # changes tells us if there are unexpected code coverage changes in other files
     # which were not changed by the diff
     changes: yes
-    
+
   # See http://docs.codecov.io/docs/ignoring-paths
   ignore:
-   - "vendor/*"
-   - "make/*"
-   - "build/*"
-   - "example/*"
-   - "openshift-ci/*"
+    - "vendor/*"
+    - "make/*"
+    - "build/*"
+    - "example/*"
+    - "openshift-ci/*"
 
 # See http://docs.codecov.io/docs/pull-request-comments-1
 comment:
   layout: "header, diff, tree"
-  behavior: # defualt = posts once then update, posts new if delete
+  behavior: # default = posts once then update, posts new if delete
             # once = post once then updates
             # new = delete old, post new
             # spammy = post new

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,35 @@
+# See http://docs.codecov.io/docs/coverage-configuration
+coverage:
+  precision: 2 # 2 = xx.xx%, 0 = xx%
+  round: down
+  # For example: 20...60 would result in any coverage less than 20%
+  # would have a red background. The color would gradually change to
+  # green approaching 60%. Any coverage over 60% would result in a
+  # solid green color.
+  range: "20...60"
+
+  status:
+    # project will give us the diff in the total code coverage between a commit
+    # and its parent
+    project: yes
+    # Patch gives just the coverage of the patch
+    patch: yes
+    # changes tells us if there are unexpected code coverage changes in other files
+    # which were not changed by the diff
+    changes: yes
+    
+  # See http://docs.codecov.io/docs/ignoring-paths
+  ignore:
+   - "vendor/*"
+   - "make/*"
+   - "build/*"
+   - "example/*"
+   - "openshift-ci/*"
+
+# See http://docs.codecov.io/docs/pull-request-comments-1
+comment:
+  layout: "header, diff, tree"
+  behavior: # defualt = posts once then update, posts new if delete
+            # once = post once then updates
+            # new = delete old, post new
+            # spammy = post new

--- a/.yamllint
+++ b/.yamllint
@@ -14,8 +14,7 @@ rules:
   hyphens: enable
   key-duplicates: enable
   key-ordering: disable
-  line-length:
-    level: warning
+  line-length: disable
   new-line-at-end-of-file: disable
   new-lines: enable
   octal-values: enable

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,5 @@
 # It's necessary to set this because some environments don't link sh -> bash.
 SHELL := /bin/bash
 
-include ./make/verbose.mk
+include ./make/*.mk
 .DEFAULT_GOAL := help
-include ./make/help.mk
-include ./make/out.mk
-include ./make/find-tools.mk
-include ./make/go.mk
-include ./make/git.mk
-include ./make/dev.mk
-include ./make/format.mk
-include ./make/lint.mk
-include ./make/test.mk
-
-GO111MODULE?=on
-export GO111MODULE
-
-.PHONY: build
-## Build the operator
-build: ./out/operator
-
-.PHONY: clean
-clean:
-	$(Q)-rm -rf ${V_FLAG} ./out
-	$(Q)go clean ${X_FLAG} ./...
-
-./out/operator:
-	$(Q)CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
-		go build ${V_FLAG} \
-		-ldflags "-X ${GO_PACKAGE_PATH}/cmd/manager.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/cmd/manager.BuildTime=${BUILD_TIME}" \
-		-o ./out/operator \
-		cmd/manager/main.go
-
-.PHONY: vendor
-vendor:
-	$(Q)go mod vendor

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,9 @@
 = Member Operator
 
+image:https://goreportcard.com/badge/github.com/codeready-toolchain/member-operator[Go Report Card, link="https://goreportcard.com/report/github.com/codeready-toolchain/member-operator"]
+image:https://godoc.org/github.com/codeready-toolchain/member-operator?status.png[GoDoc,link="https://godoc.org/github.com/codeready-toolchain/member-operator"]
+image:https://codecov.io/gh/codeready-toolchain/member-operator/branch/master/graph/badge.svg[Codecov.io,link="https://codecov.io/gh/codeready-toolchain/member-operator"]
+
 This is the CodeReady Toolchain Member Operator repository. It contains the OpenShift Operator that is deployed on the "member" cluster in the SaaS.
 
 == Build

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -1,0 +1,4 @@
+.PHONY: clean
+clean:
+	$(Q)-rm -rf ${V_FLAG} $(OUT_DIR)
+	$(Q)go clean ${X_FLAG} ./...

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -1,9 +1,3 @@
-ifndef DEV_MK
-DEV_MK:=# Prevent repeated "-include".
-
-include ./make/verbose.mk
-include ./make/git.mk
-
 DOCKER_REPO?=quay.io/codeready-toolchain
 IMAGE_NAME?=member-operator
 
@@ -74,5 +68,3 @@ add-member-to-host:
 ## Run script add-cluster.sh host host-cluster
 add-host-to-member:
 	@${ADD_CLUSTER_SCRIPT_PATH} host host-cluster
-
-endif

--- a/make/find-tools.mk
+++ b/make/find-tools.mk
@@ -1,6 +1,3 @@
-ifndef FIND_TOOLS_MK
-FIND_TOOLS_MK:=# Prevent repeated "-include".
-
 # Check all required tools are accessible
 REQUIRED_EXECUTABLES = go gofmt git oc operator-sdk sed yamllint find grep python3
 # If we're running e.g. "make docker-build", nothing but docker is required
@@ -19,6 +16,3 @@ K := $(foreach exec,$(REQUIRED_EXECUTABLES),\
         $(if $(shell which $(exec) 2>/dev/null),some string,$(error "ERROR: No "$(exec)" binary found in in PATH!")))
 endif
 endif
-
-endif
-

--- a/make/format.mk
+++ b/make/format.mk
@@ -1,8 +1,3 @@
-ifndef FORMAT_MK
-FORMAT_MK:=# Prevent repeated "-include".
-
-include ./make/out.mk
-
 GOFORMAT_FILES := $(shell find  . -name '*.go')
 
 .PHONY: check-go-format
@@ -20,5 +15,3 @@ check-go-format:
 ## Formats any go file that does not match formatting defined by gofmt
 format-go-code:
 	$(Q)gofmt -s -l -w ${GOFORMAT_FILES}
-
-endif

--- a/make/git.mk
+++ b/make/git.mk
@@ -1,6 +1,3 @@
-ifndef GIT_MK
-GIT_MK:=# Prevent repeated "-include".
-
 GIT_COMMIT_ID := $(shell git rev-parse HEAD)
 ifneq ($(shell git status --porcelain --untracked-files=no),)
        GIT_COMMIT_ID := $(GIT_COMMIT_ID)-dirty
@@ -12,5 +9,3 @@ ifneq ($(shell git status --porcelain --untracked-files=no),)
 endif
 
 BUILD_TIME = `date -u '+%Y-%m-%dT%H:%M:%SZ'`
-
-endif

--- a/make/go.mk
+++ b/make/go.mk
@@ -1,9 +1,22 @@
-ifndef GO_MK
-GO_MK:=# Prevent repeated "-include".
-
 # By default the project should be build under GOPATH/src/github.com/<orgname>/<reponame>
 GO_PACKAGE_ORG_NAME ?= $(shell basename $$(dirname $$PWD))
 GO_PACKAGE_REPO_NAME ?= $(shell basename $$PWD)
 GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 
-endif
+GO111MODULE?=on
+export GO111MODULE
+
+.PHONY: build
+## Build the operator
+build: $(OUT_DIR)/operator
+
+$(OUT_DIR)/operator:
+	$(Q)CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
+		go build ${V_FLAG} \
+		-ldflags "-X ${GO_PACKAGE_PATH}/cmd/manager.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/cmd/manager.BuildTime=${BUILD_TIME}" \
+		-o ./out/operator \
+		cmd/manager/main.go
+
+.PHONY: vendor
+vendor:
+	$(Q)go mod vendor

--- a/make/help.mk
+++ b/make/help.mk
@@ -1,6 +1,3 @@
-ifndef HELP_MK
-HELP_MK:=# Prevent repeated "-include".
-
 .PHONY: help
 # Based on https://gist.github.com/rcmachado/af3db315e31383502660
 ## Display this help text
@@ -25,5 +22,3 @@ help:/
 	    lastLine = $$0 \
           } \
         }' $(MAKEFILE_LIST)
-
-endif

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -1,9 +1,3 @@
-ifndef LINT_MK
-LINT_MK:=# Prevent repeated "-include".
-
-include ./make/verbose.mk
-include ./make/go.mk
-
 .PHONY: lint
 ## Runs linters on Go code files and YAML files
 lint: lint-go-code lint-yaml
@@ -19,6 +13,3 @@ lint-yaml: ${YAML_FILES}
 lint-go-code:
 	$(Q)go get github.com/golangci/golangci-lint/cmd/golangci-lint
 	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run --deadline=10m
-
-endif
-

--- a/make/out.mk
+++ b/make/out.mk
@@ -1,9 +1,5 @@
-ifndef OUT_MK
-OUT_MK:=# Prevent repeated "-include".
-
 # Create output directory for artifacts and test results. ./out is supposed to
 # be a safe place for all targets to write to while knowing that all content
 # inside of ./out is wiped once "make clean" is run.
-$(shell mkdir -p ./out);
-
-endif
+OUT_DIR := ./out
+$(shell mkdir -p $(OUT_DIR));

--- a/make/test.mk
+++ b/make/test.mk
@@ -1,26 +1,22 @@
-ifndef TEST_MK
-TEST_MK:=# Prevent repeated "-include".
-UNAME_S := $(shell uname -s)
-
-include ./make/verbose.mk
-include ./make/out.mk
-
 .PHONY: test
-## Runs Go package tests and stops when the first one fails
-test:
-	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -failfast
-
-.PHONY: test-coverage
-## Runs Go package tests and produces coverage information
-test-coverage: ./out/cover.out
-
-.PHONY: test-coverage-html
-## Gather (if needed) coverage information and show it in your browser
-test-coverage-html: ./out/cover.out
-	$(Q)go tool cover -html=./out/cover.out
-
-./out/cover.out:
-	$(Q)go test ${V_FLAG} -race $(shell go list ./... | grep -v /test/e2e) -failfast -coverprofile=cover.out -covermode=atomic -outputdir=./out
-
-
+## runs the tests *with* coverage
+test: 
+	@echo "running the tests with coverage..."
+	-mkdir -p $(COV_DIR)
+	-rm $(COV_DIR)/coverage.txt
+	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -coverprofile=$(COV_DIR)/profile.out -covermode=atomic ./...
+ifeq (,$(wildcard $(COV_DIR)/profile.out))
+	cat $(COV_DIR)/profile.out >> $(COV_DIR)/coverage.txt
+	rm $(COV_DIR)/profile.out
 endif
+	# Upload coverage to codecov.io
+	bash <(curl -s https://codecov.io/bash) -f $(COV_DIR)/coverage.txt -t 51cc45ad-2e54-4e68-98cb-8ab15cf2b8df
+
+# Output directory for coverage information
+COV_DIR = $(OUT_DIR)/coverage
+
+.PHONY: test-without-coverage
+## runs the tests without coverage and excluding E2E tests
+test-without-coverage:
+	@echo "running the tests without coverage and excluding E2E tests..."
+	$(Q)go test ${V_FLAG} -race $(shell go list ./... | grep -v /test/e2e) -failfast

--- a/make/verbose.mk
+++ b/make/verbose.mk
@@ -1,6 +1,3 @@
-ifndef VERBOSE_MK
-VERBOSE_MK:=# Prevent repeated "-include".
-
 # When you run make VERBOSE=1 (the default), executed commands will be printed
 # before executed. If you run make VERBOSE=2 verbose flags are turned on and
 # quiet flags are turned off for various commands. Use V_FLAG in places where
@@ -24,6 +21,4 @@ ifeq ($(VERBOSE),2)
        S_FLAG =
        V_FLAG = -v
        X_FLAG = -x
-endif
-
 endif


### PR DESCRIPTION
- remove all 'inlclude' directives and just
use a wildcard include in Makefile

- add coverage on 'test' and upload the result
to codecov.io with the token for the repo

- add a goal to run the tests (except E2E) without
coverage (aimed at local testing)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>