### PR TITLE
separate goal to upload codecov report

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -1,15 +1,24 @@
 .PHONY: test
+## runs the tests without coverage and excluding E2E tests
+test:
+	@echo "running the tests without coverage and excluding E2E tests..."
+	$(Q)go test ${V_FLAG} -race $(shell go list ./... | grep -v /test/e2e) -failfast
+	
+.PHONY: test-ci
+# runs the tests and uploads the coverage report on codecov.io
+# DO NOT USE LOCALLY: must only be called by OpenShift CI when processing new PR and when a PR is merged! 
+test-ci: test-with-coverage upload-codecov-report
+
+# Output directory for coverage information
+COV_DIR = $(OUT_DIR)/coverage
+
+.PHONY: test-with-coverage
 ## runs the tests *with* coverage
-test: 
+test-with-coverage: 
 	@echo "running the tests with coverage..."
 	@-mkdir -p $(COV_DIR)
 	@-rm $(COV_DIR)/coverage.txt
 	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -coverprofile=$(COV_DIR)/coverage.txt -covermode=atomic ./...
-
-.PHONY: test-ci
-# runs the tests and uploads the coverage report on codecov.io
-# DO NOT USE LOCALLY: must only be called by OpenShift CI when processing new PR and when a PR is merged! 
-test-ci: test upload-codecov-report
 
 .PHONY: upload-codecov-report
 # Uploads the test coverage reports to codecov.io. 
@@ -17,12 +26,3 @@ test-ci: test upload-codecov-report
 upload-codecov-report: 
 	# Upload coverage to codecov.io
 	bash <(curl -s https://codecov.io/bash) -f $(COV_DIR)/coverage.txt -t 51cc45ad-2e54-4e68-98cb-8ab15cf2b8df
-
-# Output directory for coverage information
-COV_DIR = $(OUT_DIR)/coverage
-
-.PHONY: test-without-coverage
-## runs the tests without coverage and excluding E2E tests
-test-without-coverage:
-	@echo "running the tests without coverage and excluding E2E tests..."
-	$(Q)go test ${V_FLAG} -race $(shell go list ./... | grep -v /test/e2e) -failfast

--- a/make/test.mk
+++ b/make/test.mk
@@ -2,13 +2,19 @@
 ## runs the tests *with* coverage
 test: 
 	@echo "running the tests with coverage..."
-	-mkdir -p $(COV_DIR)
-	-rm $(COV_DIR)/coverage.txt
-	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -coverprofile=$(COV_DIR)/profile.out -covermode=atomic ./...
-ifeq (,$(wildcard $(COV_DIR)/profile.out))
-	cat $(COV_DIR)/profile.out >> $(COV_DIR)/coverage.txt
-	rm $(COV_DIR)/profile.out
-endif
+	@-mkdir -p $(COV_DIR)
+	@-rm $(COV_DIR)/coverage.txt
+	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -coverprofile=$(COV_DIR)/coverage.txt -covermode=atomic ./...
+
+.PHONY: test-ci
+# runs the tests and uploads the coverage report on codecov.io
+# DO NOT USE LOCALLY: must only be called by OpenShift CI when processing new PR and when a PR is merged! 
+test-ci: test upload-codecov-report
+
+.PHONY: upload-codecov-report
+# Uploads the test coverage reports to codecov.io. 
+# DO NOT USE LOCALLY: must only be called by OpenShift CI when processing new PR and when a PR is merged! 
+upload-codecov-report: 
 	# Upload coverage to codecov.io
 	bash <(curl -s https://codecov.io/bash) -f $(COV_DIR)/coverage.txt -t 51cc45ad-2e54-4e68-98cb-8ab15cf2b8df
 


### PR DESCRIPTION
New goal to avoid uploading the coverage report on codecov.io each time we run the tests locally (🤦‍♂) 

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>