### PR TITLE
Switch UserAccount to Status Conditions

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_useraccount.yaml
+++ b/deploy/crds/toolchain_v1alpha1_useraccount.yaml
@@ -30,6 +30,10 @@ spec:
           type: object
         spec:
           properties:
+            disabled:
+              description: If set to true then the corresponding user should not be
+                able to login "false" is assumed by default
+              type: boolean
             nsLimit:
               description: The namespace limit name
               type: string
@@ -73,12 +77,32 @@ spec:
           type: object
         status:
           properties:
-            error:
-              description: The error message in case of failed status
-              type: string
-            status:
-              description: 'Observed status. For example: provisioning|provisioned'
-              type: string
+            conditions:
+              description: 'Conditions is an array of current User Account conditions
+                Supported condition types: Provisioning, UserNotReady, IdentityNotReady,
+                UserIdentityMappingNotReady, NSTemplateSetNotReady and Ready +patchMergeKey=type
+                +patchStrategy=merge'
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                required:
+                - status
+                type: object
+              type: array
           type: object
   version: v1alpha1
 status:

--- a/deploy/crds/toolchain_v1alpha1_useraccount.yaml
+++ b/deploy/crds/toolchain_v1alpha1_useraccount.yaml
@@ -15,6 +15,7 @@ spec:
     - name: User ID
       type: string
       JSONPath: .spec.userID
+      priority: 1
     - name: NS Limit
       type: string
       JSONPath: .spec.nsLimit
@@ -30,6 +31,7 @@ spec:
     - name: Disabled
       type: boolean
       JSONPath: .spec.disabled
+      priority: 1
   subresources:
     status: {}
   validation:

--- a/deploy/crds/toolchain_v1alpha1_useraccount.yaml
+++ b/deploy/crds/toolchain_v1alpha1_useraccount.yaml
@@ -21,15 +21,15 @@ spec:
     - name: Tier Name
       type: string
       JSONPath: .spec.nsTemplateSet.tierName
-    - name: Disabled
-      type: boolean
-      JSONPath: .spec.disabled
     - name: Ready
       type: string
       JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
     - name: Reason
       type: string
       JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Disabled
+      type: boolean
+      JSONPath: .spec.disabled
   subresources:
     status: {}
   validation:

--- a/deploy/crds/toolchain_v1alpha1_useraccount.yaml
+++ b/deploy/crds/toolchain_v1alpha1_useraccount.yaml
@@ -11,6 +11,25 @@ spec:
     kind: UserAccount
     plural: useraccounts
   scope: Namespaced
+  additionalPrinterColumns:
+    - name: User ID
+      type: string
+      JSONPath: .spec.userID
+    - name: NS Limit
+      type: string
+      JSONPath: .spec.nsLimit
+    - name: Tier Name
+      type: string
+      JSONPath: .spec.nsTemplateSet.tierName
+    - name: Disabled
+      type: boolean
+      JSONPath: .spec.disabled
+    - name: Ready
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
   subresources:
     status: {}
   validation:

--- a/deploy/crds/toolchain_v1alpha1_useraccount.yaml
+++ b/deploy/crds/toolchain_v1alpha1_useraccount.yaml
@@ -99,7 +99,11 @@ spec:
                   status:
                     description: Status of the condition, one of True, False, Unknown.
                     type: string
+                  type:
+                    description: Type of condition
+                    type: string
                 required:
+                - type
                 - status
                 type: object
               type: array

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ require (
 	cloud.google.com/go v0.40.0 // indirect
 	contrib.go.opencensus.io/exporter/ocagent v0.4.9 // indirect
 	github.com/Azure/go-autorest v11.5.2+incompatible // indirect
-	github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20190710025502-b931feee5a1d
+	github.com/codeready-toolchain/api v0.0.0-20190712171113-7038210b9ba5
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20190712173044-bb50b23fbdd7
 	github.com/coreos/prometheus-operator v0.26.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/go-logr/logr v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ require (
 	cloud.google.com/go v0.40.0 // indirect
 	contrib.go.opencensus.io/exporter/ocagent v0.4.9 // indirect
 	github.com/Azure/go-autorest v11.5.2+incompatible // indirect
-	github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870
+	github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20190710025502-b931feee5a1d
 	github.com/coreos/prometheus-operator v0.26.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/go-logr/logr v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	cloud.google.com/go v0.40.0 // indirect
 	contrib.go.opencensus.io/exporter/ocagent v0.4.9 // indirect
 	github.com/Azure/go-autorest v11.5.2+incompatible // indirect
-	github.com/codeready-toolchain/api v0.0.0-20190627153646-25d21e70de5d
+	github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870
 	github.com/coreos/prometheus-operator v0.26.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20190627153646-25d21e70de5d h1:hV+TNcbizmv1OA2wIeYpIJG3Vglp7LfCRt/ujxIPTE8=
 github.com/codeready-toolchain/api v0.0.0-20190627153646-25d21e70de5d/go.mod h1:19DWz5JtVlZTj2FpVZMb/B9BehujyM2G4kfWDu3BtGI=
+github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b h1:n/a0Kw0jjggJMVeUzeX1RfwYQYxpVgcvrdh0PpzNf3U=
+github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b/go.mod h1:THipEIgxvhBvngWP2bmD5TXoCuQ1v2cz0IwAwQaaoPE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870 h1:edpEZ10vHO8kAkATYnfH1QSMZJrXK6iDJl5YIWWJWtM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870/go.mod h1:ugjpT4MV5lyYg3OpTfEvXrx/7ns2US4NgQPCeMT/ibA=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -38,10 +38,16 @@ github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b h1:n/a0Kw0
 github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b/go.mod h1:THipEIgxvhBvngWP2bmD5TXoCuQ1v2cz0IwAwQaaoPE=
 github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1 h1:CJMZwz83ihcWnV4OdYQUWlSV+Ss0s4J8I6SkmI5lJzg=
 github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1/go.mod h1:THipEIgxvhBvngWP2bmD5TXoCuQ1v2cz0IwAwQaaoPE=
+github.com/codeready-toolchain/api v0.0.0-20190712171113-7038210b9ba5 h1:bTmnva6ifSFde4whh3taRt83Ev6197G5IE0C4ywTlAs=
+github.com/codeready-toolchain/api v0.0.0-20190712171113-7038210b9ba5/go.mod h1:THipEIgxvhBvngWP2bmD5TXoCuQ1v2cz0IwAwQaaoPE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870 h1:edpEZ10vHO8kAkATYnfH1QSMZJrXK6iDJl5YIWWJWtM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870/go.mod h1:ugjpT4MV5lyYg3OpTfEvXrx/7ns2US4NgQPCeMT/ibA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190710025502-b931feee5a1d h1:Vt9vwCkqJJftOZURQ44KtNnTRGRZyfyDbgl0BouTp+o=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190710025502-b931feee5a1d/go.mod h1:xkXiBqyba2FZhIBeBioVvS4ZaiqKMV1JGLiLyj82yYI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190712152359-f3aa50179b69 h1:hHajV9Gh0WlXPUGA3XvRhs2/5jJoPQ+G005LZQNN9ns=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190712152359-f3aa50179b69/go.mod h1:xkXiBqyba2FZhIBeBioVvS4ZaiqKMV1JGLiLyj82yYI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190712173044-bb50b23fbdd7 h1:KowSczd+RxrnFwIOB/+wU/HPs8l4C7NElKf7ZcS9ILc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190712173044-bb50b23fbdd7/go.mod h1:xkXiBqyba2FZhIBeBioVvS4ZaiqKMV1JGLiLyj82yYI=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,12 @@ github.com/codeready-toolchain/api v0.0.0-20190627153646-25d21e70de5d h1:hV+TNcb
 github.com/codeready-toolchain/api v0.0.0-20190627153646-25d21e70de5d/go.mod h1:19DWz5JtVlZTj2FpVZMb/B9BehujyM2G4kfWDu3BtGI=
 github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b h1:n/a0Kw0jjggJMVeUzeX1RfwYQYxpVgcvrdh0PpzNf3U=
 github.com/codeready-toolchain/api v0.0.0-20190703153909-5b2c0d42be1b/go.mod h1:THipEIgxvhBvngWP2bmD5TXoCuQ1v2cz0IwAwQaaoPE=
+github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1 h1:CJMZwz83ihcWnV4OdYQUWlSV+Ss0s4J8I6SkmI5lJzg=
+github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1/go.mod h1:THipEIgxvhBvngWP2bmD5TXoCuQ1v2cz0IwAwQaaoPE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870 h1:edpEZ10vHO8kAkATYnfH1QSMZJrXK6iDJl5YIWWJWtM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190628135548-152ae535f870/go.mod h1:ugjpT4MV5lyYg3OpTfEvXrx/7ns2US4NgQPCeMT/ibA=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190710025502-b931feee5a1d h1:Vt9vwCkqJJftOZURQ44KtNnTRGRZyfyDbgl0BouTp+o=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190710025502-b931feee5a1d/go.mod h1:xkXiBqyba2FZhIBeBioVvS4ZaiqKMV1JGLiLyj82yYI=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -1,4 +1,4 @@
 .PHONY: clean
 clean:
-	$(Q)-rm -rf ${V_FLAG} $(OUT_DIR)
+	$(Q)-rm -rf ${V_FLAG} $(OUT_DIR) ./vendor
 	$(Q)go clean ${X_FLAG} ./...

--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -135,7 +135,7 @@ func (r *ReconcileUserAccount) ensureUser(logger logr.Logger, userAcc *toolchain
 			if err := r.client.Create(context.TODO(), user); err != nil {
 				return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, r.setStatusUserCreationFailed, err, "failed to create user '%s'", userAcc.Name)
 			}
-			if err := r.setStatusUserCreationOK(userAcc); err != nil {
+			if err := r.setStatusProvisioning(userAcc); err != nil {
 				return nil, false, err
 			}
 			logger.Info("user created successfully", "name", userAcc.Name)
@@ -155,7 +155,7 @@ func (r *ReconcileUserAccount) ensureUser(logger logr.Logger, userAcc *toolchain
 		if err := r.client.Update(context.TODO(), user); err != nil {
 			return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, r.setStatusMappingCreationFailed, err, "failed to update user '%s'", userAcc.Name)
 		}
-		if err := r.setStatusMappingCreationOK(userAcc); err != nil {
+		if err := r.setStatusProvisioning(userAcc); err != nil {
 			return nil, false, err
 		}
 		logger.Info("user updated successfully", "name", userAcc.Name)
@@ -180,7 +180,7 @@ func (r *ReconcileUserAccount) ensureIdentity(logger logr.Logger, userAcc *toolc
 			if err := r.client.Create(context.TODO(), identity); err != nil {
 				return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, r.setStatusIdentityCreationFailed, err, "failed to create identity '%s'", name)
 			}
-			if err := r.setStatusIdentityCreationOK(userAcc); err != nil {
+			if err := r.setStatusProvisioning(userAcc); err != nil {
 				return nil, false, err
 			}
 			logger.Info("identity created successfully", "name", name)
@@ -203,7 +203,7 @@ func (r *ReconcileUserAccount) ensureIdentity(logger logr.Logger, userAcc *toolc
 		if err := r.client.Update(context.TODO(), identity); err != nil {
 			return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, r.setStatusMappingCreationFailed, err, "failed to update identity '%s'", name)
 		}
-		if err := r.setStatusMappingCreationOK(userAcc); err != nil {
+		if err := r.setStatusProvisioning(userAcc); err != nil {
 			return nil, false, err
 		}
 		logger.Info("identity updated successfully", "name", name)
@@ -225,90 +225,41 @@ func (r *ReconcileUserAccount) wrapErrorWithStatusUpdate(logger logr.Logger, use
 }
 
 func (r *ReconcileUserAccount) setStatusUserCreationFailed(userAcc *toolchainv1alpha1.UserAccount, message string) error {
-	reason := unableToCreateUserReason
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserAccountUserNotReady,
-			Status:  corev1.ConditionTrue,
-			Reason:  reason,
+			Type:    toolchainv1alpha1.UserAccountReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  unableToCreateUserReason,
 			Message: message,
-		},
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountReady,
-			Status: corev1.ConditionFalse,
-			Reason: reason,
 		})
 }
 
 func (r *ReconcileUserAccount) setStatusIdentityCreationFailed(userAcc *toolchainv1alpha1.UserAccount, message string) error {
-	reason := unableToCreateIdentityReason
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserAccountIdentityNotReady,
-			Status:  corev1.ConditionTrue,
-			Reason:  reason,
+			Type:    toolchainv1alpha1.UserAccountReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  unableToCreateIdentityReason,
 			Message: message,
-		},
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountReady,
-			Status: corev1.ConditionFalse,
-			Reason: reason,
 		})
 }
 
 func (r *ReconcileUserAccount) setStatusMappingCreationFailed(userAcc *toolchainv1alpha1.UserAccount, message string) error {
-	reason := unableToCreateMappingReason
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserAccountUserIdentityMappingNotReady,
-			Status:  corev1.ConditionTrue,
-			Reason:  reason,
+			Type:    toolchainv1alpha1.UserAccountReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  unableToCreateMappingReason,
 			Message: message,
-		},
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountReady,
-			Status: corev1.ConditionFalse,
-			Reason: reason,
-		})
-}
-
-func (r *ReconcileUserAccount) setStatusUserCreationOK(userAcc *toolchainv1alpha1.UserAccount) error {
-	return r.updateStatusConditions(
-		userAcc,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountUserNotReady,
-			Status: corev1.ConditionFalse,
-		})
-}
-
-func (r *ReconcileUserAccount) setStatusIdentityCreationOK(userAcc *toolchainv1alpha1.UserAccount) error {
-	return r.updateStatusConditions(
-		userAcc,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountIdentityNotReady,
-			Status: corev1.ConditionFalse,
-		})
-}
-
-func (r *ReconcileUserAccount) setStatusMappingCreationOK(userAcc *toolchainv1alpha1.UserAccount) error {
-	return r.updateStatusConditions(
-		userAcc,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountUserIdentityMappingNotReady,
-			Status: corev1.ConditionFalse,
 		})
 }
 
 func (r *ReconcileUserAccount) setStatusProvisioning(userAcc *toolchainv1alpha1.UserAccount) error {
 	return r.updateStatusConditions(
 		userAcc,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountProvisioning,
-			Status: corev1.ConditionTrue,
-		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserAccountReady,
 			Status: corev1.ConditionFalse,
@@ -319,26 +270,6 @@ func (r *ReconcileUserAccount) setStatusProvisioning(userAcc *toolchainv1alpha1.
 func (r *ReconcileUserAccount) setStatusReady(userAcc *toolchainv1alpha1.UserAccount) error {
 	return r.updateStatusConditions(
 		userAcc,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountProvisioning,
-			Status: corev1.ConditionFalse,
-		},
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountUserNotReady,
-			Status: corev1.ConditionFalse,
-		},
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountIdentityNotReady,
-			Status: corev1.ConditionFalse,
-		},
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountUserIdentityMappingNotReady,
-			Status: corev1.ConditionFalse,
-		},
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountNSTemplateSetNotReady,
-			Status: corev1.ConditionFalse,
-		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserAccountReady,
 			Status: corev1.ConditionTrue,

--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -32,6 +32,8 @@ const (
 	unableToCreateUserReason     = "UnableToCreateUser"
 	unableToCreateIdentityReason = "UnableToCreateIdentity"
 	unableToCreateMappingReason  = "UnableToCreateMapping"
+	provisioningReason           = "Provisioning"
+	provisionedReason            = "Provisioned"
 )
 
 var log = logf.Log.WithName("controller_useraccount")
@@ -310,6 +312,7 @@ func (r *ReconcileUserAccount) setStatusProvisioning(userAcc *toolchainv1alpha1.
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserAccountReady,
 			Status: corev1.ConditionFalse,
+			Reason: provisioningReason,
 		})
 }
 
@@ -339,6 +342,7 @@ func (r *ReconcileUserAccount) setStatusReady(userAcc *toolchainv1alpha1.UserAcc
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserAccountReady,
 			Status: corev1.ConditionTrue,
+			Reason: provisionedReason,
 		})
 }
 

--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -228,7 +228,7 @@ func (r *ReconcileUserAccount) setStatusUserCreationFailed(userAcc *toolchainv1a
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserAccountReady,
+			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  unableToCreateUserReason,
 			Message: message,
@@ -239,7 +239,7 @@ func (r *ReconcileUserAccount) setStatusIdentityCreationFailed(userAcc *toolchai
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserAccountReady,
+			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  unableToCreateIdentityReason,
 			Message: message,
@@ -250,7 +250,7 @@ func (r *ReconcileUserAccount) setStatusMappingCreationFailed(userAcc *toolchain
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserAccountReady,
+			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  unableToCreateMappingReason,
 			Message: message,
@@ -261,7 +261,7 @@ func (r *ReconcileUserAccount) setStatusProvisioning(userAcc *toolchainv1alpha1.
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountReady,
+			Type:   toolchainv1alpha1.ConditionReady,
 			Status: corev1.ConditionFalse,
 			Reason: provisioningReason,
 		})
@@ -271,7 +271,7 @@ func (r *ReconcileUserAccount) setStatusReady(userAcc *toolchainv1alpha1.UserAcc
 	return r.updateStatusConditions(
 		userAcc,
 		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountReady,
+			Type:   toolchainv1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
 			Reason: provisionedReason,
 		})

--- a/pkg/controller/useraccount/useraccount_controller_test.go
+++ b/pkg/controller/useraccount/useraccount_controller_test.go
@@ -303,6 +303,7 @@ func TestUpdateStatus(t *testing.T) {
 		err := reconciler.updateStatusConditions(userAcc, conditions...)
 
 		// then
+		require.NoError(t, err)
 		updatedAcc := &toolchainv1alpha1.UserAccount{}
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Namespace: "toolchain-member", Name: userAcc.Name}, updatedAcc)
 		require.NoError(t, err)
@@ -327,6 +328,7 @@ func TestUpdateStatus(t *testing.T) {
 		err := reconciler.updateStatusConditions(userAcc, conditions...)
 
 		// then
+		require.NoError(t, err)
 		updatedAcc := &toolchainv1alpha1.UserAccount{}
 		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Namespace: "toolchain-member", Name: userAcc.Name}, updatedAcc)
 		require.NoError(t, err)

--- a/pkg/controller/useraccount/useraccount_controller_test.go
+++ b/pkg/controller/useraccount/useraccount_controller_test.go
@@ -118,6 +118,7 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
+					Reason: "Provisioning",
 				})
 		})
 
@@ -141,6 +142,7 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
+					Reason: "Provisioning",
 				})
 		})
 	})
@@ -187,6 +189,7 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
+					Reason: "Provisioning",
 				})
 		})
 
@@ -211,9 +214,9 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
+					Reason: "Provisioning",
 				})
 		})
-
 	})
 
 	// Last cycle of reconcile. User, Identity created/updated.
@@ -256,6 +259,7 @@ func TestReconcileOK(t *testing.T) {
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserAccountReady,
 				Status: corev1.ConditionTrue,
+				Reason: "Provisioned",
 			})
 	})
 }

--- a/pkg/controller/useraccount/useraccount_controller_test.go
+++ b/pkg/controller/useraccount/useraccount_controller_test.go
@@ -118,7 +118,7 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
-					Reason: "Provisioning",
+					Reason: provisioningReason,
 				})
 		})
 
@@ -142,7 +142,7 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
-					Reason: "Provisioning",
+					Reason: provisioningReason,
 				})
 		})
 	})
@@ -189,7 +189,7 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
-					Reason: "Provisioning",
+					Reason: provisioningReason,
 				})
 		})
 
@@ -214,7 +214,7 @@ func TestReconcileOK(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserAccountReady,
 					Status: corev1.ConditionFalse,
-					Reason: "Provisioning",
+					Reason: provisioningReason,
 				})
 		})
 	})
@@ -259,7 +259,7 @@ func TestReconcileOK(t *testing.T) {
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserAccountReady,
 				Status: corev1.ConditionTrue,
-				Reason: "Provisioned",
+				Reason: provisionedReason,
 			})
 	})
 }

--- a/test/e2e/useraccount_test.go
+++ b/test/e2e/useraccount_test.go
@@ -7,6 +7,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	"github.com/codeready-toolchain/member-operator/pkg/controller/useraccount"
+
 	userv1 "github.com/openshift/api/user/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
@@ -39,7 +40,7 @@ func TestUserAccount(t *testing.T) {
 	client := f.Client.Client
 
 	// wait for operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "member-operator", 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "member-operator", 1, operatorRetryInterval, operatorTimeout)
 	require.NoError(t, err, "failed while waiting for operator deployment")
 
 	t.Log("member-operator is ready and running state")
@@ -54,7 +55,7 @@ func TestUserAccount(t *testing.T) {
 	t.Logf("user account '%s' created", userAcc.Name)
 
 	t.Run("verify_useraccount_ok", func(t *testing.T) {
-		err := verifyResources(t, f, userAcc)
+		err := verifyResources(t, f, namespace, userAcc)
 		assert.NoError(t, err)
 	})
 
@@ -66,7 +67,7 @@ func TestUserAccount(t *testing.T) {
 		err = client.Delete(context.TODO(), user)
 		require.NoError(t, err)
 
-		err = verifyResources(t, f, userAcc)
+		err = verifyResources(t, f, namespace, userAcc)
 		assert.NoError(t, err)
 	})
 
@@ -78,7 +79,7 @@ func TestUserAccount(t *testing.T) {
 		err = client.Delete(context.TODO(), identity)
 		require.NoError(t, err)
 
-		err = verifyResources(t, f, userAcc)
+		err = verifyResources(t, f, namespace, userAcc)
 		assert.NoError(t, err)
 	})
 
@@ -91,7 +92,7 @@ func TestUserAccount(t *testing.T) {
 		err = client.Update(context.TODO(), user)
 		require.NoError(t, err)
 
-		err = verifyResources(t, f, userAcc)
+		err = verifyResources(t, f, namespace, userAcc)
 		assert.NoError(t, err)
 	})
 
@@ -104,11 +105,11 @@ func TestUserAccount(t *testing.T) {
 		err = client.Update(context.TODO(), identity)
 		require.NoError(t, err)
 
-		err = verifyResources(t, f, userAcc)
+		err = verifyResources(t, f, namespace, userAcc)
 		assert.NoError(t, err)
 	})
 
-	err = verifyResources(t, f, extraUserAcc)
+	err = verifyResources(t, f, namespace, extraUserAcc)
 	assert.NoError(t, err)
 	t.Log("extra useraccount verified at end")
 }
@@ -135,11 +136,19 @@ func newUserAcc(namespace, name string) *toolchainv1alpha1.UserAccount {
 	return userAcc
 }
 
-func verifyResources(t *testing.T, f *framework.Framework, userAcc *toolchainv1alpha1.UserAccount) error {
+func verifyResources(t *testing.T, f *framework.Framework, namespace string, userAcc *toolchainv1alpha1.UserAccount) error {
 	if err := waitForUser(t, f.Client.Client, userAcc.Name); err != nil {
 		return err
 	}
 	if err := waitForIdentity(t, f.Client.Client, useraccount.ToIdentityName(userAcc.Spec.UserID)); err != nil {
+		return err
+	}
+	if err := waitForUserAccStatusConditions(t, f.Client.Client, namespace, userAcc.Name,
+		toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.UserAccountReady,
+			Status: corev1.ConditionTrue,
+			Reason: "Provisioned",
+		}); err != nil {
 		return err
 	}
 	return nil
@@ -153,7 +162,7 @@ func createUserAccount(t *testing.T, f *framework.Framework, ctx *framework.Test
 	err = f.Client.Create(context.TODO(), userAcc, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	require.NoError(t, err)
 
-	err = verifyResources(t, f, userAcc)
+	err = verifyResources(t, f, namespace, userAcc)
 	assert.NoError(t, err)
 
 	return userAcc

--- a/test/e2e/useraccount_test.go
+++ b/test/e2e/useraccount_test.go
@@ -145,7 +145,7 @@ func verifyResources(t *testing.T, f *framework.Framework, namespace string, use
 	}
 	if err := waitForUserAccStatusConditions(t, f.Client.Client, namespace, userAcc.Name,
 		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserAccountReady,
+			Type:   toolchainv1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
 			Reason: "Provisioned",
 		}); err != nil {

--- a/test/e2e/wait_util.go
+++ b/test/e2e/wait_util.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	userv1 "github.com/openshift/api/user/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -69,33 +70,10 @@ func waitForUserAccStatusConditions(t *testing.T, client client.Client, namespac
 			}
 			return false, err
 		}
-		if ConditionsMatch(userAcc.Status.Conditions, conditions...) {
+		if test.ConditionsMatch(userAcc.Status.Conditions, conditions...) {
 			t.Log("conditions match")
 			return true, nil
 		}
 		return false, nil
 	})
-}
-
-// TODO Move to toolchain-common
-func ConditionsMatch(actual []toolchainv1alpha1.Condition, expected ...toolchainv1alpha1.Condition) bool {
-	if len(expected) != len(actual) {
-		return false
-	}
-	for _, c := range expected {
-		if !ContainsCondition(actual, c) {
-			return false
-		}
-	}
-	return true
-}
-
-// TODO Move to toolchain-common
-func ContainsCondition(conditions []toolchainv1alpha1.Condition, contains toolchainv1alpha1.Condition) bool {
-	for _, c := range conditions {
-		if c.Type == contains.Type {
-			return contains.Status == c.Status && contains.Reason == c.Reason && contains.Message == c.Message
-		}
-	}
-	return false
 }


### PR DESCRIPTION
This PR introduces Status Condition to UserAccount Controller: **Ready**

Also there are new [additional printer columns](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#additional-printer-columns) in UserAccount CRD:
```
$ oc get useraccounts
NAME        NS LIMIT   TIER NAME   READY     REASON 
bob         default    basic       True      Provisioned   
alice       default    basic       False     Provisioning   
johnsmith   admin      basic       False     UnableToCreateIdentity   

$ oc get useraccounts -o wide
NAME        USER ID               NS LIMIT   TIER NAME   READY     REASON                    DISABLED
bob         d8a88d7-1d27c0d7e52   default    basic       True      Provisioned   
alice       f758563-2d27c0d7e53   default    basic       False     Provisioning   
johnsmith   1a03eca-2dd7fb21c40   admin      basic       False     UnableToCreateIdentity   
```
Where in the example above ^ **bob** successfully provisioned. **Alice** is still being provisioned and **JohnSmith** provision failed.