### PR TITLE
Fix race condition in UserAccount controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect
 	github.com/rogpeppe/go-internal v1.3.0 // indirect
+	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
 	go.opencensus.io v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhg
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=

--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-
 	"github.com/codeready-toolchain/member-operator/pkg/config"
+
 	"github.com/go-logr/logr"
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
@@ -97,18 +97,13 @@ func (r *ReconcileUserAccount) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	var created bool
+	var createdOrUpdated bool
 	var user *userv1.User
-	if user, created, err = r.ensureUser(reqLogger, userAcc); err != nil || created {
+	if user, createdOrUpdated, err = r.ensureUser(reqLogger, userAcc); err != nil || createdOrUpdated {
 		return reconcile.Result{}, err
 	}
 
-	var identity *userv1.Identity
-	if identity, created, err = r.ensureIdentity(reqLogger, userAcc); err != nil || created {
-		return reconcile.Result{}, err
-	}
-
-	if created, err = r.ensureMapping(reqLogger, userAcc, user, identity); err != nil || created {
+	if _, createdOrUpdated, err = r.ensureIdentity(reqLogger, userAcc, user); err != nil || createdOrUpdated {
 		return reconcile.Result{}, err
 	}
 
@@ -136,10 +131,24 @@ func (r *ReconcileUserAccount) ensureUser(logger logr.Logger, userAcc *toolchain
 		return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, err, "failed to get user '%s'", userAcc.Name)
 	}
 	logger.Info("user already exists", "name", userAcc.Name)
+
+	// ensure mapping
+	if user.Identities == nil || len(user.Identities) < 1 || user.Identities[0] != getIdentityName(userAcc) {
+		logger.Info("user is missing a reference to identity; updating the reference", "name", userAcc.Name)
+		if err := r.updateStatus(userAcc, toolchainv1alpha1.StatusProvisioning, ""); err != nil {
+			return nil, false, err
+		}
+		user.Identities = []string{getIdentityName(userAcc)}
+		if err := r.client.Update(context.TODO(), user); err != nil {
+			return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, err, "failed to update user '%s'", userAcc.Name)
+		}
+		logger.Info("user updated successfully", "name", userAcc.Name)
+		return user, true, nil
+	}
 	return user, false, nil
 }
 
-func (r *ReconcileUserAccount) ensureIdentity(logger logr.Logger, userAcc *toolchainv1alpha1.UserAccount) (*userv1.Identity, bool, error) {
+func (r *ReconcileUserAccount) ensureIdentity(logger logr.Logger, userAcc *toolchainv1alpha1.UserAccount, user *userv1.User) (*userv1.Identity, bool, error) {
 	name := getIdentityName(userAcc)
 	identity := &userv1.Identity{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: name}, identity); err != nil {
@@ -148,7 +157,7 @@ func (r *ReconcileUserAccount) ensureIdentity(logger logr.Logger, userAcc *toolc
 			if err := r.updateStatus(userAcc, toolchainv1alpha1.StatusProvisioning, ""); err != nil {
 				return nil, false, err
 			}
-			identity = newIdentity(userAcc)
+			identity = newIdentity(userAcc, user)
 			if err := controllerutil.SetControllerReference(userAcc, identity, r.scheme); err != nil {
 				return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, err, "failed to set controller reference for identity '%s'", name)
 			}
@@ -161,25 +170,25 @@ func (r *ReconcileUserAccount) ensureIdentity(logger logr.Logger, userAcc *toolc
 		return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, err, "failed to get identity '%s'", name)
 	}
 	logger.Info("identity already exists", "name", name)
-	return identity, false, nil
-}
 
-func (r *ReconcileUserAccount) ensureMapping(logger logr.Logger, userAcc *toolchainv1alpha1.UserAccount, user *userv1.User, identity *userv1.Identity) (bool, error) {
-	mapping := newMapping(user, identity)
-	name := mapping.Name
-	if err := controllerutil.SetControllerReference(userAcc, mapping, r.scheme); err != nil {
-		return false, err
-	}
-
-	if err := r.client.Create(context.TODO(), mapping); err != nil {
-		if errors.IsAlreadyExists(err) {
-			logger.Info("user-identity mapping already exists", "name", name)
-			return false, nil
+	// ensure mapping
+	if identity.User.Name != user.Name || identity.User.UID != user.UID {
+		logger.Info("identity is missing a reference to user; updating the reference", "identity", name, "user", user.Name)
+		if err := r.updateStatus(userAcc, toolchainv1alpha1.StatusProvisioning, ""); err != nil {
+			return nil, false, err
 		}
-		return false, r.wrapErrorWithStatusUpdate(logger, userAcc, err, "failed to create user-identity mapping '%s'", name)
+		identity.User = corev1.ObjectReference{
+			Name: user.Name,
+			UID:  user.UID,
+		}
+		if err := r.client.Update(context.TODO(), identity); err != nil {
+			return nil, false, r.wrapErrorWithStatusUpdate(logger, userAcc, err, "failed to update identity '%s'", name)
+		}
+		logger.Info("identity updated successfully", "name", name)
+		return identity, true, nil
 	}
-	logger.Info("user-identity mapping created successfully", "name", name)
-	return true, r.updateStatus(userAcc, toolchainv1alpha1.StatusProvisioning, "")
+
+	return identity, false, nil
 }
 
 // updateStatus updates user account status to given status with errMsg but only if the current status doesn't match
@@ -212,11 +221,12 @@ func newUser(userAcc *toolchainv1alpha1.UserAccount) *userv1.User {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: userAcc.Name,
 		},
+		Identities: []string{getIdentityName(userAcc)},
 	}
 	return user
 }
 
-func newIdentity(userAcc *toolchainv1alpha1.UserAccount) *userv1.Identity {
+func newIdentity(userAcc *toolchainv1alpha1.UserAccount, user *userv1.User) *userv1.Identity {
 	name := getIdentityName(userAcc)
 	identity := &userv1.Identity{
 		ObjectMeta: metav1.ObjectMeta{
@@ -224,26 +234,12 @@ func newIdentity(userAcc *toolchainv1alpha1.UserAccount) *userv1.Identity {
 		},
 		ProviderName:     config.GetIdP(),
 		ProviderUserName: userAcc.Spec.UserID,
-	}
-	return identity
-}
-
-func newMapping(user *userv1.User, identity *userv1.Identity) *userv1.UserIdentityMapping {
-	name := identity.Name
-	mapping := &userv1.UserIdentityMapping{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
 		User: corev1.ObjectReference{
 			Name: user.Name,
 			UID:  user.UID,
 		},
-		Identity: corev1.ObjectReference{
-			Name: identity.Name,
-			UID:  identity.UID,
-		},
 	}
-	return mapping
+	return identity
 }
 
 func getIdentityName(userAcc *toolchainv1alpha1.UserAccount) string {

--- a/pkg/controller/useraccount/useraccount_controller_test.go
+++ b/pkg/controller/useraccount/useraccount_controller_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	"github.com/codeready-toolchain/member-operator/pkg/config"
 	userv1 "github.com/openshift/api/user/v1"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,16 +31,21 @@ func TestReconcileOK(t *testing.T) {
 
 	// given
 	userAcc := newUserAccount(username, userID)
-	createdIdentity := &userv1.Identity{ObjectMeta: metav1.ObjectMeta{
+	userUID := types.UID(username + "user")
+	preexistingIdentity := &userv1.Identity{ObjectMeta: metav1.ObjectMeta{
 		Name:      getIdentityName(userAcc),
 		Namespace: "toolchain-member",
 		UID:       types.UID(username + "identity"),
+	}, User: corev1.ObjectReference{
+		Name: username,
+		UID:  userUID,
 	}}
-	createdUser := &userv1.User{ObjectMeta: metav1.ObjectMeta{
-		Name:      username,
-		Namespace: "toolchain-member",
-		UID:       types.UID(username + "user"),
-	}}
+	preexistingUser := &userv1.User{ObjectMeta: metav1.ObjectMeta{
+		Name:            username,
+		Namespace:       "toolchain-member",
+		UID:             userUID,
+		OwnerReferences: []metav1.OwnerReference{},
+	}, Identities: []string{getIdentityName(userAcc)}}
 
 	t.Run("deleted_account_ignored", func(t *testing.T) {
 		// given
@@ -62,96 +70,109 @@ func TestReconcileOK(t *testing.T) {
 	})
 
 	// First cycle of reconcile. Freshly created UserAccount.
-	t.Run("create_user", func(t *testing.T) {
-		// given
-		r, req := prepareReconcile(t, username, userAcc)
+	t.Run("create_or_update_user", func(t *testing.T) {
+		reconcile := func(r *ReconcileUserAccount, req reconcile.Request) {
+			//when
+			res, err := r.Reconcile(req)
 
-		//when
-		res, err := r.Reconcile(req)
+			//then
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, res)
 
-		//then
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, res)
+			// Check that the user account status has been updated
+			updatedAcc := &toolchainv1alpha1.UserAccount{}
+			err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: req.Namespace, Name: userAcc.Name}, updatedAcc)
+			require.NoError(t, err)
+			assert.Equal(t, toolchainv1alpha1.StatusProvisioning, updatedAcc.Status.Status)
+			assert.Empty(t, updatedAcc.Status.Error)
 
-		// Check that the user account status has been updated
-		updatedAcc := &toolchainv1alpha1.UserAccount{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: req.Namespace, Name: userAcc.Name}, updatedAcc)
-		require.NoError(t, err)
-		assert.Equal(t, toolchainv1alpha1.StatusProvisioning, updatedAcc.Status.Status)
-		assert.Empty(t, updatedAcc.Status.Error)
+			// Check the created/updated user
+			user := &userv1.User{}
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: userAcc.Name}, user)
+			require.NoError(t, err)
+			assert.Equal(t, userAcc.Name, user.Name)
+			require.Len(t, user.GetOwnerReferences(), 1)
+			assert.Equal(t, updatedAcc.UID, user.GetOwnerReferences()[0].UID)
 
-		// Check the created user
-		user := &userv1.User{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{Name: userAcc.Name}, user)
-		require.NoError(t, err)
-		assert.Equal(t, userAcc.Name, user.Name)
-		assert.Len(t, user.GetOwnerReferences(), 1)
-		assert.Equal(t, updatedAcc.UID, user.GetOwnerReferences()[0].UID)
+			// Check the user identity mapping
+			user.UID = preexistingUser.UID // we have to set UID for the obtained user because the fake client doesn't set it
+			checkMapping(t, user, preexistingIdentity)
 
-		// Check the identity is not created yet
-		err = r.client.Get(context.TODO(), types.NamespacedName{Name: getIdentityName(userAcc)}, &userv1.Identity{})
-		require.Error(t, err)
-		assert.True(t, errors.IsNotFound(err))
+			// Check the identity is not created yet
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: getIdentityName(userAcc)}, &userv1.Identity{})
+			require.Error(t, err)
+			assert.True(t, errors.IsNotFound(err))
+		}
+
+		t.Run("create", func(t *testing.T) {
+			r, req := prepareReconcile(t, username, userAcc)
+			reconcile(r, req)
+		})
+
+		t.Run("update", func(t *testing.T) {
+			preexistingUserWithNoMapping := &userv1.User{ObjectMeta: metav1.ObjectMeta{
+				Name:            username,
+				Namespace:       "toolchain-member",
+				UID:             userUID,
+				OwnerReferences: []metav1.OwnerReference{{UID: userAcc.UID}},
+			}}
+			r, req := prepareReconcile(t, username, userAcc, preexistingUserWithNoMapping)
+			reconcile(r, req)
+		})
 	})
 
 	// Second cycle of reconcile. User already created.
-	t.Run("create_identity", func(t *testing.T) {
-		// given
-		r, req := prepareReconcile(t, username, userAcc, createdUser)
+	t.Run("create_or_update_identity", func(t *testing.T) {
+		reconcile := func(r *ReconcileUserAccount, req reconcile.Request) {
+			//when
+			res, err := r.Reconcile(req)
 
-		//when
-		res, err := r.Reconcile(req)
+			//then
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, res)
 
-		//then
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, res)
+			// Check that the user account status is now "provisioning"
+			updatedAcc := &toolchainv1alpha1.UserAccount{}
+			err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: req.Namespace, Name: userAcc.Name}, updatedAcc)
+			require.NoError(t, err)
+			assert.Equal(t, toolchainv1alpha1.StatusProvisioning, updatedAcc.Status.Status)
+			assert.Empty(t, updatedAcc.Status.Error)
 
-		// Check that the user account status is still "provisioning"
-		updatedAcc := &toolchainv1alpha1.UserAccount{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: req.Namespace, Name: userAcc.Name}, updatedAcc)
-		require.NoError(t, err)
-		assert.Equal(t, toolchainv1alpha1.StatusProvisioning, updatedAcc.Status.Status)
-		assert.Empty(t, updatedAcc.Status.Error)
+			// Check the created/updated identity
+			identity := &userv1.Identity{}
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: getIdentityName(userAcc)}, identity)
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("%s:%s", config.GetIdP(), userAcc.Spec.UserID), identity.Name)
+			require.Len(t, identity.GetOwnerReferences(), 1)
+			assert.Equal(t, updatedAcc.UID, identity.GetOwnerReferences()[0].UID)
 
-		// Check the created identity
-		identity := &userv1.Identity{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{Name: getIdentityName(userAcc)}, identity)
-		require.NoError(t, err)
-		assert.Equal(t, fmt.Sprintf("%s:%s", config.GetIdP(), userAcc.Spec.UserID), identity.Name)
-		assert.Len(t, identity.GetOwnerReferences(), 1)
-		assert.Equal(t, updatedAcc.UID, identity.GetOwnerReferences()[0].UID)
+			// Check the user identity mapping
+			checkMapping(t, preexistingUser, identity)
+		}
+
+		t.Run("create", func(t *testing.T) {
+			r, req := prepareReconcile(t, username, userAcc, preexistingUser)
+			reconcile(r, req)
+		})
+
+		t.Run("update", func(t *testing.T) {
+			preexistingIdentityWithNoMapping := &userv1.Identity{ObjectMeta: metav1.ObjectMeta{
+				Name:            getIdentityName(userAcc),
+				Namespace:       "toolchain-member",
+				UID:             types.UID(uuid.NewV4().String()),
+				OwnerReferences: []metav1.OwnerReference{{UID: userAcc.UID}},
+			}}
+
+			r, req := prepareReconcile(t, username, userAcc, preexistingUser, preexistingIdentityWithNoMapping)
+			reconcile(r, req)
+		})
+
 	})
 
-	// Third cycle of reconcile. User and Identity already created.
-	t.Run("create_user_identity_mapping", func(t *testing.T) {
-		// given
-		r, req := prepareReconcile(t, username, userAcc, createdUser, createdIdentity)
-
-		//when
-		res, err := r.Reconcile(req)
-
-		//then
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, res)
-
-		// Check that the user account status is still "provisioning"
-		updatedAcc := &toolchainv1alpha1.UserAccount{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: req.Namespace, Name: userAcc.Name}, updatedAcc)
-		require.NoError(t, err)
-		assert.Equal(t, toolchainv1alpha1.StatusProvisioning, updatedAcc.Status.Status)
-		assert.Empty(t, updatedAcc.Status.Error)
-
-		// Check the created user identity mapping
-		mapping := newMapping(createdUser, createdIdentity)
-		err = r.client.Create(context.TODO(), mapping)
-		require.Error(t, err)
-		assert.True(t, errors.IsAlreadyExists(err))
-	})
-
-	// Last cycle of reconcile. User, Identity and UserIdentityMapping created/updated.
+	// Last cycle of reconcile. User, Identity created/updated.
 	t.Run("provisioned", func(t *testing.T) {
 		// given
-		r, req := prepareReconcile(t, username, userAcc, createdUser, createdIdentity, newMapping(createdUser, createdIdentity))
+		r, req := prepareReconcile(t, username, userAcc, preexistingUser, preexistingIdentity)
 
 		//when
 		res, err := r.Reconcile(req)
@@ -269,6 +290,7 @@ func newUserAccount(userName, userID string) *toolchainv1alpha1.UserAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      userName,
 			Namespace: "toolchain-member",
+			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{
 			UserID: userID,
@@ -284,4 +306,11 @@ func newReconcileRequest(name string) reconcile.Request {
 			Namespace: "toolchain-member",
 		},
 	}
+}
+
+func checkMapping(t *testing.T, user *userv1.User, identity *userv1.Identity) {
+	assert.Equal(t, user.Name, identity.User.Name)
+	assert.Equal(t, user.UID, identity.User.UID)
+	require.Len(t, user.Identities, 1)
+	assert.Equal(t, identity.Name, user.Identities[0])
 }


### PR DESCRIPTION
We currently "crate" `IdentityMapping`. Which is a virtual resource. The mapping rest endpoint modifies the corresponding User & Identity when the mapping is "created". It causes two reconciles in UserAccount controller which happen in parallel:

- **T1.** UserAcc created.
- **T2**. Reconcile 1 triggered. Create User. Exit Reconcile.
- **T3.** Reconcile 2. Create Identity. Exit.
- **T4.** Reconcile 3. "Create" Mapping (it modifies User and Identity, so it triggers two reconciles!). Exit reconcile.
- **T5-T6.** Race condition. Two reconciles (one because Identity modified and one because User modified)

This PR drops any `UserIdentityMapping` REST API usage. We now handle user & identity updates (for establishing a mapping between them) explicitly from the controller.