### PR TITLE
fix(CRT-223): separate Role and ClusterRole permissions + test fixes & adjustments

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,0 +1,44 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: member-operator
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - identities
+  - users
+  - useridentitymappings
+  - groups
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - core.kubefed.k8s.io
+  resources:
+  - kubefedclusters
+  verbs:
+  - "*"
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,11 +1,13 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: member-operator
 subjects:
 - kind: ServiceAccount
   name: member-operator
+  # Replace this with the namespace in which the operator will be deployed
+  namespace: REPLACE_NAMESPACE
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: member-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,12 +21,10 @@ spec:
         - member-operator
         imagePullPolicy: IfNotPresent
         env:
-        - name: OPERATOR_NAMESPACE
+        - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: WATCH_NAMESPACE
-          value: ""
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/operator_dev_cluster.yaml
+++ b/deploy/operator_dev_cluster.yaml
@@ -55,10 +55,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,4 +1,4 @@
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: member-operator
@@ -25,13 +25,6 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - "get"
-  - "create"
-- apiGroups:
   - apps
   resources:
   - deployments/finalizers
@@ -42,37 +35,7 @@ rules:
 - apiGroups:
   - core.kubefed.k8s.io
   resources:
-  - kubefedclusters
-  verbs:
-  - "*"
-- apiGroups:
-  - core.kubefed.k8s.io
-  resources:
   - kubefedclusters/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - list
-- apiGroups:
-  - toolchain.dev.openshift.com
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - user.openshift.io
-  resources:
-  - identities
-  - users
-  - useridentitymappings
-  verbs:
-  - get
-  - create
-  - update
-  - list
-  - watch
-  - delete
+

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -38,4 +38,3 @@ rules:
   - kubefedclusters/status
   verbs:
   - update
-

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	cloud.google.com/go v0.40.0 // indirect
 	github.com/Azure/go-autorest v13.0.0+incompatible // indirect
 	github.com/codeready-toolchain/api v0.0.0-20190812113906-bd1f09d19c28
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20190822023853-ee967b4125e7
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20190827045201-35e4f49da4c9
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.2 // indirect
 	github.com/gobuffalo/envy v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/codeready-toolchain/api v0.0.0-20190812113906-bd1f09d19c28 h1:+ndo0pF
 github.com/codeready-toolchain/api v0.0.0-20190812113906-bd1f09d19c28/go.mod h1:jHr8IvmLGTxmgD+jc1bBbucP4bSbT2JHnM+HdAw6N2g=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190822023853-ee967b4125e7 h1:BMxUbc0leFMb5wLGfXjA/atAB5lzwwmCXh85iVGZECw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190822023853-ee967b4125e7/go.mod h1:T/a1aW1kqIKrRxbpUxDp3l3wz97jtQBI68AFl+j+I9Q=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190827045201-35e4f49da4c9 h1:o2fX6Qv4goQbPw2IV2PcFE8CY4NalYMiSseSNeMrGQs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190827045201-35e4f49da4c9/go.mod h1:T/a1aW1kqIKrRxbpUxDp3l3wz97jtQBI68AFl+j+I9Q=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -50,7 +50,9 @@ reset-namespace: login-as-admin clean-namespace create-namespace deploy-rbac
 deploy-rbac:
 	$(Q)-oc apply -f deploy/service_account.yaml
 	$(Q)-oc apply -f deploy/role.yaml
-	$(Q)-sed -e 's|REPLACE_NAMESPACE|${LOCAL_TEST_NAMESPACE}|g' ./deploy/role_binding.yaml  | oc apply -f -
+	$(Q)-oc apply -f deploy/role_binding.yaml
+	$(Q)-oc apply -f deploy/cluster_role.yaml
+	$(Q)-sed -e 's|REPLACE_NAMESPACE|${LOCAL_TEST_NAMESPACE}|g' ./deploy/cluster_role_binding.yaml  | oc apply -f -
 
 .PHONY: deploy-crd
 ## Deploy CRD

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -5,7 +5,7 @@ TIMESTAMP:=$(shell date +%s)
 TAG?=$(GIT_COMMIT_ID_SHORT)-$(TIMESTAMP)
 
 # to watch all namespaces, keep namespace empty
-APP_NAMESPACE ?= ""
+APP_NAMESPACE ?= $(LOCAL_TEST_NAMESPACE)
 LOCAL_TEST_NAMESPACE ?= "toolchain-member-operator"
 ADD_CLUSTER_SCRIPT_PATH?=../toolchain-common/scripts/add-cluster.sh
 
@@ -13,7 +13,7 @@ ADD_CLUSTER_SCRIPT_PATH?=../toolchain-common/scripts/add-cluster.sh
 ## Run Operator locally
 up-local: login-as-admin create-namespace deploy-rbac build deploy-crd
 	$(Q)-oc new-project $(LOCAL_TEST_NAMESPACE) || true
-	$(Q)OPERATOR_NAMESPACE=$(LOCAL_TEST_NAMESPACE) operator-sdk up local --namespace=$(APP_NAMESPACE) --verbose
+	$(Q)operator-sdk up local --namespace=$(APP_NAMESPACE) --verbose
 
 .PHONY: login-as-admin
 ## Log in as system:admin

--- a/make/test.mk
+++ b/make/test.mk
@@ -102,7 +102,9 @@ e2e-setup: is-minishift
 	oc new-project $(MEMBER_NS) --display-name e2e-tests
 	oc apply -f ./deploy/service_account.yaml
 	oc apply -f ./deploy/role.yaml
-	cat ./deploy/role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(MEMBER_NS)/ | oc apply -f -
+	oc apply -f ./deploy/role_binding.yaml
+	oc apply -f ./deploy/cluster_role.yaml
+	cat ./deploy/cluster_role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(MEMBER_NS)/ | oc apply -f -
 	oc apply -f deploy/crds
 	sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g' ./deploy/operator.yaml  | oc apply -f -
 
@@ -146,6 +148,8 @@ deploy-host:
 	oc new-project $(HOST_NS)
 	oc apply -f /tmp/host-operator/deploy/service_account.yaml
 	oc apply -f /tmp/host-operator/deploy/role.yaml
-	cat /tmp/host-operator/deploy/role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(HOST_NS)/ | oc apply -f -
+	oc apply -f /tmp/host-operator/deploy/role_binding.yaml
+	oc apply -f /tmp/host-operator/deploy/cluster_role.yaml
+	cat /tmp/host-operator/deploy/cluster_role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(HOST_NS)/ | oc apply -f -
 	oc apply -f /tmp/host-operator/deploy/crds
 	sed -e 's|REPLACE_IMAGE|registry.svc.ci.openshift.org/codeready-toolchain/host-operator-v0.1:host-operator|g' /tmp/host-operator/deploy/operator.yaml  | oc apply -f -

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -1,5 +1,0 @@
-package config
-
-const (
-	OperatorNamespace = "OPERATOR_NAMESPACE"
-)

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -1,13 +1,5 @@
 package config
 
-import (
-	"os"
-)
-
-func GetOperatorNamespace() string {
-	return os.Getenv(OperatorNamespace)
-}
-
 func GetIdP() string {
 	// TODO get from openshift
 	return "rhd"

--- a/pkg/controller/kubefedcluster.go
+++ b/pkg/controller/kubefedcluster.go
@@ -1,11 +1,9 @@
 package controller
 
 import (
-	"fmt"
-	"github.com/codeready-toolchain/member-operator/pkg/config"
 	"github.com/codeready-toolchain/toolchain-common/pkg/controller"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/klog"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/kubefed/pkg/controller/kubefedcluster"
 	"sigs.k8s.io/kubefed/pkg/controller/util"
@@ -15,23 +13,27 @@ func StartKubeFedClusterControllers(mgr manager.Manager, stopChan <-chan struct{
 	if err := startHealthCheckController(mgr, stopChan); err != nil {
 		return err
 	}
-	if err := controller.StartCachingController(mgr, stopChan); err != nil {
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return err
+	}
+	if err := controller.StartCachingController(mgr, namespace, stopChan); err != nil {
 		return err
 	}
 	return nil
 }
 
 func startHealthCheckController(mgr manager.Manager, stopChan <-chan struct{}) error {
-	ns, found := os.LookupEnv(config.OperatorNamespace)
-	if !found {
-		return fmt.Errorf("%s must be set", config.OperatorNamespace)
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return err
 	}
 	controllerConfig := &util.ControllerConfig{
 		KubeConfig:              mgr.GetConfig(),
 		ClusterAvailableDelay:   util.DefaultClusterAvailableDelay,
 		ClusterUnavailableDelay: util.DefaultClusterUnavailableDelay,
 		KubeFedNamespaces: util.KubeFedNamespaces{
-			KubeFedNamespace: ns,
+			KubeFedNamespace: namespace,
 		},
 	}
 	clusterHealthCheckConfig := &util.ClusterHealthCheckConfig{


### PR DESCRIPTION
* separates Role and ClusterRole permissions
* modifies KubeFedCluster e2e test to meet changes in codeready-toolchain/toolchain-common#33
* removed unnecessary `OPERATOR_NAMESPACE` var

NOTE: depends on changes made in codeready-toolchain/toolchain-common#33 as well as in https://github.com/codeready-toolchain/host-operator/pull/55