### PR TITLE
chore: install newer git and allow unrelated histories while merging

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -113,7 +113,7 @@ ifeq ($(E2E_REPO_PATH),"")
 			# fetch the branch \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${BRANCH_REF}; \
 			# merge the branch with master \
-			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge FETCH_HEAD; \
+			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge --allow-unrelated-histories FETCH_HEAD; \
 		fi;
     endif
 endif

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -14,9 +14,10 @@ ENV LANG=en_US.utf8 \
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/member-operator
 
 RUN yum install epel-release -y \
+    && yum install  https://centos7.iuscommunity.org/ius-release.rpm -y \
     && yum install --enablerepo=centosplus install -y --quiet \
     findutils \
-    git \
+    git2u-all \
     golang \
     make \
     procps-ng \


### PR DESCRIPTION
install newer git and allow unrelated histories while merging to avoid conflict while merging