### PR TITLE
fix(e2e): install gcc in Dockerfile.tools

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -29,6 +29,7 @@ RUN yum install epel-release -y \
     python36-virtualenv \
     jq \
     go-bindata \
+    gcc \
     && yum clean all
 
 WORKDIR /tmp


### PR DESCRIPTION
to unblock e2e tests executed in member-operator repo: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/codeready-toolchain_member-operator/89/pull-ci-codeready-toolchain-member-operator-master-e2e/368