### PR TITLE
Add missing Permissions to member operator SA

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -14,8 +14,10 @@ rules:
   - ""
   resources:
   - nodes
+  - componentstatuses
   verbs:
   - list
+  - get
 - apiGroups:
   - ""
   resources:

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -15,9 +15,12 @@ rules:
   resources:
   - nodes
   - componentstatuses
+  - pods
+  - services
   verbs:
   - list
   - get
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
@@ -97,8 +97,10 @@ spec:
           - ""
           resources:
           - nodes
+          - componentstatuses
           verbs:
           - list
+          - get
         - apiGroups:
           - ""
           resources:
@@ -253,11 +255,14 @@ spec:
           - update
         - apiGroups:
           - authorization.openshift.io
+          - rbac.authorization.k8s.io
           resources:
           - subjectrulesreviews
           - subjectaccessreviews
           - localsubjectaccessreviews
           - resourceaccessreviews
+          - roles
+          - rolebindings
           verbs:
           - get
           - list

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
@@ -98,9 +98,12 @@ spec:
           resources:
           - nodes
           - componentstatuses
+          - pods
+          - services
           verbs:
           - list
           - get
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
@@ -231,6 +231,7 @@ spec:
           - bindings
           - podtemplates
           - serviceaccounts
+          - replicationcontrollers
           verbs:
           - '*'
         - apiGroups:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -16,6 +16,7 @@ rules:
   - bindings
   - podtemplates
   - serviceaccounts
+  - replicationcontrollers
   verbs:
   - "*"
 - apiGroups:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -43,11 +43,14 @@ rules:
   - update
 - apiGroups:
   - authorization.openshift.io
+  - rbac.authorization.k8s.io
   resources:
   - subjectrulesreviews
   - subjectaccessreviews
   - localsubjectaccessreviews
   - resourceaccessreviews
+  - roles
+  - rolebindings
   verbs:
   - get
   - list

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -378,9 +378,12 @@ data:
                 resources:
                 - nodes
                 - componentstatuses
+                - pods
+                - services
                 verbs:
                 - list
                 - get
+                - watch
               - apiGroups:
                 - ""
                 resources:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -511,6 +511,7 @@ data:
                 - bindings
                 - podtemplates
                 - serviceaccounts
+                - replicationcontrollers
                 verbs:
                 - '*'
               - apiGroups:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -377,8 +377,10 @@ data:
                 - ""
                 resources:
                 - nodes
+                - componentstatuses
                 verbs:
                 - list
+                - get
               - apiGroups:
                 - ""
                 resources:
@@ -533,11 +535,14 @@ data:
                 - update
               - apiGroups:
                 - authorization.openshift.io
+                - rbac.authorization.k8s.io
                 resources:
                 - subjectrulesreviews
                 - subjectaccessreviews
                 - localsubjectaccessreviews
                 - resourceaccessreviews
+                - roles
+                - rolebindings
                 verbs:
                 - get
                 - list


### PR DESCRIPTION
There are a lot of error messages in the log:

```
cannot get resource "nodes" in API group "" in the namespace "toolchain-member-operator"
cannot list resource "roles" in API group "authorization.openshift.io"
cannot list resource "roles" in API group "rbac.authorization.k8s.io"
cannot list resource "componentstatuses" in API group ""
```
