### PR TITLE
Permission error in member

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -92,3 +92,10 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - processedtemplates
+  verbs:
+  - "get"
+  - "list"

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
@@ -175,6 +175,13 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          verbs:
+          - get
+          - list
         serviceAccountName: member-operator
       deployments:
       - name: member-operator

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -455,6 +455,13 @@ data:
                 verbs:
                 - get
                 - list
+              - apiGroups:
+                - template.openshift.io
+                resources:
+                - processedtemplates
+                verbs:
+                - get
+                - list
               serviceAccountName: member-operator
             deployments:
             - name: member-operator


### PR DESCRIPTION
Fixes one more error I found in the logs:
```
E0102 14:41:22.330962       1 reflector.go:126] pkg/mod/k8s.io/client-go@v11.0.1-0.20190409021438-1a26190bd76a+incompatible/tools/cache/reflector.go:94: Failed to list *unstructured.Unstructured: processedtemplates.template.openshift.io is forbidden: User "system:serviceaccount:toolchain-member-operator:member-operator" cannot list resource "processedtemplates" in API group "template.openshift.io" in the namespace "toolchain-member-operator"
```