### PR TITLE
chore: remove unneeded permissons

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -15,7 +15,7 @@ rules:
   resources:
   - nodes
   verbs:
-  - list
+  - "list"
 - apiGroups:
   - ""
   resources:
@@ -34,12 +34,7 @@ rules:
   - useridentitymappings
   - groups
   verbs:
-  - get
-  - create
-  - update
-  - list
-  - watch
-  - delete
+  - "*"
 - apiGroups:
   - core.kubefed.io
   resources:
@@ -49,9 +44,9 @@ rules:
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:
-  - '*'
+  - "*"
   verbs:
-  - '*'
+  - "*"
 - apiGroups:
   - rbac.authorization.k8s.io
   - authorization.openshift.io

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -14,13 +14,8 @@ rules:
   - ""
   resources:
   - nodes
-  - componentstatuses
-  - pods
-  - services
   verbs:
   - list
-  - get
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -73,29 +68,10 @@ rules:
   verbs:
   - "get"
   - "create"
-  - "list"
-  - "watch"
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
-  verbs:
-  - "get"
-  - "list"
-- apiGroups:
-  - authorization.openshift.io
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - subjectaccessreviews
-  - resourceaccessreviews
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - template.openshift.io
-  resources:
-  - processedtemplates
   verbs:
   - "get"
   - "list"

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
@@ -117,12 +117,7 @@ spec:
           - useridentitymappings
           - groups
           verbs:
-          - get
-          - create
-          - update
-          - list
-          - watch
-          - delete
+          - '*'
         - apiGroups:
           - core.kubefed.io
           resources:

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
@@ -97,13 +97,8 @@ spec:
           - ""
           resources:
           - nodes
-          - componentstatuses
-          - pods
-          - services
           verbs:
           - list
-          - get
-          - watch
         - apiGroups:
           - ""
           resources:
@@ -156,29 +151,10 @@ spec:
           verbs:
           - get
           - create
-          - list
-          - watch
         - apiGroups:
           - route.openshift.io
           resources:
           - routes
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - authorization.openshift.io
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          - subjectaccessreviews
-          - resourceaccessreviews
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - template.openshift.io
-          resources:
-          - processedtemplates
           verbs:
           - get
           - list
@@ -227,10 +203,7 @@ spec:
           - events
           - configmaps
           - secrets
-          - bindings
-          - podtemplates
           - serviceaccounts
-          - replicationcontrollers
           verbs:
           - '*'
         - apiGroups:
@@ -256,26 +229,6 @@ spec:
           - kubefedclusters/status
           verbs:
           - update
-        - apiGroups:
-          - authorization.openshift.io
-          - rbac.authorization.k8s.io
-          resources:
-          - subjectrulesreviews
-          - subjectaccessreviews
-          - localsubjectaccessreviews
-          - resourceaccessreviews
-          - roles
-          - rolebindings
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - template.openshift.io
-          resources:
-          - templateinstances
-          verbs:
-          - get
-          - list
         serviceAccountName: member-operator
     strategy: deployment
   installModes:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -38,4 +38,4 @@ rules:
   resources:
   - kubefedclusters/status
   verbs:
-  - update
+  - "update"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -13,10 +13,7 @@ rules:
   - events
   - configmaps
   - secrets
-  - bindings
-  - podtemplates
   - serviceaccounts
-  - replicationcontrollers
   verbs:
   - "*"
 - apiGroups:
@@ -42,23 +39,3 @@ rules:
   - kubefedclusters/status
   verbs:
   - update
-- apiGroups:
-  - authorization.openshift.io
-  - rbac.authorization.k8s.io
-  resources:
-  - subjectrulesreviews
-  - subjectaccessreviews
-  - localsubjectaccessreviews
-  - resourceaccessreviews
-  - roles
-  - rolebindings
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - template.openshift.io
-  resources:
-  - templateinstances
-  verbs:
-  - get
-  - list

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -377,13 +377,8 @@ data:
                 - ""
                 resources:
                 - nodes
-                - componentstatuses
-                - pods
-                - services
                 verbs:
                 - list
-                - get
-                - watch
               - apiGroups:
                 - ""
                 resources:
@@ -436,29 +431,10 @@ data:
                 verbs:
                 - get
                 - create
-                - list
-                - watch
               - apiGroups:
                 - route.openshift.io
                 resources:
                 - routes
-                verbs:
-                - get
-                - list
-              - apiGroups:
-                - authorization.openshift.io
-                - rbac.authorization.k8s.io
-                resources:
-                - clusterrolebindings
-                - subjectaccessreviews
-                - resourceaccessreviews
-                verbs:
-                - get
-                - list
-              - apiGroups:
-                - template.openshift.io
-                resources:
-                - processedtemplates
                 verbs:
                 - get
                 - list
@@ -507,10 +483,7 @@ data:
                 - events
                 - configmaps
                 - secrets
-                - bindings
-                - podtemplates
                 - serviceaccounts
-                - replicationcontrollers
                 verbs:
                 - '*'
               - apiGroups:
@@ -536,26 +509,6 @@ data:
                 - kubefedclusters/status
                 verbs:
                 - update
-              - apiGroups:
-                - authorization.openshift.io
-                - rbac.authorization.k8s.io
-                resources:
-                - subjectrulesreviews
-                - subjectaccessreviews
-                - localsubjectaccessreviews
-                - resourceaccessreviews
-                - roles
-                - rolebindings
-                verbs:
-                - get
-                - list
-              - apiGroups:
-                - template.openshift.io
-                resources:
-                - templateinstances
-                verbs:
-                - get
-                - list
               serviceAccountName: member-operator
           strategy: deployment
         installModes:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -397,12 +397,7 @@ data:
                 - useridentitymappings
                 - groups
                 verbs:
-                - get
-                - create
-                - update
-                - list
-                - watch
-                - delete
+                - '*'
               - apiGroups:
                 - core.kubefed.io
                 resources:


### PR DESCRIPTION
Since the RBAC issue with `reflector.go:95: Failed to list` errors should be fixed I decided to remove unneeded permissions from our roles. I didn't spend much time investigating which particular permissions are used and which are not, I just removed those that were apparently added just as a workaround for making our logs clean and happy.