### PR TITLE
Add `toolchain.dev.openshift.com/` prefix to namespace labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/member-operator
 require (
 	github.com/Azure/go-autorest/autorest v0.9.2 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200106162618-9b2c84309f9d
+	github.com/codeready-toolchain/api v0.0.0-20200109145334-5e7cde0ac10d
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624
 	github.com/go-logr/logr v0.1.0
 	github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible
@@ -21,8 +21,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.2.2
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20191023070212-24d45e9f4f15
 )
-
-replace github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20200108223257-d11e1101fffb
 
 // Pinned to kubernetes-1.14.1
 replace (

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20191023070212-24d45e9f4f15
 )
 
+replace github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20200108223257-d11e1101fffb
+
 // Pinned to kubernetes-1.14.1
 replace (
 	// using 'github.com/openshift/api@release-4.2'

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alexeykazakov/api v0.0.0-20200108223257-d11e1101fffb h1:KL9ajyFCB2FZO23DEgAf7YV6GJewb9748dqxtovCuCA=
-github.com/alexeykazakov/api v0.0.0-20200108223257-d11e1101fffb/go.mod h1:zPbdWiEiv9SpZMvyRkY6E6n7Eynm5Y0uhJhBiGXjkg0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -65,8 +63,8 @@ github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/codeready-toolchain/api v0.0.0-20200106162618-9b2c84309f9d h1:eKA5oNOO/Z2f9n9mjEdoVgRUSlj8HIzK49QDVrlpghY=
-github.com/codeready-toolchain/api v0.0.0-20200106162618-9b2c84309f9d/go.mod h1:st8k0LKhkg1Z7hNNia2NYLiFoNCxeBfJwpwgRdzqrLg=
+github.com/codeready-toolchain/api v0.0.0-20200109145334-5e7cde0ac10d h1:KPZ4RCOUHRnAwrFKGHS+orAotRVg4SOlYQdmg3wCB+M=
+github.com/codeready-toolchain/api v0.0.0-20200109145334-5e7cde0ac10d/go.mod h1:zPbdWiEiv9SpZMvyRkY6E6n7Eynm5Y0uhJhBiGXjkg0=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624 h1:m3y0VL12u4Aso1+LfaFHDgvWgj62Q+22kDFWTjaPqrg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206153324-4205c5ebe624/go.mod h1:fQpxuAw8pI0BwVJhgKHN9vbWko/eWsCzsZ+9pknFVLQ=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexeykazakov/api v0.0.0-20200108223257-d11e1101fffb h1:KL9ajyFCB2FZO23DEgAf7YV6GJewb9748dqxtovCuCA=
+github.com/alexeykazakov/api v0.0.0-20200108223257-d11e1101fffb/go.mod h1:zPbdWiEiv9SpZMvyRkY6E6n7Eynm5Y0uhJhBiGXjkg0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -39,8 +39,12 @@ const (
 
 func TestFindNamespace(t *testing.T) {
 	namespaces := []corev1.Namespace{
-		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-dev", Labels: map[string]string{"type": "dev"}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-code", Labels: map[string]string{"type": "code"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-dev", Labels: map[string]string{
+			toolchainv1alpha1.TypeLabelKey: "dev",
+		}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-code", Labels: map[string]string{
+			toolchainv1alpha1.TypeLabelKey: "code",
+		}}},
 	}
 
 	t.Run("found", func(t *testing.T) {
@@ -48,7 +52,7 @@ func TestFindNamespace(t *testing.T) {
 		namespace, found := findNamespace(namespaces, typeName)
 		assert.True(t, found)
 		assert.NotNil(t, namespace)
-		assert.Equal(t, typeName, namespace.GetLabels()["type"])
+		assert.Equal(t, typeName, namespace.GetLabels()[toolchainv1alpha1.TypeLabelKey])
 	})
 
 	t.Run("not_found", func(t *testing.T) {
@@ -62,13 +66,20 @@ func TestNextMissingNamespace(t *testing.T) {
 	userNamespaces := []corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-dev", Labels: map[string]string{"owner": "johnsmith", "revision": "abcde11", "type": "dev"},
+				Name: "johnsmith-dev", Labels: map[string]string{
+					toolchainv1alpha1.OwnerLabelKey:    "johnsmith",
+					toolchainv1alpha1.RevisionLabelKey: "abcde11",
+					toolchainv1alpha1.TypeLabelKey:     "dev",
+				},
 			},
 			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-code", Labels: map[string]string{"owner": "johnsmith", "type": "code"},
+				Name: "johnsmith-code", Labels: map[string]string{
+					toolchainv1alpha1.OwnerLabelKey: "johnsmith",
+					toolchainv1alpha1.TypeLabelKey:  "code",
+				},
 			},
 			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 		},
@@ -89,7 +100,7 @@ func TestNextMissingNamespace(t *testing.T) {
 	})
 
 	t.Run("missing_namespace", func(t *testing.T) {
-		userNamespaces[1].Labels["revision"] = "abcde11"
+		userNamespaces[1].Labels[toolchainv1alpha1.RevisionLabelKey] = "abcde11"
 
 		// test
 		tcNS, userNS, found := nextNamespaceToProvision(tcNamespaces, userNamespaces)
@@ -100,10 +111,13 @@ func TestNextMissingNamespace(t *testing.T) {
 	})
 
 	t.Run("namespace_not_found", func(t *testing.T) {
-		userNamespaces[1].Labels["revision"] = "abcde11"
+		userNamespaces[1].Labels[toolchainv1alpha1.RevisionLabelKey] = "abcde11"
 		userNamespaces = append(userNamespaces, corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-stage", Labels: map[string]string{"revision": "abcde11", "type": "stage"},
+				Name: "johnsmith-stage", Labels: map[string]string{
+					toolchainv1alpha1.RevisionLabelKey: "abcde11",
+					toolchainv1alpha1.TypeLabelKey:     "stage",
+				},
 			},
 			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 		})
@@ -517,8 +531,12 @@ func createNamespace(t *testing.T, client client.Client, revision, typeName stri
 	nsName := fmt.Sprintf("%s-%s", username, typeName)
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   nsName,
-			Labels: map[string]string{"owner": username, "revision": revision, "type": typeName},
+			Name: nsName,
+			Labels: map[string]string{
+				toolchainv1alpha1.OwnerLabelKey:    username,
+				toolchainv1alpha1.RevisionLabelKey: revision,
+				toolchainv1alpha1.TypeLabelKey:     typeName,
+			},
 		},
 		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 	}
@@ -562,8 +580,8 @@ func checkNamespace(t *testing.T, cl client.Client, username, typeName string) {
 	nsName := fmt.Sprintf("%s-%s", username, typeName)
 	err := cl.Get(context.TODO(), types.NamespacedName{Name: nsName}, namespace)
 	require.NoError(t, err)
-	require.Equal(t, username, namespace.Labels["owner"])
-	require.Equal(t, typeName, namespace.Labels["type"])
+	require.Equal(t, username, namespace.Labels[toolchainv1alpha1.OwnerLabelKey])
+	require.Equal(t, typeName, namespace.Labels[toolchainv1alpha1.TypeLabelKey])
 }
 
 func checkInnerResources(t *testing.T, client *test.FakeClient, nsName string) {

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -40,10 +40,10 @@ const (
 func TestFindNamespace(t *testing.T) {
 	namespaces := []corev1.Namespace{
 		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-dev", Labels: map[string]string{
-			toolchainv1alpha1.TypeLabelKey: "dev",
+			"toolchain.dev.openshift.com/type": "dev",
 		}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-code", Labels: map[string]string{
-			toolchainv1alpha1.TypeLabelKey: "code",
+			"toolchain.dev.openshift.com/type": "code",
 		}}},
 	}
 
@@ -52,7 +52,7 @@ func TestFindNamespace(t *testing.T) {
 		namespace, found := findNamespace(namespaces, typeName)
 		assert.True(t, found)
 		assert.NotNil(t, namespace)
-		assert.Equal(t, typeName, namespace.GetLabels()[toolchainv1alpha1.TypeLabelKey])
+		assert.Equal(t, typeName, namespace.GetLabels()["toolchain.dev.openshift.com/type"])
 	})
 
 	t.Run("not_found", func(t *testing.T) {
@@ -67,9 +67,9 @@ func TestNextMissingNamespace(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "johnsmith-dev", Labels: map[string]string{
-					toolchainv1alpha1.OwnerLabelKey:    "johnsmith",
-					toolchainv1alpha1.RevisionLabelKey: "abcde11",
-					toolchainv1alpha1.TypeLabelKey:     "dev",
+					"toolchain.dev.openshift.com/owner":    "johnsmith",
+					"toolchain.dev.openshift.com/revision": "abcde11",
+					"toolchain.dev.openshift.com/type":     "dev",
 				},
 			},
 			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
@@ -77,8 +77,8 @@ func TestNextMissingNamespace(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "johnsmith-code", Labels: map[string]string{
-					toolchainv1alpha1.OwnerLabelKey: "johnsmith",
-					toolchainv1alpha1.TypeLabelKey:  "code",
+					"toolchain.dev.openshift.com/owner": "johnsmith",
+					"toolchain.dev.openshift.com/type":  "code",
 				},
 			},
 			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
@@ -100,7 +100,7 @@ func TestNextMissingNamespace(t *testing.T) {
 	})
 
 	t.Run("missing_namespace", func(t *testing.T) {
-		userNamespaces[1].Labels[toolchainv1alpha1.RevisionLabelKey] = "abcde11"
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde11"
 
 		// test
 		tcNS, userNS, found := nextNamespaceToProvision(tcNamespaces, userNamespaces)
@@ -111,12 +111,12 @@ func TestNextMissingNamespace(t *testing.T) {
 	})
 
 	t.Run("namespace_not_found", func(t *testing.T) {
-		userNamespaces[1].Labels[toolchainv1alpha1.RevisionLabelKey] = "abcde11"
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde11"
 		userNamespaces = append(userNamespaces, corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "johnsmith-stage", Labels: map[string]string{
-					toolchainv1alpha1.RevisionLabelKey: "abcde11",
-					toolchainv1alpha1.TypeLabelKey:     "stage",
+					"toolchain.dev.openshift.com/revision": "abcde11",
+					"toolchain.dev.openshift.com/type":     "stage",
 				},
 			},
 			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
@@ -533,9 +533,9 @@ func createNamespace(t *testing.T, client client.Client, revision, typeName stri
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
 			Labels: map[string]string{
-				toolchainv1alpha1.OwnerLabelKey:    username,
-				toolchainv1alpha1.RevisionLabelKey: revision,
-				toolchainv1alpha1.TypeLabelKey:     typeName,
+				"toolchain.dev.openshift.com/owner":    username,
+				"toolchain.dev.openshift.com/revision": revision,
+				"toolchain.dev.openshift.com/type":     typeName,
 			},
 		},
 		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
@@ -580,8 +580,8 @@ func checkNamespace(t *testing.T, cl client.Client, username, typeName string) {
 	nsName := fmt.Sprintf("%s-%s", username, typeName)
 	err := cl.Get(context.TODO(), types.NamespacedName{Name: nsName}, namespace)
 	require.NoError(t, err)
-	require.Equal(t, username, namespace.Labels[toolchainv1alpha1.OwnerLabelKey])
-	require.Equal(t, typeName, namespace.Labels[toolchainv1alpha1.TypeLabelKey])
+	require.Equal(t, username, namespace.Labels["toolchain.dev.openshift.com/owner"])
+	require.Equal(t, typeName, namespace.Labels["toolchain.dev.openshift.com/type"])
 }
 
 func checkInnerResources(t *testing.T, client *test.FakeClient, nsName string) {


### PR DESCRIPTION
`owner` -> `toolchain.dev.openshift.com/owner`
`type` -> `toolchain.dev.openshift.com/type`
`revision` -> `toolchain.dev.openshift.com/revision`

Requires https://github.com/codeready-toolchain/api/pull/85

E2E tests - https://github.com/codeready-toolchain/toolchain-e2e/pull/64