### PR TITLE
chore: install github.com/kislyuk/yq binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
 - cp operator-sdk /home/travis/bin/operator-sdk
 - rm operator-sdk
 - pip3 install operator-courier
+- pip3 install yq
 
 script:
 - make build && make docker-login && make docker-push && curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/push-to-quay-nightly.sh | bash -s -- -pr ../member-operator/

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -30,7 +30,11 @@ RUN yum install epel-release -y \
     jq \
     go-bindata \
     gcc \
+    pip3 \
     && yum clean all
+
+# Install yq that will be used for parsing/reading yaml files.
+RUN pip3 install yq
 
 WORKDIR /tmp
 


### PR DESCRIPTION
yq binary is needed in the script introduced here codeready-toolchain/api#88. The script will be then used for e2e tests as well as for CD