### PR TITLE
refactoring useraccountspec to use useraccountspecbase

### DIFF
--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain-member-operator.v0.0.1.clusterserviceversion.yaml
@@ -6,6 +6,33 @@ metadata:
       [
         {
           "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+          "kind": "NSTemplateSet",
+          "metadata": {
+            "labels": {
+              "username": "johnsmith"
+            },
+            "name": "johnsmith"
+          },
+          "spec": {
+            "namespaces": [
+              {
+                "revision": "ab12ef",
+                "type": "ide"
+              },
+              {
+                "revision": "34efcd",
+                "type": "cicd"
+              },
+              {
+                "revision": "cdef56",
+                "type": "stage"
+              }
+            ],
+            "tierName": "basic"
+          }
+        },
+        {
+          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
           "kind": "UserAccount",
           "metadata": {
             "name": "johnsmith",
@@ -31,33 +58,6 @@ metadata:
               "tierName": "basic"
             },
             "userID": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
-          }
-        },
-        {
-          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-          "kind": "NSTemplateSet",
-          "metadata": {
-            "labels": {
-              "username": "johnsmith"
-            },
-            "name": "johnsmith"
-          },
-          "spec": {
-            "namespaces": [
-              {
-                "revision": "ab12ef",
-                "type": "ide"
-              },
-              {
-                "revision": "34efcd",
-                "type": "cicd"
-              },
-              {
-                "revision": "cdef56",
-                "type": "stage"
-              }
-            ],
-            "tierName": "basic"
           }
         }
       ]

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -286,6 +286,33 @@ data:
             [
               {
                 "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+                "kind": "NSTemplateSet",
+                "metadata": {
+                  "labels": {
+                    "username": "johnsmith"
+                  },
+                  "name": "johnsmith"
+                },
+                "spec": {
+                  "namespaces": [
+                    {
+                      "revision": "ab12ef",
+                      "type": "ide"
+                    },
+                    {
+                      "revision": "34efcd",
+                      "type": "cicd"
+                    },
+                    {
+                      "revision": "cdef56",
+                      "type": "stage"
+                    }
+                  ],
+                  "tierName": "basic"
+                }
+              },
+              {
+                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
                 "kind": "UserAccount",
                 "metadata": {
                   "name": "johnsmith",
@@ -311,33 +338,6 @@ data:
                     "tierName": "basic"
                   },
                   "userID": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
-                }
-              },
-              {
-                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-                "kind": "NSTemplateSet",
-                "metadata": {
-                  "labels": {
-                    "username": "johnsmith"
-                  },
-                  "name": "johnsmith"
-                },
-                "spec": {
-                  "namespaces": [
-                    {
-                      "revision": "ab12ef",
-                      "type": "ide"
-                    },
-                    {
-                      "revision": "34efcd",
-                      "type": "cicd"
-                    },
-                    {
-                      "revision": "cdef56",
-                      "type": "stage"
-                    }
-                  ],
-                  "tierName": "basic"
                 }
               }
             ]


### PR DESCRIPTION
Relates to PR: codeready-toolchain/api#100
Relates to PR: https://github.com/codeready-toolchain/host-operator/pull/143
Relates to Jira task: https://issues.redhat.com/browse/CRT-455
Relates to Jira story: https://issues.redhat.com/browse/CRT-444

Copying UserAccountSpec to masteruserrecord_types and rename to UserAccountEmbedded in order to decouple UserAccountSpec type from UserAccount.

This will be done in three stages:

Deprecate Embedded UA ID/Disabled
Change the implementation and start using the new API. Roll out to prod.
Delete deprecated API.

This PR is a part of stage 1.