### PR TITLE
fix: NSTemplateSet tests should test a CRQ in basic tier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.9.2 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20200416071738-c52e81ffb85d
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200430074824-fb63cc12194b
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
@@ -26,8 +26,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.5.0
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20200504102205-05095b3cf41b
 
 // Pinned to kubernetes-1.16.2
 replace (

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.1
 	k8s.io/apiextensions-apiserver v0.18.1
 	k8s.io/apimachinery v0.18.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.9.2 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20200416071738-c52e81ffb85d
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200427080755-4d31a88fd82c
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200430074824-fb63cc12194b
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
@@ -27,8 +27,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.5.0
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20200429153037-a2a22771697a
 
 // Pinned to kubernetes-1.16.2
 replace (

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20200429153037-a2a22771697a
+
 // Pinned to kubernetes-1.16.2
 replace (
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20200504102205-05095b3cf41b
+
 // Pinned to kubernetes-1.16.2
 replace (
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
-	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.1
 	k8s.io/apiextensions-apiserver v0.18.1
 	k8s.io/apimachinery v0.18.1

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/api v0.0.0-20200416071738-c52e81ffb85d h1:aG2EGkdf/mGlnNCsOjkxF0nz3Xi0aNrXKRdF+rWhAlY=
 github.com/codeready-toolchain/api v0.0.0-20200416071738-c52e81ffb85d/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200430074824-fb63cc12194b h1:vAZSE+r/zgczbIAiA430uTzhmbu/p5awokEP8xlKfo8=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200430074824-fb63cc12194b/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527 h1:sdODhNlkdU9TXR7JrV3T81E1JB3EUXIcapH2IBVzaLg=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/containerd/console v0.0.0-20170925154832-84eeaae905fa/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.0.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -470,8 +470,6 @@ github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b/go.mod h1
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
-github.com/matousjobanek/toolchain-common v0.0.0-20200504102205-05095b3cf41b h1:3zvUvhm8DO9DoT2k/M+3PnZUIlGDpicTyUFrpZSbHjU=
-github.com/matousjobanek/toolchain-common v0.0.0-20200504102205-05095b3cf41b/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,7 @@ github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b/go.mod h1
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
+github.com/matousjobanek/toolchain-common v0.0.0-20200429153037-a2a22771697a h1:CfGUofFw/SDmwDzrcGNDP4jDaMklM8/8/Rp+kdesmFI=
 github.com/matousjobanek/toolchain-common v0.0.0-20200429153037-a2a22771697a/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,8 @@ github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b/go.mod h1
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
+github.com/matousjobanek/toolchain-common v0.0.0-20200504102205-05095b3cf41b h1:3zvUvhm8DO9DoT2k/M+3PnZUIlGDpicTyUFrpZSbHjU=
+github.com/matousjobanek/toolchain-common v0.0.0-20200504102205-05095b3cf41b/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/api v0.0.0-20200416071738-c52e81ffb85d h1:aG2EGkdf/mGlnNCsOjkxF0nz3Xi0aNrXKRdF+rWhAlY=
 github.com/codeready-toolchain/api v0.0.0-20200416071738-c52e81ffb85d/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200427080755-4d31a88fd82c h1:c1suJM+TOWx8U1YBje24F8C3KPX1rmnYXNqmqorouSE=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200427080755-4d31a88fd82c/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200430074824-fb63cc12194b h1:vAZSE+r/zgczbIAiA430uTzhmbu/p5awokEP8xlKfo8=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200430074824-fb63cc12194b/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/containerd/console v0.0.0-20170925154832-84eeaae905fa/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.0.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -470,8 +470,6 @@ github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b/go.mod h1
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
-github.com/matousjobanek/toolchain-common v0.0.0-20200429153037-a2a22771697a h1:CfGUofFw/SDmwDzrcGNDP4jDaMklM8/8/Rp+kdesmFI=
-github.com/matousjobanek/toolchain-common v0.0.0-20200429153037-a2a22771697a/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,7 @@ github.com/maorfr/helm-plugin-utils v0.0.0-20181205064038-588190cb5e3b/go.mod h1
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
+github.com/matousjobanek/toolchain-common v0.0.0-20200429153037-a2a22771697a/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -1722,9 +1722,7 @@ func prepareController(t *testing.T, initObjs ...runtime.Object) (*NSTemplateSet
 		if err != nil {
 			return err
 		}
-		innerFakeClient := test.NewFakeClient(t)
-		innerFakeClient.Client = fakeClient.Client
-		if err := innerFakeClient.Create(ctx, o, opts...); err != nil {
+		if err := test.Create(fakeClient, ctx, o, opts...); err != nil {
 			return err
 		}
 		return passGeneration(o, obj)
@@ -1734,9 +1732,7 @@ func prepareController(t *testing.T, initObjs ...runtime.Object) (*NSTemplateSet
 		if err != nil {
 			return err
 		}
-		innerFakeClient := test.NewFakeClient(t)
-		innerFakeClient.Client = fakeClient.Client
-		if err := innerFakeClient.Update(ctx, o, opts...); err != nil {
+		if err := test.Update(fakeClient, ctx, o, opts...); err != nil {
 			return err
 		}
 		return passGeneration(o, obj)

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/codeready-toolchain/member-operator/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	authv1 "github.com/openshift/api/authorization/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -510,7 +511,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 		t.Run("status provisioned after all resources exist", func(t *testing.T) {
 			// given
 			// create cluster resource quotas
-			crq := newClusterResourceQuota(username, "advanced")
+			crq := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 			// create namespaces (and assume they are complete since they have the expected revision number)
 			devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
 			codeNS := newNamespace("advanced", username, "code", withRevision("abcde11"))
@@ -551,7 +552,8 @@ func TestReconcileUpdate(t *testing.T) {
 				devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
 				ro := newRole(devNS.Name, "rbac-edit")
 				rb := newRoleBinding(devNS.Name, "user-edit")
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, ro, rb)
+				crq := newClusterResourceQuota(username, "basic", "1750m", "7Gi")
+				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, ro, rb, crq)
 				err := fakeClient.Update(context.TODO(), nsTmplSet)
 				require.NoError(t, err)
 
@@ -611,7 +613,7 @@ func TestReconcileUpdate(t *testing.T) {
 				rb := newRoleBinding(devNS.Name, "user-edit")
 				rbacRb := newRoleBinding(devNS.Name, "user-rbac-edit")
 				ro := newRole(devNS.Name, "rbac-edit")
-				crq := newClusterResourceQuota(username, "advanced")
+				crq := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, rb, rbacRb, ro, crq)
 
 				// when - should remove ClusterResourceQuota that is missing in basic tier
@@ -665,7 +667,8 @@ func TestReconcileUpdate(t *testing.T) {
 				// create namespace (and assume it is complete since it has the expected revision number)
 				devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
 				ro := newRole(devNS.Name, "rbac-edit")
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, ro)
+				crq := newClusterResourceQuota(username, "basic", "1750m", "7Gi")
+				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, ro, crq)
 
 				err := fakeClient.Update(context.TODO(), nsTmplSet)
 				require.NoError(t, err)
@@ -738,7 +741,7 @@ func TestReconcileUpdate(t *testing.T) {
 				devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
 				rb := newRoleBinding(devNS.Name, "user-edit")
 				ro := newRole(devNS.Name, "rbac-edit")
-				crq := newClusterResourceQuota(username, "advanced")
+				crq := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, rb, ro, crq)
 
 				// when - should remove ClusterResourceQuota
@@ -842,7 +845,7 @@ func TestReconcileUpdate(t *testing.T) {
 					nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
 					devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
 					codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
-					crq := newClusterResourceQuota(username, "advanced")
+					crq := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS, crq) // current user has also a 'code' NS
 
 					// when - should delete the -code namespace
@@ -910,7 +913,7 @@ func TestReconcileUpdate(t *testing.T) {
 				t.Run("no redundant cluster resource to delete while upgrading tier", func(t *testing.T) {
 					// given same as above, but not upgrading tier and no cluster resource quota to delete
 					nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withClusterResources())
-					basicCRQ := newClusterResourceQuota(username, "basic")                                  // resource has same name in both tiers
+					basicCRQ := newClusterResourceQuota(username, "basic", "2000m", "10Gi")                 // resource has same values in advanced tier
 					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, basicCRQ) // current bnasic NSTemplateSet also has a cluster resource quota
 					fakeClient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
 						// because the fake client does not support such a type of list :(
@@ -941,8 +944,8 @@ func TestReconcileUpdate(t *testing.T) {
 					// given 'advanced' NSTemplate only has a cluster resource
 					nsTmplSet := newNSTmplSet(namespaceName, username, "advanced") // no cluster resources, so the "advancedCRQ" should be deleted
 					anotherNsTmplSet := newNSTmplSet(namespaceName, "another-user", "basic")
-					advancedCRQ := newClusterResourceQuota(username, "advanced")
-					anotherCRQ := newClusterResourceQuota("another-user", "basic")
+					advancedCRQ := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
+					anotherCRQ := newClusterResourceQuota("another-user", "basic", "1750m", "7Gi")
 					r, req, fakeClient := prepareReconcile(t, namespaceName, username, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ)
 
 					// when
@@ -958,7 +961,7 @@ func TestReconcileUpdate(t *testing.T) {
 				t.Run("delete redundant cluster resource quota while downgrading tier", func(t *testing.T) {
 					// given 'advanced' NSTemplate only has a cluster resource
 					nsTmplSet := newNSTmplSet(namespaceName, username, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
-					advancedCRQ := newClusterResourceQuota(username, "advanced")
+					advancedCRQ := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, advancedCRQ)
 
 					// when
@@ -985,7 +988,7 @@ func TestReconcileUpdate(t *testing.T) {
 				t.Run("delete redundant cluster resources when ClusterResources field is nil in NSTemplateSet", func(t *testing.T) {
 					// given 'advanced' NSTemplate only has a cluster resource
 					nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq") // no cluster resources, so the "advancedCRQ" should be deleted even if the tier contains the "advancedCRQ"
-					advancedCRQ := newClusterResourceQuota(username, "advanced")
+					advancedCRQ := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, advancedCRQ)
 
 					// when
@@ -1012,8 +1015,8 @@ func TestReconcileUpdate(t *testing.T) {
 				t.Run("delete only one redundant cluster resource during single reconcile", func(t *testing.T) {
 					// given 'advanced' NSTemplate only has a cluster resource
 					nsTmplSet := newNSTmplSet(namespaceName, username, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
-					advancedCRQ := newClusterResourceQuota(username, "withemptycrq")
-					anotherCRQ := newClusterResourceQuota(username, "withemptycrq")
+					advancedCRQ := newClusterResourceQuota(username, "withemptycrq", "2000m", "10Gi")
+					anotherCRQ := newClusterResourceQuota(username, "withemptycrq", "2000m", "10Gi")
 					anotherCRQ.Name = "for-empty"
 					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, advancedCRQ, anotherCRQ)
 
@@ -1102,7 +1105,7 @@ func TestReconcileUpdate(t *testing.T) {
 				nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
 				// create namespace (and assume it is complete since it has the expected revision number)
 				devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
-				crq := newClusterResourceQuota(username, "advanced")
+				crq := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 				rb := newRoleBinding(devNS.Name, "user-edit")
 				ro := newRole(devNS.Name, "rbac-edit")
 				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, crq, rb, ro)
@@ -1548,7 +1551,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 	t.Run("with cluster resources and 2 user namespaces to delete", func(t *testing.T) {
 		// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
 		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withDeletionTs(), withClusterResources())
-		crq := newClusterResourceQuota(username, "advanced")
+		crq := newClusterResourceQuota(username, "advanced", "2000m", "10Gi")
 		devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
 		codeNS := newNamespace("advanced", username, "code", withRevision("abcde11"))
 		r, _ := prepareController(t, nsTmplSet, crq, devNS, codeNS)
@@ -1722,17 +1725,40 @@ func prepareController(t *testing.T, initObjs ...runtime.Object) (*NSTemplateSet
 		if err != nil {
 			return err
 		}
-		return fakeClient.Client.Create(ctx, o, opts...)
+		innerFakeClient := test.NewFakeClient(t)
+		innerFakeClient.Client = fakeClient.Client
+		if err := innerFakeClient.Create(ctx, o, opts...); err != nil {
+			return err
+		}
+		return passGeneration(o, obj)
 	}
 	fakeClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 		o, err := toStructured(obj, decoder)
 		if err != nil {
 			return err
 		}
-		return fakeClient.Client.Update(ctx, o, opts...)
+		innerFakeClient := test.NewFakeClient(t)
+		innerFakeClient.Client = fakeClient.Client
+		if err := innerFakeClient.Update(ctx, o, opts...); err != nil {
+			return err
+		}
+		return passGeneration(o, obj)
 	}
 
 	return r, fakeClient
+}
+
+func passGeneration(from, to runtime.Object) error {
+	fromMeta, err := meta.Accessor(from)
+	if err != nil {
+		return err
+	}
+	toMeta, err := meta.Accessor(to)
+	if err != nil {
+		return err
+	}
+	toMeta.SetGeneration(fromMeta.GetGeneration())
+	return nil
 }
 
 func toStructured(obj runtime.Object, decoder runtime.Decoder) (runtime.Object, error) {
@@ -1869,7 +1895,7 @@ func newRole(namespace, name string) *rbacv1.Role { //nolint: unparam
 	}
 }
 
-func newClusterResourceQuota(username, tier string) *quotav1.ClusterResourceQuota {
+func newClusterResourceQuota(username, tier, cpu, memory string) *quotav1.ClusterResourceQuota {
 	return &quotav1.ClusterResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -1879,12 +1905,13 @@ func newClusterResourceQuota(username, tier string) *quotav1.ClusterResourceQuot
 			},
 			Annotations: map[string]string{},
 			Name:        "for-" + username,
+			Generation:  int64(1),
 		},
 		Spec: quotav1.ClusterResourceQuotaSpec{
 			Quota: corev1.ResourceQuotaSpec{
 				Hard: corev1.ResourceList{
-					"limits.cpu":    resource.MustParse("1750m"),
-					"limits.memory": resource.MustParse("7Gi"),
+					"limits.cpu":    resource.MustParse(cpu),
+					"limits.memory": resource.MustParse(memory),
 				},
 			},
 			Selector: quotav1.ClusterResourceQuotaSelector{
@@ -1912,8 +1939,8 @@ func getTemplateContent(decoder runtime.Decoder) func(tierName, typeName string)
 			}
 		case "basic":
 			switch typeName {
-			case ClusterResources: // assume that this tier has no "cluster resources" template
-				return nil, nil
+			case ClusterResources:
+				tmplContent = test.CreateTemplate(test.WithObjects(basicCrq), test.WithParams(username))
 			default:
 				tmplContent = test.CreateTemplate(test.WithObjects(ns, rb), test.WithParams(username))
 			}
@@ -1992,6 +2019,22 @@ var (
 - name: USERNAME
   value: johnsmith`
 
+	basicCrq test.TemplateObject = `
+- apiVersion: quota.openshift.io/v1
+  kind: ClusterResourceQuota
+  metadata:
+    name: for-${USERNAME}
+  spec:
+    quota:
+      hard:
+        limits.cpu: 1750m
+        limits.memory: 7Gi
+    selector:
+      annotations:
+        openshift.io/requester: ${USERNAME}
+    labels: null
+  `
+
 	advancedCrq test.TemplateObject = `
 - apiVersion: quota.openshift.io/v1
   kind: ClusterResourceQuota
@@ -1999,23 +2042,12 @@ var (
     name: for-${USERNAME}
   spec:
     quota:
-    hard:
-      limits.cpu: 1750m
-      limits.memory: 7Gi
-      limits.ephemeral-storage: 5Gi
-      requests.cpu: 1750m
-      requests.memory: 7Gi
-      requests.storage: 5Gi
-      requests.ephemeral-storage: 5Gi
-      persistentvolumeclaims: "2"
-      pods: "100"
-      replicationcontrollers: "100"
-      services: "100"
-      secrets: "100"
-      configmaps: "100"
+      hard:
+        limits.cpu: 2000m
+        limits.memory: 10Gi
     selector:
-    annotations:
-      openshift.io/requester: ${USERNAME}
+      annotations:
+        openshift.io/requester: ${USERNAME}
     labels: null
   `
 


### PR DESCRIPTION
this PR fixes a few things in the test:
* there was a wrong indentation in the ClusterResourceQuotas yaml snipets
* when using fake client it should rely on changes of the generation - based on this information it decides what to do next
* ~the basic tier should contain the ClusterResourceQuotas resource - it's more or less prerequisite of all tiers~
* when creating the ClusterResourceQuotas resource during the test setup, we need to parse the quota from yaml file, otherwise, the object contains slightly different formating that the one retrieved from the template - this causes that it looks like the resource was modified, thus generation incremented