### PR TITLE
chore: improve status handling in NSTemplateSet controller

### DIFF
--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -67,12 +67,11 @@ func Provisioned() toolchainv1alpha1.Condition {
 	}
 }
 
-func Provisioning(msg string) toolchainv1alpha1.Condition {
+func Provisioning() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:    toolchainv1alpha1.ConditionReady,
 		Status:  corev1.ConditionFalse,
 		Reason:  toolchainv1alpha1.NSTemplateSetProvisioningReason,
-		Message: msg,
 	}
 }
 


### PR DESCRIPTION
The PR improves the status handling in NSTemplateSet controller. First of all, it removes the message from the provisioning condition. The reasons are:
* there is no point in having the message - it doesn't bring any value
* it adds additional load in the status synchronization between UA and MUR

Then it changes methods:
* `setStatusProvisioning` -> `setStatusProvisioningIfNotUpdating`
* `setStatusUpdating` -> `setStatusUpdatingIfNotProvisioning`

so they first check if the other condition reason is set or not. If it's set, then keeps the original reason, if not, then sets the given reason. 
The reason for this change was that the conditions changed over and over agin from updating to provisioning and back.