### PR TITLE
chore: split nstemplateset controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.1
 	k8s.io/apiextensions-apiserver v0.18.1
 	k8s.io/apimachinery v0.18.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
-	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.1
 	k8s.io/apiextensions-apiserver v0.18.1
 	k8s.io/apimachinery v0.18.1

--- a/pkg/controller/nstemplateset/cluster_resources.go
+++ b/pkg/controller/nstemplateset/cluster_resources.go
@@ -96,6 +96,11 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 	return false, nil
 }
 
+// delete deletes cluster scoped resources taken the ClusterResources template. The method deletes only one resource in one call
+// and returns information if any resource was deleted or not. The cases are described below:
+//
+// If some resource that should be deleted is found, then it deletes it and returns 'true,nil'. If there is no resource to be deleted
+// which means that everything was deleted previously, then it returns 'false,nil'. In case of any error it returns 'false,error'.
 func (r *clusterResourcesManager) delete(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
 	username := nsTmplSet.Name
 	objs, err := process(r.templateContent(nsTmplSet.Spec.TierName, ClusterResources), r.scheme, username)

--- a/pkg/controller/nstemplateset/cluster_resources.go
+++ b/pkg/controller/nstemplateset/cluster_resources.go
@@ -1,0 +1,133 @@
+package nstemplateset
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
+	"github.com/go-logr/logr"
+	quotav1 "github.com/openshift/api/quota/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type clusterResourcesManager struct {
+	*statusManager
+}
+
+// ensure ensures that the cluster resources exists.
+// Returns `true, nil` if something was changed, `false, nil` if nothing changed, `false, err` if an error occurred
+func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
+	logger.Info("ensuring cluster resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName)
+	username := nsTmplSet.GetName()
+	newObjs := make([]runtime.RawExtension, 0)
+	var err error
+	if nsTmplSet.Spec.ClusterResources != nil {
+		newObjs, err = process(r.templateContent(nsTmplSet.Spec.TierName, ClusterResources), r.scheme, username)
+		if err != nil {
+			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusClusterResourcesProvisionFailed, err, "failed to retrieve template for the cluster resources")
+		}
+	}
+
+	// let's look for existing cluster resource quotas to determine the current tier
+	crqs := quotav1.ClusterResourceQuotaList{}
+	if err := r.client.List(context.TODO(), &crqs, listByOwnerLabel(username)); err != nil {
+		logger.Error(err, "failed to list existing cluster resource quotas")
+		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusClusterResourcesProvisionFailed, err, "failed to list existing cluster resource quotas")
+	} else if len(crqs.Items) > 0 {
+		// only if necessary
+		crqMeta, err := meta.Accessor(&(crqs.Items[0]))
+		if err != nil {
+			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusClusterResourcesProvisionFailed, err, "failed to get meta info from object %v", crqs.Items[0])
+		}
+		if currentTier, exists := crqMeta.GetLabels()[toolchainv1alpha1.TierLabelKey]; exists && currentTier != nsTmplSet.Spec.TierName {
+			if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
+				return false, err
+			}
+			currentObjs, err := process(r.templateContent(currentTier, ClusterResources), r.scheme, username)
+			if err != nil {
+				return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve cluster resources template for tier '%s'", currentTier)
+			}
+			if deleted, err := deleteRedundantObjects(logger, r.client, true, currentObjs, newObjs); err != nil {
+				logger.Error(err, "failed to delete redundant cluster resources")
+				return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to delete redundant cluster resources")
+			} else if deleted {
+				return true, nil // something changed
+			}
+		}
+	}
+	if len(newObjs) == 0 {
+		logger.Info("no cluster resources to create or update")
+		return false, nil
+	}
+
+	var labels = map[string]string{
+		toolchainv1alpha1.OwnerLabelKey:    nsTmplSet.GetName(),
+		toolchainv1alpha1.TypeLabelKey:     ClusterResources,
+		toolchainv1alpha1.RevisionLabelKey: nsTmplSet.Spec.ClusterResources.Revision,
+		toolchainv1alpha1.TierLabelKey:     nsTmplSet.Spec.TierName,
+		toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
+	}
+	// Note: we don't set an owner reference between the NSTemplateSet (namespaced resource) and the cluster-wide resources
+	// because a namespaced resource (NSTemplateSet) cannot be the owner of a cluster resource (the GC will delete the child resource, considering it is an orphan resource)
+	// As a consequence, when the NSTemplateSet is deleted, we explicitly delete the associated cluster-wide resources that belong to the same user.
+	// see https://issues.redhat.com/browse/CRT-429
+
+	for _, obj := range newObjs {
+		logger.Info("applying cluster resources object", "obj", obj.Object.GetObjectKind(), "username", username)
+		if createdOrUpdated, err := applycl.NewApplyClient(r.client, r.scheme).Apply([]runtime.RawExtension{obj}, labels); err != nil {
+			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusClusterResourcesProvisionFailed, err, "failed to create cluster resources")
+		} else if createdOrUpdated {
+			namespaces, err := fetchNamespaces(r.client, username)
+			if err != nil {
+				return true, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusProvisionFailed, err, "failed to list namespace with label owner '%s'", username)
+			}
+			if len(namespaces) == 0 {
+				logger.Info("provisioned cluster resource")
+				return true, r.setStatusProvisioningIfNotUpdating(nsTmplSet)
+			}
+			logger.Info("updated cluster resource")
+			return true, r.setStatusUpdatingIfNotProvisioning(nsTmplSet)
+		}
+	}
+	logger.Info("cluster resources already provisioned")
+	return false, nil
+}
+
+func (r *clusterResourcesManager) delete(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
+	username := nsTmplSet.Name
+	objs, err := process(r.templateContent(nsTmplSet.Spec.TierName, ClusterResources), r.scheme, username)
+	if err != nil {
+		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to list cluster resources for user '%s'", username)
+	}
+	logger.Info("listed cluster resources to delete", "count", len(objs))
+	for _, obj := range objs {
+		objectToDelete := obj.Object
+		objMeta, err := meta.Accessor(objectToDelete)
+		if err != nil {
+			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to delete cluster resource of kind '%s'", objectToDelete.GetObjectKind())
+		}
+		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: objMeta.GetName()}, objectToDelete); err != nil && !errors.IsNotFound(err) {
+			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err,
+				"failed to get current object '%s' while deleting cluster resource of kind '%s'", objMeta.GetName(), objectToDelete.GetObjectKind())
+		}
+		// ignore cluster resource that are already flagged for deletion
+		if errors.IsNotFound(err) || objMeta.GetDeletionTimestamp() != nil {
+			continue
+		}
+		logger.Info("deleting cluster resource", "name", objMeta.GetName())
+		err = r.client.Delete(context.TODO(), objectToDelete)
+		if err != nil && errors.IsNotFound(err) {
+			// ignore case where the resource did not exist anymore, move to the next one to delete
+			continue
+		} else if err != nil {
+			// report an error only if the resource could not be deleted (but ignore if the resource did not exist anymore)
+			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to delete cluster resource '%s'", objMeta.GetName())
+		}
+		// stop there for now. Will reconcile again for the next cluster resource (if any exists)
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/controller/nstemplateset/cluster_resources_test.go
+++ b/pkg/controller/nstemplateset/cluster_resources_test.go
@@ -98,7 +98,7 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 	t.Run("should not do anything when the CRQ is already created", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources(), withConditions(Provisioned()))
-		crq := newClusterResourceQuota(t, username, "advanced")
+		crq := newClusterResourceQuota(username, "advanced")
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 		// when
@@ -181,7 +181,7 @@ func TestDeleteClusterResources(t *testing.T) {
 
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
-	crq := newClusterResourceQuota(t, username, "advanced")
+	crq := newClusterResourceQuota(username, "advanced")
 	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withDeletionTs(), withClusterResources())
 
 	t.Run("delete ClusterResourceQuota", func(t *testing.T) {
@@ -201,8 +201,8 @@ func TestDeleteClusterResources(t *testing.T) {
 	t.Run("should delete only one ClusterResourceQuota even when tier contains more of them", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("dev"), withClusterResources())
-		crq := newClusterResourceQuota(t, username, "withemptycrq")
-		emptyCrq := newClusterResourceQuota(t, "empty", "withemptycrq")
+		crq := newClusterResourceQuota(username, "withemptycrq")
+		emptyCrq := newClusterResourceQuota("empty", "withemptycrq")
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq)
 
 		// when
@@ -233,10 +233,10 @@ func TestDeleteClusterResources(t *testing.T) {
 	t.Run("delete the second ClusterResourceQuota since the first one has deletion timestamp set", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("dev"), withClusterResources())
-		crq := newClusterResourceQuota(t, username, "withemptycrq")
+		crq := newClusterResourceQuota(username, "withemptycrq")
 		deletionTS := v1.NewTime(time.Now())
 		crq.SetDeletionTimestamp(&deletionTS)
-		emptyCrq := newClusterResourceQuota(t, "empty", "withemptycrq")
+		emptyCrq := newClusterResourceQuota("empty", "withemptycrq")
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq)
 
 		// when
@@ -297,7 +297,7 @@ func TestPromoteClusterResources(t *testing.T) {
 		t.Run("upgrade from advanced to team tier by changing the CRQ", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "team", withNamespaces("dev"), withClusterResources())
-			crq := newClusterResourceQuota(t, username, "advanced")
+			crq := newClusterResourceQuota(username, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 			// when
@@ -319,7 +319,7 @@ func TestPromoteClusterResources(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
 			// create namespace (and assume it is complete since it has the expected revision number)
-			crq := newClusterResourceQuota(t, username, "advanced")
+			crq := newClusterResourceQuota(username, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 			// when
@@ -338,7 +338,7 @@ func TestPromoteClusterResources(t *testing.T) {
 		t.Run("delete redundant cluster resources when ClusterResources field is nil in NSTemplateSet", func(t *testing.T) {
 			// given 'advanced' NSTemplate only has a cluster resource
 			nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq") // no cluster resources, so the "advancedCRQ" should be deleted even if the tier contains the "advancedCRQ"
-			crq := newClusterResourceQuota(t, username, "advanced")
+			crq := newClusterResourceQuota(username, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 			// when
@@ -378,8 +378,8 @@ func TestPromoteClusterResources(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withConditions(Provisioned())) // no cluster resources, so the "advancedCRQ" should be deleted
 			anotherNsTmplSet := newNSTmplSet(namespaceName, "another-user", "basic")
-			advancedCRQ := newClusterResourceQuota(t, username, "advanced")
-			anotherCRQ := newClusterResourceQuota(t, "another-user", "basic")
+			advancedCRQ := newClusterResourceQuota(username, "advanced")
+			anotherCRQ := newClusterResourceQuota("another-user", "basic")
 			manager, cl := prepareClusterResourcesManager(t, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ)
 
 			// when
@@ -396,8 +396,8 @@ func TestPromoteClusterResources(t *testing.T) {
 		t.Run("delete only one redundant cluster resource during one call", func(t *testing.T) {
 			// given 'advanced' NSTemplate only has a cluster resource
 			nsTmplSet := newNSTmplSet(namespaceName, username, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
-			advancedCRQ := newClusterResourceQuota(t, username, "withemptycrq")
-			anotherCRQ := newClusterResourceQuota(t, username, "withemptycrq")
+			advancedCRQ := newClusterResourceQuota(username, "withemptycrq")
+			anotherCRQ := newClusterResourceQuota(username, "withemptycrq")
 			anotherCRQ.Name = "for-empty"
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, advancedCRQ, anotherCRQ)
 
@@ -434,7 +434,7 @@ func TestPromoteClusterResources(t *testing.T) {
 		t.Run("promotion to another tier fails because it cannot load current template", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
-			crq := newClusterResourceQuota(t, username, "fail")
+			crq := newClusterResourceQuota(username, "fail")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 			// when
@@ -454,7 +454,7 @@ func TestPromoteClusterResources(t *testing.T) {
 		t.Run("fail to downgrade from advanced to basic tier", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
-			crq := newClusterResourceQuota(t, username, "advanced")
+			crq := newClusterResourceQuota(username, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 			cl.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 				return fmt.Errorf("some error")

--- a/pkg/controller/nstemplateset/cluster_resources_test.go
+++ b/pkg/controller/nstemplateset/cluster_resources_test.go
@@ -1,0 +1,477 @@
+package nstemplateset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/codeready-toolchain/member-operator/test"
+	quotav1 "github.com/openshift/api/quota/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestEnsureClusterResourcesOK(t *testing.T) {
+
+	logf.SetLogger(logf.ZapLogger(true))
+	// given
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
+
+	t.Run("should create CRQ and set status to provisioning", func(t *testing.T) {
+		// given
+		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(Provisioning())
+		AssertThatCluster(t, fakeClient).
+			HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
+	})
+
+	t.Run("should not create ClusterResource objects when the field is nil", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"))
+		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev").
+			HasNoConditions()
+	})
+
+	t.Run("should create only one CRQ when the template contains two of them", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("dev"), withClusterResources())
+		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(Provisioning())
+		AssertThatCluster(t, fakeClient).
+			HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
+		AssertThatCluster(t, fakeClient).
+			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{})
+
+		t.Run("should create the second CRQ when the first one is already created", func(t *testing.T) {
+			// when
+			createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, createdOrUpdated)
+			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+				HasFinalizer().
+				HasConditions(Provisioning())
+			AssertThatCluster(t, fakeClient).
+				HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
+			AssertThatCluster(t, fakeClient).
+				HasResource("for-empty", &quotav1.ClusterResourceQuota{})
+		})
+	})
+
+	t.Run("should not do anything when the CRQ is already created", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources(), withConditions(Provisioned()))
+		crq := newClusterResourceQuota(t, username, "advanced")
+		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet, crq)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(Provisioned())
+		AssertThatCluster(t, fakeClient).
+			HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
+	})
+}
+
+func TestEnsureClusterResourcesFail(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	// given
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
+
+	t.Run("fail to list cluster resources", func(t *testing.T) {
+		// given
+		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
+		fakeClient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			return errors.New("unable to list cluster resources")
+		}
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to list cluster resources")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvisionClusterResources("unable to list cluster resources"))
+	})
+
+	t.Run("fail to get template containing cluster resources", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "fail", withNamespaces("dev"), withClusterResources())
+		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to retrieve template")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvisionClusterResources("failed to retrieve template"))
+	})
+
+	t.Run("fail to create cluster resources", func(t *testing.T) {
+		// given
+		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
+		fakeClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "some error")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvisionClusterResources(
+				"unable to create resource of kind: ClusterResourceQuota, version: v1: unable to create resource of kind: ClusterResourceQuota, version: v1: some error"))
+	})
+}
+
+func TestDeleteClusterResources(t *testing.T) {
+
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+	crq := newClusterResourceQuota(t, username, "advanced")
+	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withDeletionTs(), withClusterResources())
+
+	t.Run("delete ClusterResourceQuota", func(t *testing.T) {
+		// given
+		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		AssertThatCluster(t, cl).
+			HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{})
+	})
+
+	t.Run("should delete only one ClusterResourceQuota even when tier contains more of them", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("dev"), withClusterResources())
+		crq := newClusterResourceQuota(t, username, "withemptycrq")
+		emptyCrq := newClusterResourceQuota(t, "empty", "withemptycrq")
+		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq)
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		AssertThatCluster(t, cl).
+			HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{})
+		AssertThatCluster(t, cl).
+			HasResource("for-empty", &quotav1.ClusterResourceQuota{})
+
+		t.Run("delete the for-empty CRQ since it's the last one to be deleted", func(t *testing.T) {
+			// when
+			deleted, err := manager.delete(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, deleted)
+			AssertThatCluster(t, cl).
+				HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{})
+			AssertThatCluster(t, cl).
+				HasNoResource("for-empty", &quotav1.ClusterResourceQuota{})
+		})
+	})
+
+	t.Run("delete the second ClusterResourceQuota since the first one has deletion timestamp set", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("dev"), withClusterResources())
+		crq := newClusterResourceQuota(t, username, "withemptycrq")
+		deletionTS := v1.NewTime(time.Now())
+		crq.SetDeletionTimestamp(&deletionTS)
+		emptyCrq := newClusterResourceQuota(t, "empty", "withemptycrq")
+		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq)
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		AssertThatCluster(t, cl).
+			HasResource("for-"+username, &quotav1.ClusterResourceQuota{}, HasDeletionTimestamp())
+		AssertThatCluster(t, cl).
+			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{})
+	})
+
+	t.Run("should not do anything when there is nothing to be deleted", func(t *testing.T) {
+		// given
+		manager, cl := prepareClusterResourcesManager(t, nsTmplSet)
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, deleted)
+		AssertThatCluster(t, cl).
+			HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{})
+	})
+
+	t.Run("failed to delete CRQ", func(t *testing.T) {
+		// given
+		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
+		cl.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+			return fmt.Errorf("mock error")
+		}
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.False(t, deleted)
+		assert.Equal(t, "failed to delete cluster resource 'for-johnsmith': mock error", err.Error())
+		AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			HasFinalizer(). // finalizer was not added and nothing else was done
+			HasConditions(UnableToTerminate("mock error"))
+	})
+}
+
+func TestPromoteClusterResources(t *testing.T) {
+
+	logf.SetLogger(logf.ZapLogger(true))
+	// given
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+
+	t.Run("success", func(t *testing.T) {
+
+		t.Run("upgrade from advanced to team tier by changing the CRQ", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "team", withNamespaces("dev"), withClusterResources())
+			crq := newClusterResourceQuota(t, username, "advanced")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Updating())
+			AssertThatCluster(t, cl).
+				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					WithLabel("toolchain.dev.openshift.com/tier", "team"),
+					Containing(`"limits.cpu":"4","limits.memory":"15Gi"`))
+		})
+
+		t.Run("downgrade from advanced to basic tier by removing CRQ", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
+			// create namespace (and assume it is complete since it has the expected revision number)
+			crq := newClusterResourceQuota(t, username, "advanced")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Updating())
+			AssertThatCluster(t, cl).
+				HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // no cluster resource quota in 'basic` tier
+		})
+
+		t.Run("delete redundant cluster resources when ClusterResources field is nil in NSTemplateSet", func(t *testing.T) {
+			// given 'advanced' NSTemplate only has a cluster resource
+			nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq") // no cluster resources, so the "advancedCRQ" should be deleted even if the tier contains the "advancedCRQ"
+			crq := newClusterResourceQuota(t, username, "advanced")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Updating())
+			AssertThatCluster(t, cl).
+				HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // resource was deleted
+		})
+
+		t.Run("upgrade from basic to advanced by creating CRQ", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withClusterResources())
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Provisioning())
+			AssertThatCluster(t, cl).
+				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
+					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)) // upgraded
+		})
+
+		t.Run("no redundant cluster resource quota to be deleted for the given user", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withConditions(Provisioned())) // no cluster resources, so the "advancedCRQ" should be deleted
+			anotherNsTmplSet := newNSTmplSet(namespaceName, "another-user", "basic")
+			advancedCRQ := newClusterResourceQuota(t, username, "advanced")
+			anotherCRQ := newClusterResourceQuota(t, "another-user", "basic")
+			manager, cl := prepareClusterResourcesManager(t, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.False(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Provisioned())
+		})
+
+		t.Run("delete only one redundant cluster resource during one call", func(t *testing.T) {
+			// given 'advanced' NSTemplate only has a cluster resource
+			nsTmplSet := newNSTmplSet(namespaceName, username, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
+			advancedCRQ := newClusterResourceQuota(t, username, "withemptycrq")
+			anotherCRQ := newClusterResourceQuota(t, username, "withemptycrq")
+			anotherCRQ.Name = "for-empty"
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, advancedCRQ, anotherCRQ)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Updating()) //
+			quotas := &quotav1.ClusterResourceQuotaList{}
+			err = cl.List(context.TODO(), quotas, &client.ListOptions{})
+			require.NoError(t, err)
+			assert.Len(t, quotas.Items, 1)
+
+			t.Run("it should delete the second for-empty CRQ since it's the last one", func(t *testing.T) {
+				// when - should delete the second ClusterResourceQuota
+				updated, err = manager.ensure(log, nsTmplSet)
+
+				// then
+				require.NoError(t, err)
+				assert.True(t, updated)
+				err = cl.List(context.TODO(), quotas, &client.ListOptions{})
+				require.NoError(t, err)
+				assert.Len(t, quotas.Items, 0)
+			})
+		})
+	})
+
+	t.Run("failure", func(t *testing.T) {
+
+		t.Run("promotion to another tier fails because it cannot load current template", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
+			crq := newClusterResourceQuota(t, username, "fail")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.Error(t, err)
+			assert.False(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(UpdateFailed("failed to retrieve template"))
+			AssertThatCluster(t, cl).
+				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					WithLabel("toolchain.dev.openshift.com/tier", "fail"))
+		})
+
+		t.Run("fail to downgrade from advanced to basic tier", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
+			crq := newClusterResourceQuota(t, username, "advanced")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
+			cl.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+				return fmt.Errorf("some error")
+			}
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.Error(t, err)
+			assert.False(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(UpdateFailed("failed to delete object 'for-johnsmith' of kind 'ClusterResourceQuota' in namespace '': some error"))
+			AssertThatCluster(t, cl).
+				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
+		})
+	})
+}

--- a/pkg/controller/nstemplateset/namespaces.go
+++ b/pkg/controller/nstemplateset/namespaces.go
@@ -6,6 +6,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -166,6 +167,17 @@ func (r *namespacesManager) delete(logger logr.Logger, nsTmplSet *toolchainv1alp
 		}
 	}
 	return false, nil
+}
+
+// fetchNamespaces returns all current namespaces belonging to the given user
+// i.e., labeled with `"toolchain.dev.openshift.com/owner":<username>`
+func fetchNamespaces(client client.Client, username string) ([]corev1.Namespace, error) {
+	// fetch all namespace with owner=username label
+	userNamespaceList := &corev1.NamespaceList{}
+	if err := client.List(context.TODO(), userNamespaceList, listByOwnerLabel(username)); err != nil {
+		return nil, err
+	}
+	return userNamespaceList.Items, nil
 }
 
 // nextNamespaceToProvisionOrUpdate returns first namespace (from given namespaces) whose status is active and

--- a/pkg/controller/nstemplateset/namespaces.go
+++ b/pkg/controller/nstemplateset/namespaces.go
@@ -148,6 +148,11 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 	return nil // nothing changed, no error occurred
 }
 
+// delete deletes namespaces that are owned by the user (based on the label). The method deletes only one namespace in one call
+// and returns information if any namespace was deleted or not. The cases are described below:
+//
+// If there is still some namespace owned by the user, then it deletes it and returns 'true,nil'. If there is no namespace found
+// which means that everything was deleted previously, then it returns 'false,nil'. In case of any error it returns 'false,error'.
 func (r *namespacesManager) delete(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
 	// now, we can delete all "child" namespaces explicitly
 	username := nsTmplSet.Name

--- a/pkg/controller/nstemplateset/namespaces.go
+++ b/pkg/controller/nstemplateset/namespaces.go
@@ -1,0 +1,222 @@
+package nstemplateset
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
+	"github.com/codeready-toolchain/toolchain-common/pkg/template"
+
+	"github.com/go-logr/logr"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/redhat-cop/operator-utils/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type namespacesManager struct {
+	*statusManager
+}
+
+// ensure ensures that all expected namespaces exists and they contain all the expected resources
+// return `true, nil` when something changed, `false, nil` or `false, err` otherwise
+func (r *namespacesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (createdOrUpdated bool, err error) {
+	username := nsTmplSet.GetName()
+	userNamespaces, err := fetchNamespaces(r.client, username)
+	if err != nil {
+		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusProvisionFailed, err, "failed to list namespaces with label owner '%s'", username)
+	}
+
+	toDeprovision, found := nextNamespaceToDeprovision(nsTmplSet.Spec.Namespaces, userNamespaces)
+	if found {
+		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
+			return false, err
+		}
+		if err := r.client.Delete(context.TODO(), toDeprovision); err != nil {
+			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to delete namespace %s", toDeprovision.Name)
+		}
+		logger.Info("deleted namespace as part of NSTemplateSet update", "namespace", toDeprovision.Name)
+		return true, nil // we deleted the namespace - wait for another reconcile
+	}
+
+	// find next namespace for provisioning namespace resource
+	tcNamespace, userNamespace, found := nextNamespaceToProvisionOrUpdate(nsTmplSet, userNamespaces)
+	if !found {
+		logger.Info("no more namespaces to create", "username", nsTmplSet.GetName())
+		return false, nil
+	}
+
+	if len(userNamespaces) > 0 {
+		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
+			return false, err
+		}
+	} else {
+		if err := r.setStatusProvisioningIfNotUpdating(nsTmplSet); err != nil {
+			return false, err
+		}
+	}
+
+	// create namespace resource
+	return true, r.ensureNamespace(logger, nsTmplSet, tcNamespace, userNamespace)
+}
+
+// ensureNamespace ensures that the namespace exists and that it contains all the expected resources
+func (r *namespacesManager) ensureNamespace(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tcNamespace *toolchainv1alpha1.NSTemplateSetNamespace, userNamespace *corev1.Namespace) error {
+	logger.Info("ensuring namespace", "namespace", tcNamespace.Type, "tier", nsTmplSet.Spec.TierName)
+
+	// create namespace before created inner resources because creating the namespace may take some time
+	if userNamespace == nil {
+		return r.ensureNamespaceResource(logger, nsTmplSet, tcNamespace)
+	}
+	return r.ensureInnerNamespaceResources(logger, nsTmplSet, tcNamespace, userNamespace)
+}
+
+// ensureNamespaceResource ensures that the namespace exists.
+func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tcNamespace *toolchainv1alpha1.NSTemplateSetNamespace) error {
+	logger.Info("creating namespace", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tcNamespace.Type)
+
+	objs, err := process(r.templateContent(nsTmplSet.Spec.TierName, tcNamespace.Type), r.scheme, nsTmplSet.GetName(), template.RetainNamespaces)
+	if err != nil {
+		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace type '%s'", tcNamespace.Type)
+	}
+
+	labels := map[string]string{
+		toolchainv1alpha1.OwnerLabelKey:    nsTmplSet.GetName(),
+		toolchainv1alpha1.TypeLabelKey:     tcNamespace.Type,
+		toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
+	}
+
+	// Note: we don't see an owner reference between the NSTemplateSet (namespaced resource) and the namespace (cluster-wide resource)
+	// because a namespaced resource cannot be the owner of a cluster resource (the GC will delete the child resource, considering it is an orphan resource)
+	// As a consequence, when the NSTemplateSet is deleted, we explicitly delete the associated namespaces that belong to the same user.
+	// see https://issues.redhat.com/browse/CRT-429
+
+	_, err = applycl.NewApplyClient(r.client, r.scheme).Apply(objs, labels)
+	if err != nil {
+		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to create namespace with type '%s'", tcNamespace.Type)
+	}
+	logger.Info("namespace provisioned", "namespace", tcNamespace)
+	return nil
+}
+
+// ensureInnerNamespaceResources ensure that the namespace has the expected resources.
+func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tcNamespace *toolchainv1alpha1.NSTemplateSetNamespace, namespace *corev1.Namespace) error {
+	logger.Info("ensuring namespace resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tcNamespace.Type)
+	nsName := namespace.GetName()
+	username := nsTmplSet.GetName()
+	newObjs, err := process(r.templateContent(nsTmplSet.Spec.TierName, tcNamespace.Type), r.scheme, username, template.RetainAllButNamespaces)
+	if err != nil {
+		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace '%s'", nsName)
+	}
+
+	if currentTier, exists := namespace.Labels[toolchainv1alpha1.TierLabelKey]; exists && currentTier != "" && currentTier != nsTmplSet.Spec.TierName {
+		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
+			return err
+		}
+
+		currentObjs, err := process(r.templateContent(currentTier, tcNamespace.Type), r.scheme, username, template.RetainAllButNamespaces)
+		if err != nil {
+			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve template for tier/type '%s/%s'", currentTier, tcNamespace.Type)
+		}
+		if _, err := deleteRedundantObjects(logger, r.client, false, currentObjs, newObjs); err != nil {
+			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to delete redundant objects in namespace '%s'", nsName)
+		}
+	}
+
+	var labels = map[string]string{
+		toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
+	}
+	if _, err = applycl.NewApplyClient(r.client, r.scheme).Apply(newObjs, labels); err != nil {
+		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to provision namespace '%s' with required resources", nsName)
+	}
+
+	if namespace.Labels == nil {
+		namespace.Labels = make(map[string]string)
+	}
+
+	// Adding labels indicating that the namespace is up-to-date with revision/tier
+	namespace.Labels[toolchainv1alpha1.RevisionLabelKey] = tcNamespace.Revision
+	namespace.Labels[toolchainv1alpha1.TierLabelKey] = nsTmplSet.Spec.TierName
+	if err := r.client.Update(context.TODO(), namespace); err != nil {
+		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to update namespace '%s'", nsName)
+	}
+
+	logger.Info("namespace provisioned with all required resources", "tier", nsTmplSet.Spec.TierName, "namespace", tcNamespace)
+
+	// TODO add validation for other objects
+	return nil // nothing changed, no error occurred
+}
+
+func (r *namespacesManager) delete(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
+	// now, we can delete all "child" namespaces explicitly
+	username := nsTmplSet.Name
+	userNamespaces, err := fetchNamespaces(r.client, username)
+	if err != nil {
+		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to list namespace with label owner '%s'", username)
+	}
+	// delete the first namespace which (still) exists and is not in a terminating state
+	logger.Info("checking user namepaces associated with the deleted NSTemplateSet...")
+	for _, ns := range userNamespaces {
+		if !util.IsBeingDeleted(&ns) {
+			logger.Info("deleting a user namepace associated with the deleted NSTemplateSet", "namespace", ns.Name)
+			if err := r.client.Delete(context.TODO(), &ns); err != nil {
+				return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to delete user namespace '%s'", ns.Name)
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// nextNamespaceToProvisionOrUpdate returns first namespace (from given namespaces) whose status is active and
+// either revision is not set or revision or tier doesn't equal to the current one.
+// It also returns namespace present in tcNamespaces but not found in given namespaces
+func nextNamespaceToProvisionOrUpdate(nsTmplSet *toolchainv1alpha1.NSTemplateSet, namespaces []corev1.Namespace) (*toolchainv1alpha1.NSTemplateSetNamespace, *corev1.Namespace, bool) {
+	for _, tcNamespace := range nsTmplSet.Spec.Namespaces {
+		namespace, found := findNamespace(namespaces, tcNamespace.Type)
+		if found {
+			if namespace.Status.Phase == corev1.NamespaceActive {
+				if namespace.Labels[toolchainv1alpha1.RevisionLabelKey] == "" ||
+					namespace.Labels[toolchainv1alpha1.RevisionLabelKey] != tcNamespace.Revision ||
+					namespace.Labels[toolchainv1alpha1.TierLabelKey] != nsTmplSet.Spec.TierName {
+					return &tcNamespace, &namespace, true
+				}
+			}
+		} else {
+			return &tcNamespace, nil, true
+		}
+	}
+	return nil, nil, false
+}
+
+// nextNamespaceToDeprovision returns namespace (and information of it was found) that should be deprovisioned
+// because its type wasn't found in the set of namespace types in NSTemplateSet
+func nextNamespaceToDeprovision(tcNamespaces []toolchainv1alpha1.NSTemplateSetNamespace, namespaces []corev1.Namespace) (*corev1.Namespace, bool) {
+Namespaces:
+	for _, ns := range namespaces {
+		for _, tcNs := range tcNamespaces {
+			if tcNs.Type == ns.Labels[toolchainv1alpha1.TypeLabelKey] {
+				continue Namespaces
+			}
+		}
+		return &ns, true
+	}
+	return nil, false
+}
+
+func findNamespace(namespaces []corev1.Namespace, typeName string) (corev1.Namespace, bool) {
+	for _, ns := range namespaces {
+		if ns.Labels[toolchainv1alpha1.TypeLabelKey] == typeName {
+			return ns, true
+		}
+	}
+	return corev1.Namespace{}, false
+}
+
+func getNamespaceName(request reconcile.Request) (string, error) {
+	namespace := request.Namespace
+	if namespace == "" {
+		return k8sutil.GetWatchNamespace()
+	}
+	return namespace, nil
+}

--- a/pkg/controller/nstemplateset/namespaces_test.go
+++ b/pkg/controller/nstemplateset/namespaces_test.go
@@ -1,0 +1,802 @@
+package nstemplateset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	. "github.com/codeready-toolchain/member-operator/test"
+	authv1 "github.com/openshift/api/authorization/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestFindNamespace(t *testing.T) {
+	namespaces := []corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-dev", Labels: map[string]string{
+			"toolchain.dev.openshift.com/type": "dev",
+		}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-code", Labels: map[string]string{
+			"toolchain.dev.openshift.com/type": "code",
+		}}},
+	}
+
+	t.Run("found", func(t *testing.T) {
+		typeName := "dev"
+		namespace, found := findNamespace(namespaces, typeName)
+		assert.True(t, found)
+		assert.NotNil(t, namespace)
+		assert.Equal(t, typeName, namespace.GetLabels()["toolchain.dev.openshift.com/type"])
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		typeName := "stage"
+		_, found := findNamespace(namespaces, typeName)
+		assert.False(t, found)
+	})
+}
+
+func TestNextNamespaceToProvisionOrUpdate(t *testing.T) {
+	// given
+	userNamespaces := []corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "johnsmith-dev", Labels: map[string]string{
+					"toolchain.dev.openshift.com/tier":     "basic",
+					"toolchain.dev.openshift.com/revision": "abcde11",
+					"toolchain.dev.openshift.com/type":     "dev",
+				},
+			},
+			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "johnsmith-code", Labels: map[string]string{
+					"toolchain.dev.openshift.com/type": "code",
+				},
+			},
+			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		},
+	}
+	nsTemplateSet := &toolchainv1alpha1.NSTemplateSet{
+		Spec: toolchainv1alpha1.NSTemplateSetSpec{
+			TierName: "basic",
+			Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{
+				{Type: "dev", Revision: "abcde11"},
+				{Type: "code", Revision: "abcde21"},
+				{Type: "stage", Revision: "abcde31"},
+			},
+		},
+	}
+
+	t.Run("return namespace whose revision is not set", func(t *testing.T) {
+		// when
+		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "code", tcNS.Type)
+		assert.Equal(t, "johnsmith-code", userNS.GetName())
+	})
+
+	t.Run("return namespace whose revision is different than in tier", func(t *testing.T) {
+		// given
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "123"
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "basic"
+
+		// when
+		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "code", tcNS.Type)
+		assert.Equal(t, "johnsmith-code", userNS.GetName())
+	})
+
+	t.Run("return namespace whose tier is different", func(t *testing.T) {
+		// given
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde21"
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "advanced"
+
+		// when
+		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "code", tcNS.Type)
+		assert.Equal(t, "johnsmith-code", userNS.GetName())
+	})
+
+	t.Run("return namespace that is not part of user namespaces", func(t *testing.T) {
+		// given
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde21"
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "basic"
+
+		// when
+		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "stage", tcNS.Type)
+		assert.Nil(t, userNS)
+	})
+
+	t.Run("namespace not found", func(t *testing.T) {
+		// given
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde21"
+		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "basic"
+		userNamespaces = append(userNamespaces, corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "johnsmith-stage", Labels: map[string]string{
+					"toolchain.dev.openshift.com/tier":     "basic",
+					"toolchain.dev.openshift.com/revision": "abcde31",
+					"toolchain.dev.openshift.com/type":     "stage",
+				},
+			},
+			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		})
+
+		// when
+		_, _, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
+
+		// then
+		assert.False(t, found)
+	})
+}
+
+func TestNextNamespaceToDeprovision(t *testing.T) {
+	// given
+	userNamespaces := []corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "johnsmith-dev", Labels: map[string]string{
+					"toolchain.dev.openshift.com/type": "dev",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "johnsmith-code", Labels: map[string]string{
+					"toolchain.dev.openshift.com/type": "code",
+				},
+			},
+		},
+	}
+
+	t.Run("return namespace that is not part of the tier", func(t *testing.T) {
+		// given
+		tcNamespaces := []toolchainv1alpha1.NSTemplateSetNamespace{
+			{Type: "dev", Revision: "abcde11"},
+		}
+
+		// when
+		namespace, found := nextNamespaceToDeprovision(tcNamespaces, userNamespaces)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "johnsmith-code", namespace.Name)
+	})
+
+	t.Run("should not return any namespace", func(t *testing.T) {
+		// given
+		tcNamespaces := []toolchainv1alpha1.NSTemplateSetNamespace{
+			{Type: "dev", Revision: "abcde11"},
+			{Type: "code", Revision: "abcde11"},
+		}
+
+		// when
+		namespace, found := nextNamespaceToDeprovision(tcNamespaces, userNamespaces)
+
+		// then
+		assert.False(t, found)
+		assert.Nil(t, namespace)
+	})
+}
+
+func TestGetNamespaceName(t *testing.T) {
+
+	// given
+	namespaceName := "toolchain-member"
+
+	t.Run("request namespace", func(t *testing.T) {
+		// given
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "any-name",
+				Namespace: namespaceName,
+			},
+		}
+
+		// when
+		nsName, err := getNamespaceName(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, namespaceName, nsName)
+	})
+
+	t.Run("watch namespace", func(t *testing.T) {
+		// given
+		currWatchNs := os.Getenv(k8sutil.WatchNamespaceEnvVar)
+		err := os.Setenv(k8sutil.WatchNamespaceEnvVar, namespaceName)
+		require.NoError(t, err)
+		defer func() {
+			if currWatchNs == "" {
+				err := os.Unsetenv(k8sutil.WatchNamespaceEnvVar)
+				require.NoError(t, err)
+				return
+			}
+			err := os.Setenv(k8sutil.WatchNamespaceEnvVar, currWatchNs)
+			require.NoError(t, err)
+		}()
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "any-name",
+				Namespace: "", // blank
+			},
+		}
+
+		// when
+		nsName, err := getNamespaceName(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, namespaceName, nsName)
+	})
+
+	t.Run("no namespace", func(t *testing.T) {
+		// given
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "any-name",
+				Namespace: "", // blank
+			},
+		}
+
+		// when
+		nsName, err := getNamespaceName(req)
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, "", nsName)
+	})
+
+}
+
+func TestEnsureNamespacesOK(t *testing.T) {
+
+	logf.SetLogger(logf.ZapLogger(true))
+	// given
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+
+	t.Run("should create only one namespace", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev", "code").
+			HasConditions(Provisioning())
+		AssertThatNamespace(t, username+"-dev", manager.client).
+			HasNoOwnerReference().
+			HasLabel("toolchain.dev.openshift.com/owner", username).
+			HasLabel("toolchain.dev.openshift.com/type", "dev").
+			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
+			HasNoLabel("toolchain.dev.openshift.com/revision").
+			HasNoLabel("toolchain.dev.openshift.com/tier")
+		AssertThatNamespace(t, username+"-code", manager.client).
+			DoesNotExist()
+	})
+
+	t.Run("should create the second namespace when the first one already exists", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(Provisioning()))
+		devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, devNS)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev", "code").
+			HasConditions(Provisioning())
+		AssertThatNamespace(t, username+"-code", fakeClient).
+			HasNoOwnerReference().
+			HasLabel("toolchain.dev.openshift.com/owner", username).
+			HasLabel("toolchain.dev.openshift.com/type", "code").
+			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
+			HasNoLabel("toolchain.dev.openshift.com/revision").
+			HasNoLabel("toolchain.dev.openshift.com/tier")
+
+	})
+
+	t.Run("inner resources created for existing namespace", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(Provisioning()))
+		devNS := newNamespace("", username, "dev") // NS exist but it is not complete yet
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, devNS)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev", "code").
+			HasConditions(Provisioning())
+		AssertThatNamespace(t, username+"-dev", fakeClient).
+			HasLabel("toolchain.dev.openshift.com/owner", username).
+			HasLabel("toolchain.dev.openshift.com/type", "dev").
+			HasLabel("toolchain.dev.openshift.com/revision", "abcde11"). // revision is set
+			HasLabel("toolchain.dev.openshift.com/tier", "basic").
+			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
+			HasResource("user-edit", &authv1.RoleBinding{})
+		AssertThatNamespace(t, username+"-code", manager.client).
+			DoesNotExist()
+	})
+
+	t.Run("ensure inner resources for code namespace if the dev is already provisioned", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(Provisioning()))
+		devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+		codeNS := newNamespace("", username, "code") // NS exist but it is not complete yet
+		rb := newRoleBinding(devNS.Name, "user-edit")
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, devNS, codeNS, rb)
+
+		// when
+		createdOrUpdated, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev", "code").
+			HasConditions(Provisioning())
+		for _, nsType := range []string{"code", "dev"} {
+			AssertThatNamespace(t, username+"-"+nsType, fakeClient).
+				HasLabel("toolchain.dev.openshift.com/owner", username).
+				HasLabel("toolchain.dev.openshift.com/type", nsType).
+				HasLabel("toolchain.dev.openshift.com/revision", "abcde11"). // revision is set
+				HasLabel("toolchain.dev.openshift.com/tier", "basic").
+				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
+				HasResource("user-edit", &authv1.RoleBinding{})
+		}
+	})
+}
+
+func TestEnsureNamespacesFail(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	// given
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+
+	t.Run("fail to create namespace", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet)
+		fakeClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+			return errors.New("unable to create namespace")
+		}
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to create namespace")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvisionNamespace("unable to create resource of kind: Namespace, version: v1: unable to create resource of kind: Namespace, version: v1: unable to create namespace"))
+		AssertThatNamespace(t, username+"-dev", fakeClient).DoesNotExist()
+		AssertThatNamespace(t, username+"-code", fakeClient).DoesNotExist()
+	})
+
+	t.Run("fail to fetch namespaces", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet)
+		fakeClient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			return errors.New("some error")
+		}
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "some error")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvision("some error"))
+		AssertThatNamespace(t, username+"-dev", fakeClient).DoesNotExist()
+		AssertThatNamespace(t, username+"-code", fakeClient).DoesNotExist()
+	})
+
+	t.Run("fail to create inner resources", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
+		devNS := newNamespace("", username, "dev") // NS exists but is missing its inner resources (since its revision is not set yet)
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, devNS)
+		fakeClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+			return errors.New("unable to create some object")
+		}
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to create some object")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvisionNamespace(
+				"unable to create resource of kind: RoleBinding, version: v1: unable to create resource of kind: RoleBinding, version: v1: unable to create some object"))
+		AssertThatNamespace(t, username+"-dev", fakeClient).
+			HasNoResource("user-edit", &authv1.RoleBinding{})
+	})
+
+	t.Run("fail to update status when ensuring inner resources", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
+		devNS := newNamespace("advanced", username, "dev") // NS exists but is missing the resources
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, devNS)
+		fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+			return errors.New("unable to update NSTmplSet")
+		}
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to update NSTmplSet")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions() // no condition was set (none was set)
+	})
+
+	t.Run("fail to get template for namespace", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("fail"))
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet)
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to retrieve template")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvisionNamespace("failed to retrieve template"))
+	})
+
+	t.Run("fail to get template for inner resources", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("fail"))
+		failNS := newNamespace("basic", username, "fail") // NS exists but with an unknown type
+		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, failNS)
+
+		// when
+		_, err := manager.ensure(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to retrieve template")
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(UnableToProvisionNamespace("failed to retrieve template"))
+	})
+
+}
+
+func TestDeleteNamespsace(t *testing.T) {
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+	// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
+	nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withDeletionTs())
+	devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+	codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
+
+	t.Run("delete user namespace", func(t *testing.T) {
+		// given
+		manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS)
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		// get the first namespace and check its deletion timestamp
+		firstNSName := fmt.Sprintf("%s-%s", username, nsTmplSet.Spec.Namespaces[0].Type)
+		AssertThatNamespace(t, firstNSName, cl).
+			DoesNotExist()
+	})
+
+	t.Run("with 2 user namespaces to delete", func(t *testing.T) {
+		// given
+		manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, codeNS)
+
+		cl.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+			if obj, ok := obj.(*corev1.Namespace); ok {
+				// mark namespaces as deleted...
+				deletionTS := metav1.NewTime(time.Now())
+				obj.SetDeletionTimestamp(&deletionTS)
+				// ... but replace them in the fake client cache yet instead of deleting them
+				return cl.Client.Update(ctx, obj)
+			}
+			return cl.Client.Delete(ctx, obj, opts...)
+		}
+
+		t.Run("delete the first namespace", func(t *testing.T) {
+			// when
+			deleted, err := manager.delete(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, deleted)
+			// get the first namespace and check its deletion timestamp
+			firstNSName := fmt.Sprintf("%s-%s", username, nsTmplSet.Spec.Namespaces[0].Type)
+			AssertThatNamespace(t, firstNSName, cl).HasDeletionTimestamp()
+
+			t.Run("delete the second namespace", func(t *testing.T) {
+				// when
+				deleted, err := manager.delete(log, nsTmplSet)
+
+				// then
+				require.NoError(t, err)
+				assert.True(t, deleted)
+				// get the second namespace and check its deletion timestamp
+				secondtNSName := fmt.Sprintf("%s-%s", username, nsTmplSet.Spec.Namespaces[1].Type)
+				AssertThatNamespace(t, secondtNSName, cl).HasDeletionTimestamp()
+			})
+		})
+	})
+
+	t.Run("do nothing since there is no namespace to be deleted", func(t *testing.T) {
+		// given
+		manager, _ := prepareNamespacesManager(t, nsTmplSet)
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, deleted)
+	})
+
+	t.Run("failed to fetch namespaces", func(t *testing.T) {
+		// given an NSTemplateSet resource which is being deleted and whose finalizer was not removed yet
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withDeletionTs(), withNamespaces("dev", "code"))
+		manager, cl := prepareNamespacesManager(t, nsTmplSet)
+		cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			if _, ok := list.(*corev1.NamespaceList); ok {
+				return fmt.Errorf("mock error")
+			}
+			return cl.Client.List(ctx, list, opts...)
+		}
+
+		// when
+		deleted, err := manager.delete(log, nsTmplSet)
+
+		// then
+		require.Error(t, err)
+		assert.False(t, deleted)
+		assert.Equal(t, "failed to list namespace with label owner 'johnsmith': mock error", err.Error())
+		AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			HasFinalizer(). // finalizer was not added and nothing else was done
+			HasConditions(UnableToTerminate("mock error"))
+	})
+}
+
+func TestPromoteNamespaces(t *testing.T) {
+
+	logf.SetLogger(logf.ZapLogger(true))
+	// given
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+
+	t.Run("success", func(t *testing.T) {
+
+		t.Run("upgrade dev to advanced tier", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
+			// create namespace (and assume it is complete since it has the expected revision number)
+			devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+			ro := newRole(devNS.Name, "rbac-edit")
+			rb := newRoleBinding(devNS.Name, "user-edit")
+			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, ro, rb)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Updating())
+			AssertThatNamespace(t, username+"-dev", cl).
+				HasNoOwnerReference().
+				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+				HasLabel("toolchain.dev.openshift.com/owner", username).
+				HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // upgraded
+				HasLabel("toolchain.dev.openshift.com/type", "dev").
+				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+				HasResource("user-edit", &authv1.RoleBinding{}).
+				HasResource("user-rbac-edit", &authv1.RoleBinding{})
+		})
+
+		t.Run("downgrade dev to basic tier", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
+			// create namespace (and assume it is complete since it has the expected revision number)
+			devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
+			rb := newRoleBinding(devNS.Name, "user-edit")
+			rbacRb := newRoleBinding(devNS.Name, "user-rbac-edit")
+			ro := newRole(devNS.Name, "rbac-edit")
+			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, rb, rbacRb, ro)
+
+			// when
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Updating())
+			AssertThatNamespace(t, username+"-dev", cl).
+				HasNoOwnerReference().
+				HasLabel("toolchain.dev.openshift.com/owner", username).
+				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+				HasLabel("toolchain.dev.openshift.com/type", "dev").
+				HasLabel("toolchain.dev.openshift.com/tier", "basic"). // "downgraded"
+				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+				HasResource("user-edit", &authv1.RoleBinding{}).
+				HasNoResource("rbac-edit", &rbacv1.Role{}). // role does not exist
+				HasNoResource("user-rbac-edit", &authv1.RoleBinding{})
+
+		})
+
+		t.Run("delete redundant namespace while upgrading tier", func(t *testing.T) {
+			// given 'advanced' NSTemplate only has a 'dev' namespace
+			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"))
+			devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+			codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
+			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, codeNS) // current user has also a 'code' NS
+
+			// when - should delete the code namespace
+			updated, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, updated)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(Updating())
+			AssertThatNamespace(t, codeNS.Name, cl).
+				DoesNotExist() // namespace was deleted
+			AssertThatNamespace(t, devNS.Name, cl).
+				HasNoOwnerReference().
+				HasLabel("toolchain.dev.openshift.com/owner", username).
+				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+				HasLabel("toolchain.dev.openshift.com/type", "dev").
+				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+				HasLabel("toolchain.dev.openshift.com/tier", "basic") // not upgraded yet
+
+			t.Run("uprade dev namespace when there is no other namespace to be deleted", func(t *testing.T) {
+
+				// when - should upgrade the -dev namespace
+				updated, err := manager.ensure(log, nsTmplSet)
+
+				// then
+				require.NoError(t, err)
+				assert.True(t, updated)
+				AssertThatNSTemplateSet(t, namespaceName, username, cl).
+					HasFinalizer().
+					HasConditions(Updating())
+				AssertThatNamespace(t, devNS.Name, cl).
+					HasNoOwnerReference().
+					HasLabel("toolchain.dev.openshift.com/owner", username).
+					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+					HasLabel("toolchain.dev.openshift.com/type", "dev").
+					HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // upgraded
+					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+					HasResource("user-edit", &authv1.RoleBinding{}).
+					HasResource("rbac-edit", &rbacv1.Role{})
+			})
+		})
+	})
+
+	t.Run("failure", func(t *testing.T) {
+
+		t.Run("promotion to another tier fails because it cannot load current template", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
+			// create namespace but with an unknown tier
+			devNS := newNamespace("fail", username, "dev", withRevision("abcde11"))
+			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS)
+
+			// when
+			_, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.Error(t, err)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(UpdateFailed("failed to retrieve template"))
+			AssertThatNamespace(t, username+"-dev", cl).
+				HasNoOwnerReference().
+				HasLabel("toolchain.dev.openshift.com/owner", username).
+				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+				HasLabel("toolchain.dev.openshift.com/type", "dev").
+				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+				HasLabel("toolchain.dev.openshift.com/tier", "fail") // the unknown tier that caused the error
+		})
+
+		t.Run("fail to delete redundant namespace while upgrading tier", func(t *testing.T) {
+			// given
+			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
+			devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+			codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
+			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, codeNS) // current user has also a 'code' NS
+			cl.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+				return fmt.Errorf("mock error: '%T'", obj)
+			}
+
+			// when - should delete the code namespace
+			_, err := manager.ensure(log, nsTmplSet)
+
+			// then
+			require.Error(t, err)
+			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				HasFinalizer().
+				HasConditions(UpdateFailed("mock error: '*v1.Namespace'")) // failed to delete NS
+			AssertThatNamespace(t, username+"-code", cl).
+				HasNoOwnerReference().
+				HasLabel("toolchain.dev.openshift.com/owner", username).
+				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+				HasLabel("toolchain.dev.openshift.com/type", "code").
+				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+				HasLabel("toolchain.dev.openshift.com/tier", "basic") // unchanged, namespace was not deleted
+			AssertThatNamespace(t, username+"-dev", cl).
+				HasNoOwnerReference().
+				HasLabel("toolchain.dev.openshift.com/owner", username).
+				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+				HasLabel("toolchain.dev.openshift.com/type", "dev").
+				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+				HasLabel("toolchain.dev.openshift.com/tier", "basic") // not upgraded
+		})
+	})
+}

--- a/pkg/controller/nstemplateset/nstemplateset_controller.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller.go
@@ -235,17 +235,6 @@ Current:
 	return deleted, nil
 }
 
-// fetchNamespaces returns all current namespaces belonging to the given user
-// i.e., labeled with `"toolchain.dev.openshift.com/owner":<username>`
-func fetchNamespaces(client client.Client, username string) ([]corev1.Namespace, error) {
-	// fetch all namespace with owner=username label
-	userNamespaceList := &corev1.NamespaceList{}
-	if err := client.List(context.TODO(), userNamespaceList, listByOwnerLabel(username)); err != nil {
-		return nil, err
-	}
-	return userNamespaceList.Items, nil
-}
-
 // listByOwnerLabel returns client.ListOption that filters by label toolchain.dev.openshift.com/owner equal to the given username
 func listByOwnerLabel(username string) client.ListOption {
 	labels := map[string]string{toolchainv1alpha1.OwnerLabelKey: username}

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -16,12 +15,10 @@ import (
 	authv1 "github.com/openshift/api/authorization/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierros "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,258 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
-
-func TestFindNamespace(t *testing.T) {
-	namespaces := []corev1.Namespace{
-		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-dev", Labels: map[string]string{
-			"toolchain.dev.openshift.com/type": "dev",
-		}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "johnsmith-code", Labels: map[string]string{
-			"toolchain.dev.openshift.com/type": "code",
-		}}},
-	}
-
-	t.Run("found", func(t *testing.T) {
-		typeName := "dev"
-		namespace, found := findNamespace(namespaces, typeName)
-		assert.True(t, found)
-		assert.NotNil(t, namespace)
-		assert.Equal(t, typeName, namespace.GetLabels()["toolchain.dev.openshift.com/type"])
-	})
-
-	t.Run("not found", func(t *testing.T) {
-		typeName := "stage"
-		_, found := findNamespace(namespaces, typeName)
-		assert.False(t, found)
-	})
-}
-
-func TestNextNamespaceToProvisionOrUpdate(t *testing.T) {
-	// given
-	userNamespaces := []corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-dev", Labels: map[string]string{
-					"toolchain.dev.openshift.com/tier":     "basic",
-					"toolchain.dev.openshift.com/revision": "abcde11",
-					"toolchain.dev.openshift.com/type":     "dev",
-				},
-			},
-			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-code", Labels: map[string]string{
-					"toolchain.dev.openshift.com/type": "code",
-				},
-			},
-			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
-		},
-	}
-	nsTemplateSet := &toolchainv1alpha1.NSTemplateSet{
-		Spec: toolchainv1alpha1.NSTemplateSetSpec{
-			TierName: "basic",
-			Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{
-				{Type: "dev", Revision: "abcde11"},
-				{Type: "code", Revision: "abcde21"},
-				{Type: "stage", Revision: "abcde31"},
-			},
-		},
-	}
-
-	t.Run("return namespace whose revision is not set", func(t *testing.T) {
-		// when
-		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
-
-		// then
-		assert.True(t, found)
-		assert.Equal(t, "code", tcNS.Type)
-		assert.Equal(t, "johnsmith-code", userNS.GetName())
-	})
-
-	t.Run("return namespace whose revision is different than in tier", func(t *testing.T) {
-		// given
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "123"
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "basic"
-
-		// when
-		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
-
-		// then
-		assert.True(t, found)
-		assert.Equal(t, "code", tcNS.Type)
-		assert.Equal(t, "johnsmith-code", userNS.GetName())
-	})
-
-	t.Run("return namespace whose tier is different", func(t *testing.T) {
-		// given
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde21"
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "advanced"
-
-		// when
-		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
-
-		// then
-		assert.True(t, found)
-		assert.Equal(t, "code", tcNS.Type)
-		assert.Equal(t, "johnsmith-code", userNS.GetName())
-	})
-
-	t.Run("return namespace that is not part of user namespaces", func(t *testing.T) {
-		// given
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde21"
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "basic"
-
-		// when
-		tcNS, userNS, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
-
-		// then
-		assert.True(t, found)
-		assert.Equal(t, "stage", tcNS.Type)
-		assert.Nil(t, userNS)
-	})
-
-	t.Run("namespace not found", func(t *testing.T) {
-		// given
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/revision"] = "abcde21"
-		userNamespaces[1].Labels["toolchain.dev.openshift.com/tier"] = "basic"
-		userNamespaces = append(userNamespaces, corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-stage", Labels: map[string]string{
-					"toolchain.dev.openshift.com/tier":     "basic",
-					"toolchain.dev.openshift.com/revision": "abcde31",
-					"toolchain.dev.openshift.com/type":     "stage",
-				},
-			},
-			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
-		})
-
-		// when
-		_, _, found := nextNamespaceToProvisionOrUpdate(nsTemplateSet, userNamespaces)
-
-		// then
-		assert.False(t, found)
-	})
-}
-
-func TestNextNamespaceToDeprovision(t *testing.T) {
-	// given
-	userNamespaces := []corev1.Namespace{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-dev", Labels: map[string]string{
-					"toolchain.dev.openshift.com/type": "dev",
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "johnsmith-code", Labels: map[string]string{
-					"toolchain.dev.openshift.com/type": "code",
-				},
-			},
-		},
-	}
-
-	t.Run("return namespace that is not part of the tier", func(t *testing.T) {
-		// given
-		tcNamespaces := []toolchainv1alpha1.NSTemplateSetNamespace{
-			{Type: "dev", Revision: "abcde11"},
-		}
-
-		// when
-		namespace, found := nextNamespaceToDeprovision(tcNamespaces, userNamespaces)
-
-		// then
-		assert.True(t, found)
-		assert.Equal(t, "johnsmith-code", namespace.Name)
-	})
-
-	t.Run("should not return any namespace", func(t *testing.T) {
-		// given
-		tcNamespaces := []toolchainv1alpha1.NSTemplateSetNamespace{
-			{Type: "dev", Revision: "abcde11"},
-			{Type: "code", Revision: "abcde11"},
-		}
-
-		// when
-		namespace, found := nextNamespaceToDeprovision(tcNamespaces, userNamespaces)
-
-		// then
-		assert.False(t, found)
-		assert.Nil(t, namespace)
-	})
-}
-
-func TestGetNamespaceName(t *testing.T) {
-
-	// given
-	namespaceName := "toolchain-member"
-
-	t.Run("request namespace", func(t *testing.T) {
-		// given
-		req := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      "any-name",
-				Namespace: namespaceName,
-			},
-		}
-
-		// when
-		nsName, err := getNamespaceName(req)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, namespaceName, nsName)
-	})
-
-	t.Run("watch namespace", func(t *testing.T) {
-		// given
-		currWatchNs := os.Getenv(k8sutil.WatchNamespaceEnvVar)
-		err := os.Setenv(k8sutil.WatchNamespaceEnvVar, namespaceName)
-		require.NoError(t, err)
-		defer func() {
-			if currWatchNs == "" {
-				err := os.Unsetenv(k8sutil.WatchNamespaceEnvVar)
-				require.NoError(t, err)
-				return
-			}
-			err := os.Setenv(k8sutil.WatchNamespaceEnvVar, currWatchNs)
-			require.NoError(t, err)
-		}()
-		req := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      "any-name",
-				Namespace: "", // blank
-			},
-		}
-
-		// when
-		nsName, err := getNamespaceName(req)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, namespaceName, nsName)
-	})
-
-	t.Run("no namespace", func(t *testing.T) {
-		// given
-		req := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      "any-name",
-				Namespace: "", // blank
-			},
-		}
-
-		// when
-		nsName, err := getNamespaceName(req)
-
-		// then
-		require.Error(t, err)
-		assert.Equal(t, "", nsName)
-	})
-
-}
 
 func TestReconcileAddFinalizer(t *testing.T) {
 
@@ -339,198 +84,97 @@ func TestReconcileProvisionOK(t *testing.T) {
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
 
-	t.Run("without cluster resources", func(t *testing.T) {
-
-		t.Run("new namespace created", func(t *testing.T) {
-			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
-
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-				HasFinalizer().
-				HasSpecNamespaces("dev", "code").
-				HasConditions(Provisioning())
-			AssertThatNamespace(t, username+"-dev", r.client).
-				HasNoOwnerReference().
-				HasLabel("toolchain.dev.openshift.com/owner", username).
-				HasLabel("toolchain.dev.openshift.com/type", "dev").
-				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasNoLabel("toolchain.dev.openshift.com/revision").
-				HasNoLabel("toolchain.dev.openshift.com/tier")
-		})
-
-		t.Run("new namespace created with existing namespace", func(t *testing.T) {
-			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-			devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS)
-
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-				HasFinalizer().
-				HasSpecNamespaces("dev", "code").
-				HasConditions(Provisioning())
-			AssertThatNamespace(t, username+"-code", r.client).
-				HasNoOwnerReference().
-				HasLabel("toolchain.dev.openshift.com/owner", username).
-				HasLabel("toolchain.dev.openshift.com/type", "code").
-				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasNoLabel("toolchain.dev.openshift.com/revision").
-				HasNoLabel("toolchain.dev.openshift.com/tier")
-
-		})
-
-		t.Run("inner resources created for existing namespace", func(t *testing.T) {
-			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-			devNS := newNamespace("basic", username, "dev") // NS exist but it is not complete yet
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS)
-
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-				HasFinalizer().
-				HasSpecNamespaces("dev", "code").
-				HasConditions(Provisioning())
-			AssertThatNamespace(t, username+"-dev", fakeClient).
-				HasLabel("toolchain.dev.openshift.com/owner", username).
-				HasLabel("toolchain.dev.openshift.com/type", "dev").
-				HasLabel("toolchain.dev.openshift.com/revision", "abcde11"). // revision is set
-				HasLabel("toolchain.dev.openshift.com/tier", "basic").
-				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasResource("user-edit", &authv1.RoleBinding{})
-		})
-
-		t.Run("status provisioned", func(t *testing.T) {
-			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-			// create namespaces (and assume they are complete since they have the expected revision number)
-			devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-			codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
-
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-				HasFinalizer().
-				HasSpecNamespaces("dev", "code").
-				HasConditions(Provisioned())
-			AssertThatNamespace(t, username+"-dev", fakeClient).
-				HasLabel("toolchain.dev.openshift.com/owner", username).
-				HasLabel("toolchain.dev.openshift.com/type", "dev").
-				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-				HasLabel("toolchain.dev.openshift.com/tier", "basic").
-				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
-			AssertThatNamespace(t, username+"-code", fakeClient).
-				HasLabel("toolchain.dev.openshift.com/owner", username).
-				HasLabel("toolchain.dev.openshift.com/type", "code").
-				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-				HasLabel("toolchain.dev.openshift.com/tier", "basic").
-				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
-		})
-
-		t.Run("no NSTemplateSet available", func(t *testing.T) {
-			// given
-			r, req, _ := prepareReconcile(t, namespaceName, username)
-
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-		})
-
-		t.Run("should not create ClusterResource objects when the field is nil", func(t *testing.T) {
-			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
-
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-				HasFinalizer().
-				HasSpecNamespaces("dev", "code").
-				HasConditions(Provisioning())
-			AssertThatNamespace(t, username+"-dev", r.client).
-				HasNoOwnerReference().
-				HasLabel("toolchain.dev.openshift.com/owner", username).
-				HasLabel("toolchain.dev.openshift.com/type", "dev").
-				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasNoLabel("toolchain.dev.openshift.com/revision").
-				HasNoLabel("toolchain.dev.openshift.com/tier")
-		})
-	})
-
-	t.Run("with cluster resources", func(t *testing.T) {
-
+	t.Run("status provisioned when cluster resources are missing", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withClusterResources())
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
+		// create namespaces (and assume they are complete since they have the expected revision number)
+		devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+		codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
 
-		t.Run("status provisioning after creating cluster resources", func(t *testing.T) {
-			// given
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+		// when
+		res, err := r.Reconcile(req)
 
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-				HasFinalizer().
-				HasConditions(Provisioning())
-			AssertThatCluster(t, fakeClient).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
-		})
-
-		t.Run("status provisioned after all resources exist", func(t *testing.T) {
-			// given
-			// create cluster resource quotas
-			crq := newClusterResourceQuota(t, username, "advanced")
-			// create namespaces (and assume they are complete since they have the expected revision number)
-			devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
-			codeNS := newNamespace("advanced", username, "code", withRevision("abcde11"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, crq, devNS, codeNS)
-
-			// when
-			res, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-				HasFinalizer().
-				HasSpecNamespaces("dev", "code").
-				HasConditions(Provisioned())
-			AssertThatCluster(t, fakeClient).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
-		})
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev", "code").
+			HasConditions(Provisioned())
+		AssertThatNamespace(t, username+"-dev", fakeClient).
+			HasLabel("toolchain.dev.openshift.com/owner", username).
+			HasLabel("toolchain.dev.openshift.com/type", "dev").
+			HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+			HasLabel("toolchain.dev.openshift.com/tier", "basic").
+			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
+		AssertThatNamespace(t, username+"-code", fakeClient).
+			HasLabel("toolchain.dev.openshift.com/owner", username).
+			HasLabel("toolchain.dev.openshift.com/type", "code").
+			HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+			HasLabel("toolchain.dev.openshift.com/tier", "basic").
+			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
 	})
 
+	t.Run("status provisioned with cluster resources", func(t *testing.T) {
+		// given
+		// create cluster resource quotas
+		crq := newClusterResourceQuota(t, username, "advanced")
+		// create namespaces (and assume they are complete since they have the expected revision number)
+		devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
+		codeNS := newNamespace("advanced", username, "code", withRevision("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withClusterResources())
+		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, crq, devNS, codeNS)
+
+		// when
+		res, err := r.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev", "code").
+			HasConditions(Provisioned())
+		AssertThatCluster(t, fakeClient).
+			HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
+	})
+
+	t.Run("should not create ClusterResource objects when the field is nil but provision namespace", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+
+		// when
+		res, err := r.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasSpecNamespaces("dev", "code").
+			HasConditions(Provisioning())
+		AssertThatNamespace(t, username+"-dev", r.client).
+			HasNoOwnerReference().
+			HasLabel("toolchain.dev.openshift.com/owner", username).
+			HasLabel("toolchain.dev.openshift.com/type", "dev").
+			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
+			HasNoLabel("toolchain.dev.openshift.com/revision").
+			HasNoLabel("toolchain.dev.openshift.com/tier")
+	})
+
+	t.Run("no NSTemplateSet available", func(t *testing.T) {
+		// given
+		r, req, _ := prepareReconcile(t, namespaceName, username)
+
+		// when
+		res, err := r.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+	})
 }
 
 func TestReconcileUpdate(t *testing.T) {
@@ -540,599 +184,111 @@ func TestReconcileUpdate(t *testing.T) {
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("upgrade from basic to advanced tier", func(t *testing.T) {
 
-		t.Run("without cluster resources", func(t *testing.T) {
-
-			t.Run("upgrade dev to advanced tier", func(t *testing.T) {
-				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
-				// create namespace (and assume it is complete since it has the expected revision number)
-				devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-				ro := newRole(devNS.Name, "rbac-edit")
-				rb := newRoleBinding(devNS.Name, "user-edit")
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, ro, rb)
-				err := fakeClient.Update(context.TODO(), nsTmplSet)
-				require.NoError(t, err)
-
-				// when - should create ClusterResource
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/tier", "basic"). // not upgraded yet
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("user-edit", &authv1.RoleBinding{}).
-					HasNoResource("user-rbac-edit", &authv1.RoleBinding{})
-				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{}, WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
-
-				// when - should promote the namespace
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // upgraded
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("user-edit", &authv1.RoleBinding{}).
-					HasResource("user-rbac-edit", &authv1.RoleBinding{})
-
-				// when - should check if everything is OK and set status to provisioned
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Provisioned())
-			})
-
-			t.Run("downgrade dev to basic tier", func(t *testing.T) {
-				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
-				// create namespace (and assume it is complete since it has the expected revision number)
-				devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
-				rb := newRoleBinding(devNS.Name, "user-edit")
-				rbacRb := newRoleBinding(devNS.Name, "user-rbac-edit")
-				ro := newRole(devNS.Name, "rbac-edit")
-				crq := newClusterResourceQuota(t, username, "advanced")
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, rb, rbacRb, ro, crq)
-
-				// when - should remove ClusterResourceQuota that is missing in basic tier
-				_, err := r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, fakeClient).
-					HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // no cluster resource quota in 'basic` tier
-
-				// when - should downgrade the namespace
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/tier", "basic"). // "downgraded"
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("user-edit", &authv1.RoleBinding{}).
-					HasNoResource("rbac-edit", &rbacv1.Role{}). // role does not exist
-					HasNoResource("user-rbac-edit", &authv1.RoleBinding{})
-
-				// when - should check if everything is OK and set status to provisioned
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Provisioned())
-				AssertThatCluster(t, fakeClient).
-					HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // no cluster resource quota in 'basic` tier
-			})
-		})
-
-		t.Run("with cluster resources", func(t *testing.T) {
-
-			t.Run("upgrade dev to advanced tier", func(t *testing.T) {
-				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
-				// create namespace (and assume it is complete since it has the expected revision number)
-				devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-				ro := newRole(devNS.Name, "rbac-edit")
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, ro)
-
-				err := fakeClient.Update(context.TODO(), nsTmplSet)
-				require.NoError(t, err)
-
-				// when - should create ClusterResourceQuota
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/tier", "advanced")) // upgraded
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/tier", "basic"). // not upgraded yet
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("rbac-edit", &rbacv1.Role{})
-
-				// when - should upgrade the namespace
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				// NSTemplateSet provisioning is complete
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/tier", "advanced").
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain")
-
-				// when - should check if everything is OK and set status to provisioned
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				// NSTemplateSet provisioning is complete
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Provisioned())
-				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // not updgraded yet
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("user-edit", &authv1.RoleBinding{}) // role has been removed
-			})
-
-			t.Run("downgrade dev to basic tier", func(t *testing.T) {
-				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
-				// create namespace (and assume it is complete since it has the expected revision number)
-				devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
-				rb := newRoleBinding(devNS.Name, "user-edit")
-				ro := newRole(devNS.Name, "rbac-edit")
-				crq := newClusterResourceQuota(t, username, "advanced")
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, rb, ro, crq)
-
-				// when - should remove ClusterResourceQuota
-				_, err := r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, fakeClient).
-					HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // removed
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // not "downgraded" yet
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("user-edit", &authv1.RoleBinding{}).
-					HasResource("rbac-edit", &rbacv1.Role{}) // role still exists
-
-				// when - should downgrade the namespace
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/tier", "basic"). // "downgraded"
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("user-edit", &authv1.RoleBinding{}).
-					HasNoResource("rbac-edit", &rbacv1.Role{}) // role does not exist
-
-				// when - should check if everything is OK and set status to provisioned
-				_, err = r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(Provisioned())
-				AssertThatCluster(t, fakeClient).
-					HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // removed
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/tier", "basic"). // "downgraded"
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasResource("user-edit", &authv1.RoleBinding{}).
-					HasNoResource("rbac-edit", &rbacv1.Role{}) // role does not exist
-
-			})
-		})
-	})
-
-	t.Run("failure", func(t *testing.T) {
-
-		t.Run("promotion to another tier fails because it cannot load current template", func(t *testing.T) {
+		t.Run("create ClusterResourceQuota", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
-			// create namespace but with an unknown tier
-			devNS := newNamespace("fail", username, "dev", withRevision("abcde11"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS)
+			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
+			// create namespace (and assume it is complete since it has the expected revision number)
+			devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+			codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
+			devRo := newRole(devNS.Name, "rbac-edit")
+			codeRo := newRole(codeNS.Name, "rbac-edit")
+			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS, devRo, codeRo)
 
-			// when
-			_, err := r.Reconcile(req)
+			err := fakeClient.Update(context.TODO(), nsTmplSet)
+			require.NoError(t, err)
+
+			// when - should create ClusterResourceQuota
+			_, err = r.Reconcile(req)
 
 			// then
-			require.Error(t, err)
+			require.NoError(t, err)
 			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 				HasFinalizer().
-				HasConditions(UpdateFailed("failed to retrieve template for tier/type 'fail/dev': failed to retrieve template for namespace"))
-			AssertThatNamespace(t, username+"-dev", r.client).
-				HasNoOwnerReference().
-				HasLabel("toolchain.dev.openshift.com/owner", username).
-				HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-				HasLabel("toolchain.dev.openshift.com/type", "dev").
-				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-				HasLabel("toolchain.dev.openshift.com/tier", "fail") // the unknown tier that caused the error
-		})
+				HasConditions(Updating())
+			AssertThatCluster(t, fakeClient).
+				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					WithLabel("toolchain.dev.openshift.com/tier", "advanced")) // upgraded
+			for _, nsType := range []string{"code", "dev"} {
+				AssertThatNamespace(t, username+"-"+nsType, r.client).
+					HasNoOwnerReference().
+					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+					HasLabel("toolchain.dev.openshift.com/owner", username).
+					HasLabel("toolchain.dev.openshift.com/tier", "basic"). // not upgraded yet
+					HasLabel("toolchain.dev.openshift.com/type", nsType).
+					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+					HasResource("rbac-edit", &rbacv1.Role{})
+			}
 
-	})
+			t.Run("delete redundant namespace", func(t *testing.T) {
 
-	t.Run("delete redundant objects", func(t *testing.T) {
+				// when - should delete the -code namespace
+				_, err := r.Reconcile(req)
 
-		t.Run("success", func(t *testing.T) {
+				// then
+				require.NoError(t, err)
+				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+					HasFinalizer().
+					HasConditions(Updating()) // still in progress
+				AssertThatNamespace(t, codeNS.Name, r.client).
+					DoesNotExist() // namespace was deleted
+				AssertThatNamespace(t, devNS.Name, r.client).
+					HasNoOwnerReference().
+					HasLabel("toolchain.dev.openshift.com/owner", username).
+					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+					HasLabel("toolchain.dev.openshift.com/type", "dev").
+					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+					HasLabel("toolchain.dev.openshift.com/tier", "basic") // not upgraded yet
 
-			t.Run("with cluster resources", func(t *testing.T) {
+				t.Run("upgrade the dev namespace", func(t *testing.T) {
 
-				t.Run("delete redundant namespace while upgrading tier", func(t *testing.T) {
-					// given 'advanced' NSTemplate only has a 'dev' namespace
-					nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
-					devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-					codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
-					crq := newClusterResourceQuota(t, username, "advanced")
-					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS, crq) // current user has also a 'code' NS
-
-					// when - should delete the -code namespace
-					_, err := r.Reconcile(req)
+					// when - should upgrade the namespace
+					_, err = r.Reconcile(req)
 
 					// then
 					require.NoError(t, err)
+					// NSTemplateSet provisioning is complete
 					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 						HasFinalizer().
-						HasConditions(Updating()) // still in progress
+						HasConditions(Updating())
+					AssertThatCluster(t, fakeClient).
+						HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+							WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 					AssertThatNamespace(t, codeNS.Name, r.client).
-						DoesNotExist() // namespace was deleted
-					AssertThatNamespace(t, devNS.Name, r.client).
+						DoesNotExist()
+					AssertThatNamespace(t, username+"-dev", r.client).
 						HasNoOwnerReference().
 						HasLabel("toolchain.dev.openshift.com/owner", username).
-						HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+						HasLabel("toolchain.dev.openshift.com/tier", "advanced").
 						HasLabel("toolchain.dev.openshift.com/type", "dev").
-						HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-						HasLabel("toolchain.dev.openshift.com/tier", "basic") // not upgraded yet
+						HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain")
 
-					// when - should upgrade the -dev namespace
-					_, err = r.Reconcile(req)
+					t.Run("when nothing to upgrade, then it should be provisioned", func(t *testing.T) {
 
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Updating()) // still in progress, dealing with NS inner resources
-					AssertThatNamespace(t, devNS.Name, r.client).
-						HasNoOwnerReference().
-						HasLabel("toolchain.dev.openshift.com/owner", username).
-						HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-						HasLabel("toolchain.dev.openshift.com/type", "dev").
-						HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // upgraded
-						HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-						HasResource("user-edit", &authv1.RoleBinding{}).
-						HasResource("rbac-edit", &rbacv1.Role{})
+						// when - should check if everything is OK and set status to provisioned
+						_, err = r.Reconcile(req)
 
-					// when - should check if everything is OK and set status to provisioned
-					_, err = r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Provisioned()) // done
-					AssertThatNamespace(t, devNS.Name, r.client).
-						HasNoOwnerReference().
-						HasLabel("toolchain.dev.openshift.com/owner", username).
-						HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-						HasLabel("toolchain.dev.openshift.com/type", "dev").
-						HasLabel("toolchain.dev.openshift.com/tier", "advanced") // upgraded
-				})
-
-				t.Run("delete redundant objects in namespace while updating tmpl", func(t *testing.T) {
-					// we need to compare the new template vs previous one, which we can't do for now.
-					// See https://issues.redhat.com/browse/CRT-498
-					t.Skip("can't do it now")
-				})
-
-			})
-
-			t.Run("with cluster resources", func(t *testing.T) {
-
-				t.Run("no redundant cluster resource to delete while upgrading tier", func(t *testing.T) {
-					// given same as above, but not upgrading tier and no cluster resource quota to delete
-					nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withClusterResources())
-					basicCRQ := newClusterResourceQuota(t, username, "basic")                               // resource has same name in both tiers
-					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, basicCRQ) // current bnasic NSTemplateSet also has a cluster resource quota
-					fakeClient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-						// because the fake client does not support such a type of list :(
-						if list, ok := list.(*unstructured.UnstructuredList); ok {
-							basicCRQObj, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(basicCRQ)
-							list.Items = []unstructured.Unstructured{
-								{
-									Object: basicCRQObj,
-								},
-							}
-							return nil
-						}
-						return fakeClient.Client.List(ctx, list, opts...)
-					}
-					// when
-					_, err := r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Provisioned()) // done in 1 loop
-					AssertThatCluster(t, r.client).
-						HasResource("for-"+username, &quotav1.ClusterResourceQuota{}, WithLabel("toolchain.dev.openshift.com/tier", "advanced")) // upgraded
-				})
-
-				t.Run("no redundant cluster resource quota to be deleted for the given user", func(t *testing.T) {
-					// given 'advanced' NSTemplate only has a cluster resource
-					nsTmplSet := newNSTmplSet(namespaceName, username, "advanced") // no cluster resources, so the "advancedCRQ" should be deleted
-					anotherNsTmplSet := newNSTmplSet(namespaceName, "another-user", "basic")
-					advancedCRQ := newClusterResourceQuota(t, username, "advanced")
-					anotherCRQ := newClusterResourceQuota(t, "another-user", "basic")
-					r, req, fakeClient := prepareReconcile(t, namespaceName, username, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ)
-
-					// when
-					_, err := r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Provisioned()) // done
-				})
-
-				t.Run("delete redundant cluster resource quota while downgrading tier", func(t *testing.T) {
-					// given 'advanced' NSTemplate only has a cluster resource
-					nsTmplSet := newNSTmplSet(namespaceName, username, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
-					advancedCRQ := newClusterResourceQuota(t, username, "advanced")
-					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, advancedCRQ)
-
-					// when
-					_, err := r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Updating()) //
-					AssertThatCluster(t, r.client).
-						HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // resource was deleted
-
-					// when reconcile again
-					_, err = r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Provisioned()) // done
-				})
-
-				t.Run("delete redundant cluster resources when ClusterResources field is nil in NSTemplateSet", func(t *testing.T) {
-					// given 'advanced' NSTemplate only has a cluster resource
-					nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq") // no cluster resources, so the "advancedCRQ" should be deleted even if the tier contains the "advancedCRQ"
-					advancedCRQ := newClusterResourceQuota(t, username, "advanced")
-					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, advancedCRQ)
-
-					// when
-					_, err := r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Updating()) //
-					AssertThatCluster(t, r.client).
-						HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // resource was deleted
-
-					// when reconcile again
-					_, err = r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Provisioned()) // done
-				})
-
-				t.Run("delete only one redundant cluster resource during single reconcile", func(t *testing.T) {
-					// given 'advanced' NSTemplate only has a cluster resource
-					nsTmplSet := newNSTmplSet(namespaceName, username, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
-					advancedCRQ := newClusterResourceQuota(t, username, "withemptycrq")
-					anotherCRQ := newClusterResourceQuota(t, username, "withemptycrq")
-					anotherCRQ.Name = "for-empty"
-					r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, advancedCRQ, anotherCRQ)
-
-					// when - should delete the first ClusterResourceQuota
-					_, err := r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-						HasFinalizer().
-						HasConditions(Updating()) //
-					quotas := &quotav1.ClusterResourceQuotaList{}
-					err = fakeClient.List(context.TODO(), quotas, &client.ListOptions{})
-					require.NoError(t, err)
-					assert.Len(t, quotas.Items, 1)
-
-					// when - should delete the second ClusterResourceQuota
-					_, err = r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					err = fakeClient.List(context.TODO(), quotas, &client.ListOptions{})
-					require.NoError(t, err)
-					assert.Len(t, quotas.Items, 0)
-				})
-
-				t.Run("delete redundant cluster resource quota while updating tmpl", func(t *testing.T) {
-					// we need to compare the new template vs previous one, which we can't do for now.
-					// See https://issues.redhat.com/browse/CRT-498
-					t.Skip("can't do it now")
+						// then
+						require.NoError(t, err)
+						// NSTemplateSet provisioning is complete
+						AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+							HasFinalizer().
+							HasConditions(Provisioned())
+						AssertThatCluster(t, fakeClient).
+							HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+								WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
+						AssertThatNamespace(t, username+"-dev", r.client).
+							HasNoOwnerReference().
+							HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
+							HasLabel("toolchain.dev.openshift.com/owner", username).
+							HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // not updgraded yet
+							HasLabel("toolchain.dev.openshift.com/type", "dev").
+							HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
+							HasResource("user-edit", &authv1.RoleBinding{}) // role has been removed
+					})
 				})
 			})
-
-		})
-
-		t.Run("failure", func(t *testing.T) {
-
-			t.Run("fail to delete redundant namespace while upgrading tier", func(t *testing.T) {
-				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
-				devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-				codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
-				fakeClient.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
-					return fmt.Errorf("mock error: '%T'", obj)
-				}
-
-				// when reconciling for the cluster resources
-				_, err := r.Reconcile(req)
-
-				// then
-				require.NoError(t, err) // runs fine as there's nothing to delete
-
-				// when reconciling for the namespaces
-				_, err = r.Reconcile(req)
-
-				// then
-				require.Error(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(UpdateFailed("mock error: '*v1.Namespace'")) // failed to delete NS
-				AssertThatNamespace(t, username+"-code", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/type", "code").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasLabel("toolchain.dev.openshift.com/tier", "basic") // unchanged, namespace was not deleted
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasLabel("toolchain.dev.openshift.com/tier", "basic") // not upgraded
-			})
-
-			t.Run("fail to delete redundant objects in namespace while updating tmpl", func(t *testing.T) {
-				// we need to compare the new template vs previous one, which we can't do for now.
-				// See https://issues.redhat.com/browse/CRT-498
-				t.Skip("can't do it now")
-			})
-
-			t.Run("fail to delete redundant cluster resource quota while downgrading tier", func(t *testing.T) {
-				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
-				// create namespace (and assume it is complete since it has the expected revision number)
-				devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
-				crq := newClusterResourceQuota(t, username, "advanced")
-				rb := newRoleBinding(devNS.Name, "user-edit")
-				ro := newRole(devNS.Name, "rbac-edit")
-				r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, crq, rb, ro)
-				fakeClient.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
-					return fmt.Errorf("mock error: '%T'", obj)
-				}
-
-				// when
-				_, err := r.Reconcile(req)
-
-				// then
-				require.Error(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-					HasFinalizer().
-					HasConditions(UpdateFailed("failed to delete object 'for-johnsmith' of kind 'ClusterResourceQuota' in namespace '': mock error: '*unstructured.Unstructured'")) // the template objects are of type `*unstructured.Unstructured`
-				AssertThatNamespace(t, username+"-dev", r.client).
-					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
-					HasLabel("toolchain.dev.openshift.com/revision", "abcde11").
-					HasLabel("toolchain.dev.openshift.com/type", "dev").
-					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-					HasLabel("toolchain.dev.openshift.com/tier", "advanced") // unchanged
-			})
-
-			t.Run("fail to delete redundant cluster resource quota while updating tmpl", func(t *testing.T) {
-				// we need to compare the new template vs previous one, which we can't do for now.
-				// See https://issues.redhat.com/browse/CRT-498
-				t.Skip("can't do it now")
-			})
-
 		})
 	})
 }
@@ -1143,92 +299,6 @@ func TestReconcileProvisionFail(t *testing.T) {
 	// given
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
-
-	t.Run("fail to create namespace", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
-		fakeClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
-			return errors.New("unable to create namespace")
-		}
-
-		// when
-		res, err := r.Reconcile(req)
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unable to create namespace")
-		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(UnableToProvisionNamespace("unable to create resource of kind: Namespace, version: v1: unable to create resource of kind: Namespace, version: v1: unable to create namespace"))
-		AssertThatNamespace(t, username+"-dev", r.client).DoesNotExist()
-		AssertThatNamespace(t, username+"-code", r.client).DoesNotExist()
-	})
-
-	t.Run("fail to create inner resources", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-		devNS := newNamespace("basic", username, "dev") // NS exists but is missing its inner resources (since its revision is not set yet)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS)
-		fakeClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
-			return errors.New("unable to create some object")
-		}
-
-		// when
-		res, err := r.Reconcile(req)
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unable to create some object")
-		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(UnableToProvisionNamespace("unable to create resource of kind: RoleBinding, version: v1: unable to create resource of kind: RoleBinding, version: v1: unable to create some object"))
-		AssertThatNamespace(t, username+"-dev", r.client).
-			HasNoResource("user-edit", &authv1.RoleBinding{})
-	})
-
-	t.Run("fail to update status when ensuring inner resources", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
-		devNS := newNamespace("advanced", username, "dev") // NS exists but is missing the resources
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS)
-		fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
-			return errors.New("unable to update NSTmplSet")
-		}
-
-		// when
-		res, err := r.Reconcile(req)
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unable to update NSTmplSet")
-		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions() // no condition was set (none was set during the init)
-	})
-
-	t.Run("fail to cluster resources", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
-		fakeClient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			return errors.New("unable to list cluster resources")
-		}
-
-		// when
-		res, err := r.Reconcile(req)
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unable to list cluster resources")
-		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(UnableToProvisionClusterResources("unable to list cluster resources"))
-	})
 
 	t.Run("fail to get nstmplset", func(t *testing.T) {
 		// given
@@ -1266,41 +336,6 @@ func TestReconcileProvisionFail(t *testing.T) {
 			HasNoConditions() // since we're unable to update the status
 	})
 
-	t.Run("fail to get template for namespace", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("fail"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
-
-		// when
-		res, err := r.Reconcile(req)
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to retrieve template for namespace")
-		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(UnableToProvisionNamespace("failed to retrieve template for namespace"))
-	})
-
-	t.Run("fail to get template for inner resources", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("fail"))
-		failNS := newNamespace("basic", username, "fail") // NS exists but with an unknown type
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, failNS)
-
-		// when
-		res, err := r.Reconcile(req)
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to retrieve template for namespace")
-		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(UnableToProvisionNamespace("failed to retrieve template for namespace"))
-	})
-
 	t.Run("no namespace", func(t *testing.T) {
 		// given
 		r, _ := prepareController(t)
@@ -1316,274 +351,9 @@ func TestReconcileProvisionFail(t *testing.T) {
 	})
 }
 
-func TestUpdateStatus(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	s := scheme.Scheme
-	err := apis.AddToScheme(s)
-	require.NoError(t, err)
-	// given
-	username := "johnsmith"
-	namespaceName := "toolchain-member"
-
-	t.Run("status updated", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-		reconciler, fakeClient := prepareController(t, nsTmplSet)
-		condition := toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.ConditionReady,
-			Status: corev1.ConditionTrue,
-		}
-
-		// when
-		err := reconciler.updateStatusConditions(nsTmplSet, condition)
-
-		// then
-		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(condition)
-	})
-
-	t.Run("status not updated because not changed", func(t *testing.T) {
-		// given
-		conditions := []toolchainv1alpha1.Condition{{
-			Type:   toolchainv1alpha1.ConditionReady,
-			Status: corev1.ConditionFalse,
-		}}
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(conditions...))
-		reconciler, fakeClient := prepareController(t, nsTmplSet)
-
-		// when
-		err := reconciler.updateStatusConditions(nsTmplSet, conditions...)
-
-		// then
-		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(conditions...)
-	})
-
-	t.Run("status error wrapped", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
-		reconciler, _ := prepareController(t, nsTmplSet)
-		log := logf.Log.WithName("test")
-
-		t.Run("status_updated", func(t *testing.T) {
-			// given
-			statusUpdater := func(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
-				assert.Equal(t, "oopsy woopsy", message)
-				return nil
-			}
-
-			// when
-			err := reconciler.wrapErrorWithStatusUpdate(log, nsTmplSet, statusUpdater, apierros.NewBadRequest("oopsy woopsy"), "failed to create namespace")
-
-			// then
-			require.Error(t, err)
-			assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
-		})
-
-		t.Run("status update failed", func(t *testing.T) {
-			// given
-			statusUpdater := func(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
-				return errors.New("unable to update status")
-			}
-
-			// when
-			err := reconciler.wrapErrorWithStatusUpdate(log, nsTmplSet, statusUpdater, apierros.NewBadRequest("oopsy woopsy"), "failed to create namespace")
-
-			// then
-			require.Error(t, err)
-			assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
-		})
-	})
-
-	t.Run("status update failures", func(t *testing.T) {
-
-		t.Run("failed to update status during deletion", func(t *testing.T) {
-			// given an NSTemplateSet resource which is being deleted and whose finalizer was not removed yet
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withDeletionTs(), withClusterResources(), withNamespaces("dev", "code"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
-			fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
-				return fmt.Errorf("status update mock error")
-			}
-			// when a reconcile loop is triggered
-			_, err := r.Reconcile(req)
-
-			// then
-			require.Error(t, err)
-			assert.Equal(t, "failed to set status to 'ready=false/reason=terminating' on NSTemplateSet: status update mock error", err.Error())
-			AssertThatNSTemplateSet(t, namespaceName, username, r.client).
-				HasFinalizer(). // finalizer was not added and nothing else was done
-				HasConditions() // no condition was set to status update error
-		})
-	})
-
-	t.Run("don't set to provisioning if is set to updating", func(t *testing.T) {
-		// given
-		conditions := []toolchainv1alpha1.Condition{{
-			Type:   toolchainv1alpha1.ConditionReady,
-			Status: corev1.ConditionFalse,
-			Reason: toolchainv1alpha1.NSTemplateSetUpdatingReason,
-		}}
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(conditions...))
-		reconciler, fakeClient := prepareController(t, nsTmplSet)
-
-		// when
-		err := reconciler.setStatusProvisioningIfNotUpdating(nsTmplSet)
-
-		// then
-		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(conditions...)
-	})
-
-	t.Run("don't set to updating if is set to provisioning", func(t *testing.T) {
-		// given
-		conditions := []toolchainv1alpha1.Condition{{
-			Type:   toolchainv1alpha1.ConditionReady,
-			Status: corev1.ConditionFalse,
-			Reason: toolchainv1alpha1.NSTemplateSetProvisioningReason,
-		}}
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(conditions...))
-		reconciler, fakeClient := prepareController(t, nsTmplSet)
-
-		// when
-		err := reconciler.setStatusUpdatingIfNotProvisioning(nsTmplSet)
-
-		// then
-		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(conditions...)
-	})
-}
-func TestUpdateStatusToProvisionedWhenPreviouslyWasSetToFailed(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	s := scheme.Scheme
-	err := apis.AddToScheme(s)
-	require.NoError(t, err)
-	failed := toolchainv1alpha1.Condition{
-		Type:    toolchainv1alpha1.ConditionReady,
-		Status:  corev1.ConditionFalse,
-		Reason:  toolchainv1alpha1.NSTemplateSetUnableToProvisionNamespaceReason,
-		Message: "Operation cannot be fulfilled on namespaces bla bla bla",
-	}
-	username := "johnsmith"
-	namespaceName := "toolchain-member"
-
-	t.Run("when status is set to false with message, then next update to true should remove the message", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(failed))
-		reconciler, fakeClient := prepareController(t, nsTmplSet)
-
-		// when
-		err := reconciler.setStatusReady(nsTmplSet)
-
-		// then
-		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(Provisioned())
-	})
-
-	t.Run("when status is set to false with message, then next successful reconcile should update it to true and remove the message", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(failed))
-		devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-		codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
-
-		// when
-		_, err := r.Reconcile(req)
-
-		// then
-		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
-			HasFinalizer().
-			HasConditions(Provisioned())
-	})
-}
-
 func TestDeleteNSTemplateSet(t *testing.T) {
-
-	logf.SetLogger(logf.ZapLogger(true))
-	s := scheme.Scheme
-	err := apis.AddToScheme(s)
-	require.NoError(t, err)
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
-
-	t.Run("with 2 user namespaces to delete", func(t *testing.T) {
-		// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withDeletionTs())
-		devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-		codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
-		r, c := prepareController(t, nsTmplSet, devNS, codeNS)
-		c.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
-			if obj, ok := obj.(*corev1.Namespace); ok {
-				// mark namespaces as deleted...
-				deletionTS := metav1.NewTime(time.Now())
-				obj.SetDeletionTimestamp(&deletionTS)
-				// ... but replace them in the fake client cache yet instead of deleting them
-				return c.Client.Update(ctx, obj)
-			}
-			return c.Client.Delete(ctx, obj, opts...)
-		}
-
-		t.Run("reconcile after nstemplateset deletion", func(t *testing.T) {
-			// given
-			req := newReconcileRequest(namespaceName, username)
-
-			// when a first reconcile loop is triggered (when the NSTemplateSet resource is marked for deletion and there's a finalizer)
-			_, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-			// get the first namespace and check its deletion timestamp
-			firstNSName := fmt.Sprintf("%s-%s", username, nsTmplSet.Spec.Namespaces[0].Type)
-			AssertThatNamespace(t, firstNSName, r.client).HasDeletionTimestamp()
-			// get the NSTemplateSet resource again and check its status
-			AssertThatNSTemplateSet(t, namespaceName, username, r.client).
-				HasFinalizer(). // the finalizer should NOT have been removed yet
-				HasConditions(Terminating())
-
-			t.Run("reconcile after first user namespace deletion", func(t *testing.T) {
-				// given
-				req := newReconcileRequest(namespaceName, username)
-
-				// when a second reconcile loop was triggered (because a user namespace was deleted)
-				_, err := r.Reconcile(req)
-
-				// then
-				require.NoError(t, err)
-				// get the second namespace and check its deletion timestamp
-				secondtNSName := fmt.Sprintf("%s-%s", username, nsTmplSet.Spec.Namespaces[1].Type)
-				AssertThatNamespace(t, secondtNSName, r.client).HasDeletionTimestamp()
-				// get the NSTemplateSet resource again and check its finalizers and status
-				AssertThatNSTemplateSet(t, namespaceName, username, r.client).
-					HasFinalizer(). // the finalizer should not have been removed either
-					HasConditions(Terminating())
-
-				t.Run("reconcile after second user namespace deletion", func(t *testing.T) {
-					// given
-					req := newReconcileRequest(namespaceName, username)
-
-					// when
-					_, err := r.Reconcile(req)
-
-					// then
-					require.NoError(t, err)
-					// get the NSTemplateSet resource again and check its finalizers and status
-					AssertThatNSTemplateSet(t, namespaceName, username, r.client).
-						DoesNotHaveFinalizer(). // the finalizer should have been removed now
-						HasConditions(Terminating())
-				})
-			})
-		})
-	})
 
 	t.Run("with cluster resources and 2 user namespaces to delete", func(t *testing.T) {
 		// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
@@ -1593,7 +363,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		codeNS := newNamespace("advanced", username, "code", withRevision("abcde11"))
 		r, _ := prepareController(t, nsTmplSet, crq, devNS, codeNS)
 
-		t.Run("reconcile after nstemplateset deletion", func(t *testing.T) {
+		t.Run("reconcile after nstemplateset deletion triggers deletion of the first namespace", func(t *testing.T) {
 			// given
 			req := newReconcileRequest(namespaceName, username)
 
@@ -1610,7 +380,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 				HasFinalizer(). // the finalizer should NOT have been removed yet
 				HasConditions(Terminating())
 
-			t.Run("reconcile after first user namespace deletion", func(t *testing.T) {
+			t.Run("reconcile after first user namespace deletion triggers deletion of the second namespace", func(t *testing.T) {
 				// given
 				req := newReconcileRequest(namespaceName, username)
 
@@ -1627,7 +397,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 					HasFinalizer(). // the finalizer should not have been removed either
 					HasConditions(Terminating())
 
-				t.Run("reconcile after second user namespace deletion", func(t *testing.T) {
+				t.Run("reconcile after second user namespace deletion triggers deletion of CRQ", func(t *testing.T) {
 					// given a third reconcile loop was triggered (because a user namespace was deleted)
 					req := newReconcileRequest(namespaceName, username)
 
@@ -1642,7 +412,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 					AssertThatCluster(t, r.client).
 						HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // resource was deleted
 
-					t.Run("reconcile after cluster resource quota deletion", func(t *testing.T) {
+					t.Run("reconcile after cluster resource quota deletion triggers removal of the finalizer", func(t *testing.T) {
 						// given
 						req := newReconcileRequest(namespaceName, username)
 
@@ -1655,43 +425,25 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 						AssertThatNSTemplateSet(t, namespaceName, username, r.client).
 							DoesNotHaveFinalizer(). // the finalizer should have been removed now
 							HasConditions(Terminating())
-						AssertThatCluster(t, r.client).HasNoResource(username, &quotav1.ClusterResourceQuota{})
+						AssertThatCluster(t, r.client).HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{})
+
+						t.Run("final reconcile after successful deletion", func(t *testing.T) {
+							// given
+							req := newReconcileRequest(namespaceName, username)
+
+							// when
+							_, err := r.Reconcile(req)
+
+							// then
+							require.NoError(t, err)
+							// get the NSTemplateSet resource again and check its finalizers and status
+							AssertThatNSTemplateSet(t, namespaceName, username, r.client).
+								DoesNotHaveFinalizer(). // the finalizer should have been removed now
+								HasConditions(Terminating())
+						})
 					})
 				})
 			})
-		})
-	})
-
-	t.Run("without any user namespace to delete", func(t *testing.T) {
-		// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withDeletionTs())
-		r, req, c := prepareReconcile(t, namespaceName, username, nsTmplSet)
-		c.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
-			if obj, ok := obj.(*corev1.Namespace); ok {
-				// mark namespaces as deleted...
-				deletionTS := metav1.NewTime(time.Now())
-				obj.SetDeletionTimestamp(&deletionTS)
-				// ... but replace them in the fake client cache yet instead of deleting them
-				return c.Client.Update(ctx, obj)
-			}
-			return c.Client.Delete(ctx, obj, opts...)
-		}
-		t.Run("reconcile after nstemplateset deletion", func(t *testing.T) {
-			// when a first reconcile loop is triggered (when the NSTemplateSet resource is marked for deletion and there's a finalizer)
-			_, err := r.Reconcile(req)
-
-			// then
-			require.NoError(t, err)
-
-			// get the NSTemplateSet resource again and check its finalizers
-			updateNSTemplateSet := toolchainv1alpha1.NSTemplateSet{}
-			err = r.client.Get(context.TODO(), types.NamespacedName{
-				Namespace: nsTmplSet.Namespace,
-				Name:      nsTmplSet.Name,
-			}, &updateNSTemplateSet)
-			// then
-			require.NoError(t, err)
-			assert.Empty(t, updateNSTemplateSet.Finalizers)
 		})
 	})
 
@@ -1708,32 +460,6 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		AssertThatNSTemplateSet(t, namespaceName, username, r.client).
 			DoesNotHaveFinalizer() // finalizer was not added and nothing else was done
 	})
-
-	t.Run("failures", func(t *testing.T) {
-
-		t.Run("failed to fetch namespaces", func(t *testing.T) {
-			// given an NSTemplateSet resource which is being deleted and whose finalizer was not removed yet
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withDeletionTs(), withNamespaces("dev", "code"))
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
-			fakeClient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-				if _, ok := list.(*corev1.NamespaceList); ok {
-					return fmt.Errorf("mock error")
-				}
-				return fakeClient.Client.List(ctx, list, opts...)
-			}
-
-			// when a reconcile loop is triggered
-			_, err := r.Reconcile(req)
-
-			// then
-			require.Error(t, err)
-			assert.Equal(t, "failed to list namespace with label owner 'johnsmith': mock error", err.Error())
-			AssertThatNSTemplateSet(t, namespaceName, username, r.client).
-				HasFinalizer(). // finalizer was not added and nothing else was done
-				HasConditions(UnableToTerminate("mock error"))
-		})
-
-	})
 }
 
 func prepareReconcile(t *testing.T, namespaceName, name string, initObjs ...runtime.Object) (*NSTemplateSetReconciler, reconcile.Request, *test.FakeClient) {
@@ -1741,18 +467,13 @@ func prepareReconcile(t *testing.T, namespaceName, name string, initObjs ...runt
 	return r, newReconcileRequest(namespaceName, name), fakeClient
 }
 
-func prepareController(t *testing.T, initObjs ...runtime.Object) (*NSTemplateSetReconciler, *test.FakeClient) {
+func prepareApiClient(t *testing.T, initObjs ...runtime.Object) (*apiClient, *test.FakeClient) {
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
 	codecFactory := serializer.NewCodecFactory(s)
 	decoder := codecFactory.UniversalDeserializer()
 	fakeClient := test.NewFakeClient(t, initObjs...)
-	r := &NSTemplateSetReconciler{
-		client:             fakeClient,
-		scheme:             s,
-		getTemplateContent: getTemplateContent(decoder),
-	}
 
 	// objects created from OpenShift templates are `*unstructured.Unstructured`,
 	// which causes troubles when calling the `List` method on the fake client,
@@ -1777,8 +498,37 @@ func prepareController(t *testing.T, initObjs ...runtime.Object) (*NSTemplateSet
 		}
 		return passGeneration(o, obj)
 	}
+	return &apiClient{
+		client:          fakeClient,
+		scheme:          s,
+		templateContent: newTemplateContentProvider(getTemplateContent(decoder)),
+	}, fakeClient
+}
 
-	return r, fakeClient
+func prepareStatusManager(t *testing.T, initObjs ...runtime.Object) (*statusManager, *test.FakeClient) {
+	apiClient, fakeClient := prepareApiClient(t, initObjs...)
+	return &statusManager{
+		apiClient: apiClient,
+	}, fakeClient
+}
+
+func prepareNamespacesManager(t *testing.T, initObjs ...runtime.Object) (*namespacesManager, *test.FakeClient) {
+	statusManager, fakeClient := prepareStatusManager(t, initObjs...)
+	return &namespacesManager{
+		statusManager: statusManager,
+	}, fakeClient
+}
+
+func prepareClusterResourcesManager(t *testing.T, initObjs ...runtime.Object) (*clusterResourcesManager, *test.FakeClient) {
+	statusManager, fakeClient := prepareStatusManager(t, initObjs...)
+	return &clusterResourcesManager{
+		statusManager: statusManager,
+	}, fakeClient
+}
+
+func prepareController(t *testing.T, initObjs ...runtime.Object) (*NSTemplateSetReconciler, *test.FakeClient) {
+	apiClient, fakeClient := prepareApiClient(t, initObjs...)
+	return newReconciler(apiClient), fakeClient
 }
 
 func passGeneration(from, to runtime.Object) error {
@@ -1959,7 +709,7 @@ func newClusterResourceQuota(t *testing.T, username, tier string) *quotav1.Clust
 func getTemplateContent(decoder runtime.Decoder) func(tierName, typeName string) (*templatev1.Template, error) {
 	return func(tierName, typeName string) (*templatev1.Template, error) {
 		if typeName == "fail" || tierName == "fail" {
-			return nil, fmt.Errorf("failed to retrieve template for namespace")
+			return nil, fmt.Errorf("failed to retrieve template")
 		}
 		var tmplContent string
 		switch tierName {
@@ -1976,6 +726,13 @@ func getTemplateContent(decoder runtime.Decoder) func(tierName, typeName string)
 				return nil, nil
 			default:
 				tmplContent = test.CreateTemplate(test.WithObjects(ns, rb), test.WithParams(username))
+			}
+		case "team": // assume that this tier has a "cluster resources" template
+			switch typeName {
+			case ClusterResources:
+				tmplContent = test.CreateTemplate(test.WithObjects(teamCrq), test.WithParams(username))
+			default:
+				tmplContent = test.CreateTemplate(test.WithObjects(ns, rb, role, rbacRb), test.WithParams(username))
 			}
 		case "withemptycrq":
 			switch typeName {
@@ -2062,6 +819,21 @@ var (
       hard:
         limits.cpu: 2000m
         limits.memory: 10Gi
+    selector:
+      annotations:
+        openshift.io/requester: ${USERNAME}
+    labels: null
+  `
+	teamCrq test.TemplateObject = `
+- apiVersion: quota.openshift.io/v1
+  kind: ClusterResourceQuota
+  metadata:
+    name: for-${USERNAME}
+  spec:
+    quota:
+      hard:
+        limits.cpu: 4000m
+        limits.memory: 15Gi
     selector:
       annotations:
         openshift.io/requester: ${USERNAME}

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -119,7 +119,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 	t.Run("status provisioned with cluster resources", func(t *testing.T) {
 		// given
 		// create cluster resource quotas
-		crq := newClusterResourceQuota(t, username, "advanced")
+		crq := newClusterResourceQuota(username, "advanced")
 		// create namespaces (and assume they are complete since they have the expected revision number)
 		devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
 		codeNS := newNamespace("advanced", username, "code", withRevision("abcde11"))
@@ -230,9 +230,9 @@ func TestReconcileUpdate(t *testing.T) {
 				require.NoError(t, err)
 				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 					HasFinalizer().
-					HasConditions(Updating()) // still in progress
+					HasConditions(Updating())                             // still in progress
 				AssertThatNamespace(t, codeNS.Name, r.client).
-					DoesNotExist() // namespace was deleted
+					DoesNotExist()                                        // namespace was deleted
 				AssertThatNamespace(t, devNS.Name, r.client).
 					HasNoOwnerReference().
 					HasLabel("toolchain.dev.openshift.com/owner", username).
@@ -358,7 +358,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 	t.Run("with cluster resources and 2 user namespaces to delete", func(t *testing.T) {
 		// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
 		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withDeletionTs(), withClusterResources())
-		crq := newClusterResourceQuota(t, username, "advanced")
+		crq := newClusterResourceQuota(username, "advanced")
 		devNS := newNamespace("advanced", username, "dev", withRevision("abcde11"))
 		codeNS := newNamespace("advanced", username, "code", withRevision("abcde11"))
 		r, _ := prepareController(t, nsTmplSet, crq, devNS, codeNS)
@@ -678,7 +678,7 @@ func newRole(namespace, name string) *rbacv1.Role { //nolint: unparam
 	}
 }
 
-func newClusterResourceQuota(t *testing.T, username, tier string) *quotav1.ClusterResourceQuota {
+func newClusterResourceQuota(username, tier string) *quotav1.ClusterResourceQuota {
 	return &quotav1.ClusterResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{

--- a/pkg/controller/nstemplateset/status.go
+++ b/pkg/controller/nstemplateset/status.go
@@ -1,0 +1,141 @@
+package nstemplateset
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/go-logr/logr"
+	errs "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type statusManager struct {
+	*apiClient
+}
+
+// error handling methods
+type statusUpdater func(*toolchainv1alpha1.NSTemplateSet, string) error
+
+func (r *statusManager) wrapErrorWithStatusUpdate(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, updateStatus statusUpdater, err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	if err := updateStatus(nsTmplSet, err.Error()); err != nil {
+		logger.Error(err, "status update failed")
+	}
+	return errs.Wrapf(err, format, args...)
+}
+
+func (r *statusManager) updateStatusConditions(nsTmplSet *toolchainv1alpha1.NSTemplateSet, newConditions ...toolchainv1alpha1.Condition) error {
+	var updated bool
+	nsTmplSet.Status.Conditions, updated = condition.AddOrUpdateStatusConditions(nsTmplSet.Status.Conditions, newConditions...)
+	if !updated {
+		// Nothing changed
+		return nil
+	}
+	return r.client.Status().Update(context.TODO(), nsTmplSet)
+}
+
+func (r *statusManager) setStatusReady(nsTmplSet *toolchainv1alpha1.NSTemplateSet) error {
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionTrue,
+			Reason: toolchainv1alpha1.NSTemplateSetProvisionedReason,
+		})
+}
+
+func (r *statusManager) setStatusProvisioningIfNotUpdating(nsTmplSet *toolchainv1alpha1.NSTemplateSet) error {
+	readyCondition, found := condition.FindConditionByType(nsTmplSet.Status.Conditions, toolchainv1alpha1.ConditionReady)
+	if found && readyCondition.Reason == toolchainv1alpha1.NSTemplateSetUpdatingReason {
+		return nil
+	}
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionFalse,
+			Reason: toolchainv1alpha1.NSTemplateSetProvisioningReason,
+		})
+}
+
+func (r *statusManager) setStatusProvisionFailed(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.NSTemplateSetUnableToProvisionReason,
+			Message: message,
+		})
+}
+
+func (r *statusManager) setStatusNamespaceProvisionFailed(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.NSTemplateSetUnableToProvisionNamespaceReason,
+			Message: message,
+		})
+}
+
+func (r *statusManager) setStatusClusterResourcesProvisionFailed(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.NSTemplateSetUnableToProvisionClusterResourcesReason,
+			Message: message,
+		})
+}
+
+func (r *statusManager) setStatusTerminating(nsTmplSet *toolchainv1alpha1.NSTemplateSet) error {
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionFalse,
+			Reason: toolchainv1alpha1.NSTemplateSetTerminatingReason,
+		})
+}
+
+func (r *statusManager) setStatusUpdatingIfNotProvisioning(nsTmplSet *toolchainv1alpha1.NSTemplateSet) error {
+	readyCondition, found := condition.FindConditionByType(nsTmplSet.Status.Conditions, toolchainv1alpha1.ConditionReady)
+	if found && readyCondition.Reason == toolchainv1alpha1.NSTemplateSetProvisioningReason {
+		return nil
+	}
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionFalse,
+			Reason: toolchainv1alpha1.NSTemplateSetUpdatingReason,
+		})
+}
+
+func (r *statusManager) setStatusUpdateFailed(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.NSTemplateSetUpdateFailedReason,
+			Message: message,
+		})
+}
+
+func (r *statusManager) setStatusTerminatingFailed(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
+	return r.updateStatusConditions(
+		nsTmplSet,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.NSTemplateSetTerminatingFailedReason,
+			Message: message,
+		})
+}

--- a/pkg/controller/nstemplateset/status_test.go
+++ b/pkg/controller/nstemplateset/status_test.go
@@ -1,0 +1,211 @@
+package nstemplateset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	. "github.com/codeready-toolchain/member-operator/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierros "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestUpdateStatus(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	// given
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+
+	t.Run("status updated", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
+		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
+		condition := toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionTrue,
+		}
+
+		// when
+		err := statusManager.updateStatusConditions(nsTmplSet, condition)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(condition)
+	})
+
+	t.Run("status not updated because not changed", func(t *testing.T) {
+		// given
+		conditions := []toolchainv1alpha1.Condition{{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionFalse,
+		}}
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(conditions...))
+		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
+
+		// when
+		err := statusManager.updateStatusConditions(nsTmplSet, conditions...)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(conditions...)
+	})
+
+	t.Run("status error wrapped", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
+		statusManager, _ := prepareStatusManager(t, nsTmplSet)
+		log := logf.Log.WithName("test")
+
+		t.Run("status_updated", func(t *testing.T) {
+			// given
+			statusUpdater := func(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
+				assert.Equal(t, "oopsy woopsy", message)
+				return nil
+			}
+
+			// when
+			err := statusManager.wrapErrorWithStatusUpdate(log, nsTmplSet, statusUpdater, apierros.NewBadRequest("oopsy woopsy"), "failed to create namespace")
+
+			// then
+			require.Error(t, err)
+			assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
+		})
+
+		t.Run("status update failed", func(t *testing.T) {
+			// given
+			statusUpdater := func(nsTmplSet *toolchainv1alpha1.NSTemplateSet, message string) error {
+				return errors.New("unable to update status")
+			}
+
+			// when
+			err := statusManager.wrapErrorWithStatusUpdate(log, nsTmplSet, statusUpdater, apierros.NewBadRequest("oopsy woopsy"), "failed to create namespace")
+
+			// then
+			require.Error(t, err)
+			assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
+		})
+	})
+
+	t.Run("status update failures", func(t *testing.T) {
+
+		t.Run("failed to update status during deletion", func(t *testing.T) {
+			// given an NSTemplateSet resource which is being deleted and whose finalizer was not removed yet
+			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withDeletionTs(), withClusterResources(), withNamespaces("dev", "code"))
+			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+			fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+				return fmt.Errorf("status update mock error")
+			}
+			// when a reconcile loop is triggered
+			_, err := r.Reconcile(req)
+
+			// then
+			require.Error(t, err)
+			assert.Equal(t, "failed to set status to 'ready=false/reason=terminating' on NSTemplateSet: status update mock error", err.Error())
+			AssertThatNSTemplateSet(t, namespaceName, username, r.client).
+				HasFinalizer(). // finalizer was not added and nothing else was done
+				HasConditions() // no condition was set to status update error
+		})
+	})
+
+	t.Run("don't set to provisioning if is set to updating", func(t *testing.T) {
+		// given
+		conditions := []toolchainv1alpha1.Condition{{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionFalse,
+			Reason: toolchainv1alpha1.NSTemplateSetUpdatingReason,
+		}}
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(conditions...))
+		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
+
+		// when
+		err := statusManager.setStatusProvisioningIfNotUpdating(nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(conditions...)
+	})
+
+	t.Run("don't set to updating if is set to provisioning", func(t *testing.T) {
+		// given
+		conditions := []toolchainv1alpha1.Condition{{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionFalse,
+			Reason: toolchainv1alpha1.NSTemplateSetProvisioningReason,
+		}}
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(conditions...))
+		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
+
+		// when
+		err := statusManager.setStatusUpdatingIfNotProvisioning(nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(conditions...)
+	})
+}
+func TestUpdateStatusToProvisionedWhenPreviouslyWasSetToFailed(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	failed := toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.NSTemplateSetUnableToProvisionNamespaceReason,
+		Message: "Operation cannot be fulfilled on namespaces bla bla bla",
+	}
+	username := "johnsmith"
+	namespaceName := "toolchain-member"
+
+	t.Run("when status is set to false with message, then next update to true should remove the message", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(failed))
+		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
+
+		// when
+		err := statusManager.setStatusReady(nsTmplSet)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(Provisioned())
+	})
+
+	t.Run("when status is set to false with message, then next successful reconcile should update it to true and remove the message", func(t *testing.T) {
+		// given
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(failed))
+		devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
+		codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
+
+		// when
+		_, err := r.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasConditions(Provisioned())
+	})
+}

--- a/test/cluster_assertion.go
+++ b/test/cluster_assertion.go
@@ -2,9 +2,9 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -51,5 +51,21 @@ func WithLabel(key, value string) ResourceOption {
 		v, exists := acc.GetLabels()[key]
 		require.True(t, exists)
 		assert.Equal(t, value, v)
+	}
+}
+
+func Containing(value string) ResourceOption {
+	return func(t test.T, obj runtime.Object) {
+		content, err := json.Marshal(obj)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), value)
+	}
+}
+
+func HasDeletionTimestamp() ResourceOption {
+	return func(t test.T, obj runtime.Object) {
+		acc, err := meta.Accessor(obj)
+		require.NoError(t, err)
+		assert.NotNil(t, acc.GetDeletionTimestamp())
 	}
 }

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -69,9 +69,9 @@ func Provisioned() toolchainv1alpha1.Condition {
 
 func Provisioning() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
-		Type:    toolchainv1alpha1.ConditionReady,
-		Status:  corev1.ConditionFalse,
-		Reason:  toolchainv1alpha1.NSTemplateSetProvisioningReason,
+		Type:   toolchainv1alpha1.ConditionReady,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.NSTemplateSetProvisioningReason,
 	}
 }
 


### PR DESCRIPTION
Since the NSTemplateSet controller (and mainly the associated test) was getting bigger and bigger and thus also cluttered I decided to split it into several files. As part of this effort, I created additional types to isolate the behavior for easier testing. One of the new types is `apiClient` that contains information for communication through the API and is used in all other types via composition.

* `cluster_resources.go` - takes care of creating, updating, and deleting of cluster resources contained in the respective template. The main entity is `clusterResourcesManager`.
* `namespaces.go` - takes care of creating, updating, and deleting of namespaces and its inner resources. The main entity is `namespacesManager`.
* `status.go` - takes care of updating NSTemplateSet.status. The main entity is `statusManager` that is used via composition in both of the previously mentioned managers.

For all the beforementioned files, there are also associated test files testing the behavior in an isolated way. 

This PR doesn't bring any new functionality, it just moves the code to the new files + introduces some refactoring to make the move smooth and meaningful. It may contain some small fixes of bugs that were discovered during the refactoring. 
On the other hand, the unit tests contain bigger changes since in the new code it verifies the behavior in an isolated way. Some tests were added to improve the coverage, duplicated were removed.