### PR TITLE
 feat(CRT-501): migrate NSTemplateSet to templateRef field 

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_nstemplateset_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_nstemplateset_crd.yaml
@@ -62,7 +62,7 @@ spec:
                     use
                   type: string
               required:
-              - revision
+              - templateRef
               type: object
             namespaces:
               description: The namespace templates
@@ -85,8 +85,7 @@ spec:
                     description: 'The type of the namespace. For example: ide|cicd|stage|default'
                     type: string
                 required:
-                - revision
-                - type
+                - templateRef
                 type: object
               type: array
             tierName:

--- a/deploy/crds/toolchain_v1alpha1_useraccount_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_useraccount_crd.yaml
@@ -83,7 +83,7 @@ spec:
                         to use
                       type: string
                   required:
-                  - revision
+                  - templateRef
                   type: object
                 namespaces:
                   description: The namespace templates
@@ -106,8 +106,7 @@ spec:
                         description: 'The type of the namespace. For example: ide|cicd|stage|default'
                         type: string
                     required:
-                    - revision
-                    - type
+                    - templateRef
                     type: object
                   type: array
                 tierName:

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain_v1alpha1_nstemplateset_crd.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain_v1alpha1_nstemplateset_crd.yaml
@@ -62,7 +62,7 @@ spec:
                     use
                   type: string
               required:
-              - revision
+              - templateRef
               type: object
             namespaces:
               description: The namespace templates
@@ -85,8 +85,7 @@ spec:
                     description: 'The type of the namespace. For example: ide|cicd|stage|default'
                     type: string
                 required:
-                - revision
-                - type
+                - templateRef
                 type: object
               type: array
             tierName:

--- a/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain_v1alpha1_useraccount_crd.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/0.0.1/toolchain_v1alpha1_useraccount_crd.yaml
@@ -83,7 +83,7 @@ spec:
                         to use
                       type: string
                   required:
-                  - revision
+                  - templateRef
                   type: object
                 namespaces:
                   description: The namespace templates
@@ -106,8 +106,7 @@ spec:
                         description: 'The type of the namespace. For example: ide|cicd|stage|default'
                         type: string
                     required:
-                    - revision
-                    - type
+                    - templateRef
                     type: object
                   type: array
                 tierName:

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
 
+replace github.com/codeready-toolchain/api => ../api
+
 // Pinned to kubernetes-1.16.2
 replace (
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
 
-replace github.com/codeready-toolchain/api => github.com/MatousJobanek/api v0.0.0-20200514221709-6828f4a4090a
+replace github.com/codeready-toolchain/api => github.com/MatousJobanek/api v0.0.0-20200515110108-4f5f9ccea1e9
 
 // Pinned to kubernetes-1.16.2
 replace (

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
 
-replace github.com/codeready-toolchain/api => ../api
+replace github.com/codeready-toolchain/api => github.com/MatousJobanek/api v0.0.0-20200514221709-6828f4a4090a
 
 // Pinned to kubernetes-1.16.2
 replace (

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/member-operator
 require (
 	github.com/Azure/go-autorest/autorest v0.9.2 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1
+	github.com/codeready-toolchain/api v0.0.0-20200519085052-34d2a9c4a8e9
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/swag v0.19.9 // indirect
@@ -30,8 +30,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.5.0
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
-
-replace github.com/codeready-toolchain/api => github.com/MatousJobanek/api v0.0.0-20200515110108-4f5f9ccea1e9
 
 // Pinned to kubernetes-1.16.2
 replace (

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/sprig/v3 v3.0.0/go.mod h1:NEUY/Qq8Gdm2xgYA+NwJM6wmfdRV9xkh8h/Rld20R0U=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
-github.com/MatousJobanek/api v0.0.0-20200514221709-6828f4a4090a h1:7fLnH/zju8QXbBtjNQ833GgqnuzHF4yPTqN1mICEslo=
-github.com/MatousJobanek/api v0.0.0-20200514221709-6828f4a4090a/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/MatousJobanek/api v0.0.0-20200515110108-4f5f9ccea1e9 h1:OysgrBBevKFHPJ6MtzsAoTb/OojI1TfvxfIP/NDNvc4=
+github.com/MatousJobanek/api v0.0.0-20200515110108-4f5f9ccea1e9/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/sprig/v3 v3.0.0/go.mod h1:NEUY/Qq8Gdm2xgYA+NwJM6wmfdRV9xkh8h/Rld20R0U=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
-github.com/MatousJobanek/api v0.0.0-20200515110108-4f5f9ccea1e9 h1:OysgrBBevKFHPJ6MtzsAoTb/OojI1TfvxfIP/NDNvc4=
-github.com/MatousJobanek/api v0.0.0-20200515110108-4f5f9ccea1e9/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
@@ -114,6 +112,9 @@ github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1w
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
+github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/codeready-toolchain/api v0.0.0-20200519085052-34d2a9c4a8e9 h1:lDpk5qG4SXK3NnTnMgzvEg6IKEpzl04s/ovflLOmf5A=
+github.com/codeready-toolchain/api v0.0.0-20200519085052-34d2a9c4a8e9/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527 h1:sdODhNlkdU9TXR7JrV3T81E1JB3EUXIcapH2IBVzaLg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/sprig/v3 v3.0.0/go.mod h1:NEUY/Qq8Gdm2xgYA+NwJM6wmfdRV9xkh8h/Rld20R0U=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
+github.com/MatousJobanek/api v0.0.0-20200514221709-6828f4a4090a h1:7fLnH/zju8QXbBtjNQ833GgqnuzHF4yPTqN1mICEslo=
+github.com/MatousJobanek/api v0.0.0-20200514221709-6828f4a4090a/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
@@ -112,9 +114,6 @@ github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1w
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
-github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1 h1:QlZeSc0rKbUEA4L2Z1EH6Q9Ckr2UrPdYumEmF2YO5W0=
-github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527 h1:sdODhNlkdU9TXR7JrV3T81E1JB3EUXIcapH2IBVzaLg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200504150510-6252228f3527/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -71,7 +71,7 @@ data:
                           use
                         type: string
                     required:
-                    - revision
+                    - templateRef
                     type: object
                   namespaces:
                     description: The namespace templates
@@ -94,8 +94,7 @@ data:
                           description: 'The type of the namespace. For example: ide|cicd|stage|default'
                           type: string
                       required:
-                      - revision
-                      - type
+                      - templateRef
                       type: object
                     type: array
                   tierName:
@@ -234,7 +233,7 @@ data:
                               to use
                             type: string
                         required:
-                        - revision
+                        - templateRef
                         type: object
                       namespaces:
                         description: The namespace templates
@@ -257,8 +256,7 @@ data:
                               description: 'The type of the namespace. For example: ide|cicd|stage|default'
                               type: string
                           required:
-                          - revision
-                          - type
+                          - templateRef
                           type: object
                         type: array
                       tierName:

--- a/pkg/controller/nstemplateset/cluster_resources.go
+++ b/pkg/controller/nstemplateset/cluster_resources.go
@@ -82,6 +82,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 		toolchainv1alpha1.OwnerLabelKey:       nsTmplSet.GetName(),
 		toolchainv1alpha1.TypeLabelKey:        "cluster",
 		toolchainv1alpha1.TemplateRefLabelKey: tierTemplate.templateRef,
+		toolchainv1alpha1.TierLabelKey:        tierTemplate.tierName,
 		toolchainv1alpha1.ProviderLabelKey:    toolchainv1alpha1.ProviderLabelValue,
 	}
 	// Note: we don't set an owner reference between the NSTemplateSet (namespaced resource) and the cluster-wide resources

--- a/pkg/controller/nstemplateset/cluster_resources.go
+++ b/pkg/controller/nstemplateset/cluster_resources.go
@@ -80,7 +80,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 
 	var labels = map[string]string{
 		toolchainv1alpha1.OwnerLabelKey:       nsTmplSet.GetName(),
-		toolchainv1alpha1.TypeLabelKey:        "cluster",
+		toolchainv1alpha1.TypeLabelKey:        clusterResourcesType,
 		toolchainv1alpha1.TemplateRefLabelKey: tierTemplate.templateRef,
 		toolchainv1alpha1.TierLabelKey:        tierTemplate.tierName,
 		toolchainv1alpha1.ProviderLabelKey:    toolchainv1alpha1.ProviderLabelValue,

--- a/pkg/controller/nstemplateset/cluster_resources_test.go
+++ b/pkg/controller/nstemplateset/cluster_resources_test.go
@@ -312,6 +312,7 @@ func TestPromoteClusterResources(t *testing.T) {
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "team-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/tier", "team"),
 					Containing(`"limits.cpu":"4","limits.memory":"15Gi"`))
 		})
 
@@ -371,6 +372,7 @@ func TestPromoteClusterResources(t *testing.T) {
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
 					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)) // upgraded
 		})
 
@@ -448,7 +450,8 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(UpdateFailed("failed to retrieve template"))
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "fail-cluster-12345bb"))
+					WithLabel("toolchain.dev.openshift.com/templateref", "fail-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/tier", "fail"))
 		})
 
 		t.Run("fail to downgrade from advanced to basic tier", func(t *testing.T) {
@@ -471,7 +474,8 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(UpdateFailed("failed to delete object 'for-johnsmith' of kind 'ClusterResourceQuota' in namespace '': some error"))
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"))
+					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 		})
 	})
 }

--- a/pkg/controller/nstemplateset/cluster_resources_test.go
+++ b/pkg/controller/nstemplateset/cluster_resources_test.go
@@ -311,7 +311,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "team-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/templateref", "team-clusterresources-12345bb"),
 					WithLabel("toolchain.dev.openshift.com/tier", "team"),
 					Containing(`"limits.cpu":"4","limits.memory":"15Gi"`))
 		})
@@ -371,7 +371,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(Provisioning())
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-12345bb"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
 					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)) // upgraded
 		})
@@ -450,7 +450,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(UpdateFailed("failed to retrieve template"))
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "fail-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/templateref", "fail-clusterresources-12345bb"),
 					WithLabel("toolchain.dev.openshift.com/tier", "fail"))
 		})
 
@@ -474,7 +474,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(UpdateFailed("failed to delete object 'for-johnsmith' of kind 'ClusterResourceQuota' in namespace '': some error"))
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-12345bb"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 		})
 	})

--- a/pkg/controller/nstemplateset/cluster_resources_test.go
+++ b/pkg/controller/nstemplateset/cluster_resources_test.go
@@ -311,7 +311,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/tier", "team"),
+					WithLabel("toolchain.dev.openshift.com/templateref", "team-cluster-12345bb"),
 					Containing(`"limits.cpu":"4","limits.memory":"15Gi"`))
 		})
 
@@ -370,13 +370,13 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(Provisioning())
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
+					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
 					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)) // upgraded
 		})
 
 		t.Run("no redundant cluster resource quota to be deleted for the given user", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withConditions(Provisioned())) // no cluster resources, so the "advancedCRQ" should be deleted
+			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withConditions(Provisioned()), withClusterResources())
 			anotherNsTmplSet := newNSTmplSet(namespaceName, "another-user", "basic")
 			advancedCRQ := newClusterResourceQuota(username, "advanced")
 			anotherCRQ := newClusterResourceQuota("another-user", "basic")
@@ -448,7 +448,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(UpdateFailed("failed to retrieve template"))
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/tier", "fail"))
+					WithLabel("toolchain.dev.openshift.com/templateref", "fail-cluster-12345bb"))
 		})
 
 		t.Run("fail to downgrade from advanced to basic tier", func(t *testing.T) {
@@ -471,7 +471,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				HasConditions(UpdateFailed("failed to delete object 'for-johnsmith' of kind 'ClusterResourceQuota' in namespace '': some error"))
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
+					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"))
 		})
 	})
 }

--- a/pkg/controller/nstemplateset/namespaces.go
+++ b/pkg/controller/nstemplateset/namespaces.go
@@ -28,7 +28,12 @@ func (r *namespacesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusProvisionFailed, err, "failed to list namespaces with label owner '%s'", username)
 	}
 
-	toDeprovision, found := nextNamespaceToDeprovision(nsTmplSet.Spec.Namespaces, userNamespaces)
+	tierTemplatesByType, err := r.getTierTemplatesForAllNamespaces(nsTmplSet)
+	if err != nil {
+		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err,
+			"failed to get TierTemplates for tier '%s'", nsTmplSet.Spec.TierName)
+	}
+	toDeprovision, found := nextNamespaceToDeprovision(tierTemplatesByType, userNamespaces)
 	if found {
 		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
 			return false, err
@@ -41,7 +46,7 @@ func (r *namespacesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 	}
 
 	// find next namespace for provisioning namespace resource
-	tcNamespace, userNamespace, found := nextNamespaceToProvisionOrUpdate(nsTmplSet, userNamespaces)
+	tierTemplate, userNamespace, found := nextNamespaceToProvisionOrUpdate(tierTemplatesByType, userNamespaces)
 	if !found {
 		logger.Info("no more namespaces to create", "username", nsTmplSet.GetName())
 		return false, nil
@@ -56,34 +61,33 @@ func (r *namespacesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 			return false, err
 		}
 	}
-
 	// create namespace resource
-	return true, r.ensureNamespace(logger, nsTmplSet, tcNamespace, userNamespace)
+	return true, r.ensureNamespace(logger, nsTmplSet, tierTemplate, userNamespace)
 }
 
 // ensureNamespace ensures that the namespace exists and that it contains all the expected resources
-func (r *namespacesManager) ensureNamespace(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tcNamespace *toolchainv1alpha1.NSTemplateSetNamespace, userNamespace *corev1.Namespace) error {
-	logger.Info("ensuring namespace", "namespace", tcNamespace.Type, "tier", nsTmplSet.Spec.TierName)
+func (r *namespacesManager) ensureNamespace(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate, userNamespace *corev1.Namespace) error {
+	logger.Info("ensuring namespace", "namespace", tierTemplate.typeName, "tier", nsTmplSet.Spec.TierName)
 
 	// create namespace before created inner resources because creating the namespace may take some time
 	if userNamespace == nil {
-		return r.ensureNamespaceResource(logger, nsTmplSet, tcNamespace)
+		return r.ensureNamespaceResource(logger, nsTmplSet, tierTemplate)
 	}
-	return r.ensureInnerNamespaceResources(logger, nsTmplSet, tcNamespace, userNamespace)
+	return r.ensureInnerNamespaceResources(logger, nsTmplSet, tierTemplate, userNamespace)
 }
 
 // ensureNamespaceResource ensures that the namespace exists.
-func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tcNamespace *toolchainv1alpha1.NSTemplateSetNamespace) error {
-	logger.Info("creating namespace", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tcNamespace.Type)
+func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate) error {
+	logger.Info("creating namespace", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
 
-	objs, err := process(r.templateContent(nsTmplSet.Spec.TierName, tcNamespace.Type), r.scheme, nsTmplSet.GetName(), template.RetainNamespaces)
+	objs, err := tierTemplate.process(r.scheme, nsTmplSet.GetName(), template.RetainNamespaces)
 	if err != nil {
-		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace type '%s'", tcNamespace.Type)
+		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace type '%s'", tierTemplate.typeName)
 	}
 
 	labels := map[string]string{
 		toolchainv1alpha1.OwnerLabelKey:    nsTmplSet.GetName(),
-		toolchainv1alpha1.TypeLabelKey:     tcNamespace.Type,
+		toolchainv1alpha1.TypeLabelKey:     tierTemplate.typeName,
 		toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
 	}
 
@@ -94,30 +98,33 @@ func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSe
 
 	_, err = applycl.NewApplyClient(r.client, r.scheme).Apply(objs, labels)
 	if err != nil {
-		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to create namespace with type '%s'", tcNamespace.Type)
+		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to create namespace with type '%s'", tierTemplate.typeName)
 	}
-	logger.Info("namespace provisioned", "namespace", tcNamespace)
+	logger.Info("namespace provisioned", "namespace", tierTemplate)
 	return nil
 }
 
 // ensureInnerNamespaceResources ensure that the namespace has the expected resources.
-func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tcNamespace *toolchainv1alpha1.NSTemplateSetNamespace, namespace *corev1.Namespace) error {
-	logger.Info("ensuring namespace resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tcNamespace.Type)
+func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate, namespace *corev1.Namespace) error {
+	logger.Info("ensuring namespace resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
 	nsName := namespace.GetName()
 	username := nsTmplSet.GetName()
-	newObjs, err := process(r.templateContent(nsTmplSet.Spec.TierName, tcNamespace.Type), r.scheme, username, template.RetainAllButNamespaces)
+	newObjs, err := tierTemplate.process(r.scheme, username, template.RetainAllButNamespaces)
 	if err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace '%s'", nsName)
 	}
 
-	if currentTier, exists := namespace.Labels[toolchainv1alpha1.TierLabelKey]; exists && currentTier != "" && currentTier != nsTmplSet.Spec.TierName {
+	if currentRef, exists := namespace.Labels[toolchainv1alpha1.TemplateRefLabelKey]; exists && currentRef != "" && currentRef != tierTemplate.templateRef {
 		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
 			return err
 		}
-
-		currentObjs, err := process(r.templateContent(currentTier, tcNamespace.Type), r.scheme, username, template.RetainAllButNamespaces)
+		currentTierTemplate, err := r.getTemplateContent(currentRef)
 		if err != nil {
-			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve template for tier/type '%s/%s'", currentTier, tcNamespace.Type)
+			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve current TierTemplate with name '%s'", currentRef)
+		}
+		currentObjs, err := currentTierTemplate.process(r.scheme, username, template.RetainAllButNamespaces)
+		if err != nil {
+			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to process template for TierTemplate with name '%s'", currentRef)
 		}
 		if _, err := deleteRedundantObjects(logger, r.client, false, currentObjs, newObjs); err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to delete redundant objects in namespace '%s'", nsName)
@@ -135,14 +142,13 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 		namespace.Labels = make(map[string]string)
 	}
 
-	// Adding labels indicating that the namespace is up-to-date with revision/tier
-	namespace.Labels[toolchainv1alpha1.RevisionLabelKey] = tcNamespace.Revision
-	namespace.Labels[toolchainv1alpha1.TierLabelKey] = nsTmplSet.Spec.TierName
+	// Adding label indicating that the namespace is up-to-date with TierTemplate
+	namespace.Labels[toolchainv1alpha1.TemplateRefLabelKey] = tierTemplate.templateRef
 	if err := r.client.Update(context.TODO(), namespace); err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to update namespace '%s'", nsName)
 	}
 
-	logger.Info("namespace provisioned with all required resources", "tier", nsTmplSet.Spec.TierName, "namespace", tcNamespace)
+	logger.Info("namespace provisioned with all required resources", "templateRef", tierTemplate.templateRef)
 
 	// TODO add validation for other objects
 	return nil // nothing changed, no error occurred
@@ -174,6 +180,18 @@ func (r *namespacesManager) delete(logger logr.Logger, nsTmplSet *toolchainv1alp
 	return false, nil
 }
 
+func (r *namespacesManager) getTierTemplatesForAllNamespaces(nsTmplSet *toolchainv1alpha1.NSTemplateSet) ([]*tierTemplate, error) {
+	var tmpls []*tierTemplate
+	for _, ns := range nsTmplSet.Spec.Namespaces {
+		nsTmpl, err := r.getTemplateContent(ns.TemplateRef)
+		if err != nil {
+			return nil, err
+		}
+		tmpls = append(tmpls, nsTmpl)
+	}
+	return tmpls, nil
+}
+
 // fetchNamespaces returns all current namespaces belonging to the given user
 // i.e., labeled with `"toolchain.dev.openshift.com/owner":<username>`
 func fetchNamespaces(client client.Client, username string) ([]corev1.Namespace, error) {
@@ -188,19 +206,18 @@ func fetchNamespaces(client client.Client, username string) ([]corev1.Namespace,
 // nextNamespaceToProvisionOrUpdate returns first namespace (from given namespaces) whose status is active and
 // either revision is not set or revision or tier doesn't equal to the current one.
 // It also returns namespace present in tcNamespaces but not found in given namespaces
-func nextNamespaceToProvisionOrUpdate(nsTmplSet *toolchainv1alpha1.NSTemplateSet, namespaces []corev1.Namespace) (*toolchainv1alpha1.NSTemplateSetNamespace, *corev1.Namespace, bool) {
-	for _, tcNamespace := range nsTmplSet.Spec.Namespaces {
-		namespace, found := findNamespace(namespaces, tcNamespace.Type)
+func nextNamespaceToProvisionOrUpdate(tierTemplatesByType []*tierTemplate, namespaces []corev1.Namespace) (*tierTemplate, *corev1.Namespace, bool) {
+	for _, nsTemplate := range tierTemplatesByType {
+		namespace, found := findNamespace(namespaces, nsTemplate.typeName)
 		if found {
 			if namespace.Status.Phase == corev1.NamespaceActive {
-				if namespace.Labels[toolchainv1alpha1.RevisionLabelKey] == "" ||
-					namespace.Labels[toolchainv1alpha1.RevisionLabelKey] != tcNamespace.Revision ||
-					namespace.Labels[toolchainv1alpha1.TierLabelKey] != nsTmplSet.Spec.TierName {
-					return &tcNamespace, &namespace, true
+				if namespace.Labels[toolchainv1alpha1.TemplateRefLabelKey] == "" ||
+					namespace.Labels[toolchainv1alpha1.TemplateRefLabelKey] != nsTemplate.templateRef {
+					return nsTemplate, &namespace, true
 				}
 			}
 		} else {
-			return &tcNamespace, nil, true
+			return nsTemplate, nil, true
 		}
 	}
 	return nil, nil, false
@@ -208,11 +225,11 @@ func nextNamespaceToProvisionOrUpdate(nsTmplSet *toolchainv1alpha1.NSTemplateSet
 
 // nextNamespaceToDeprovision returns namespace (and information of it was found) that should be deprovisioned
 // because its type wasn't found in the set of namespace types in NSTemplateSet
-func nextNamespaceToDeprovision(tcNamespaces []toolchainv1alpha1.NSTemplateSetNamespace, namespaces []corev1.Namespace) (*corev1.Namespace, bool) {
+func nextNamespaceToDeprovision(tierTemplatesByType []*tierTemplate, namespaces []corev1.Namespace) (*corev1.Namespace, bool) {
 Namespaces:
 	for _, ns := range namespaces {
-		for _, tcNs := range tcNamespaces {
-			if tcNs.Type == ns.Labels[toolchainv1alpha1.TypeLabelKey] {
+		for _, nsTemplate := range tierTemplatesByType {
+			if nsTemplate.typeName == ns.Labels[toolchainv1alpha1.TypeLabelKey] {
 				continue Namespaces
 			}
 		}

--- a/pkg/controller/nstemplateset/namespaces.go
+++ b/pkg/controller/nstemplateset/namespaces.go
@@ -144,6 +144,7 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 
 	// Adding label indicating that the namespace is up-to-date with TierTemplate
 	namespace.Labels[toolchainv1alpha1.TemplateRefLabelKey] = tierTemplate.templateRef
+	namespace.Labels[toolchainv1alpha1.TierLabelKey] = tierTemplate.tierName
 	if err := r.client.Update(context.TODO(), namespace); err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to update namespace '%s'", nsName)
 	}

--- a/pkg/controller/nstemplateset/namespaces_test.go
+++ b/pkg/controller/nstemplateset/namespaces_test.go
@@ -73,19 +73,16 @@ func TestNextNamespaceToProvisionOrUpdate(t *testing.T) {
 	tierTemplates := []*tierTemplate{
 		{
 			templateRef: "basic-dev-abcde11",
-			revision:    "abcde11",
 			typeName:    "dev",
 			tierName:    "basic",
 		},
 		{
 			templateRef: "basic-code-abcde21",
-			revision:    "abcde21",
 			typeName:    "code",
 			tierName:    "basic",
 		},
 		{
 			templateRef: "basic-stage-abcde13",
-			revision:    "abcde13",
 			typeName:    "stage",
 			tierName:    "basic",
 		},
@@ -185,7 +182,6 @@ func TestNextNamespaceToDeprovision(t *testing.T) {
 		tierTemplates := []*tierTemplate{
 			{
 				templateRef: "basic-dev-abcde11",
-				revision:    "abcde11",
 				typeName:    "dev",
 				tierName:    "basic",
 			},
@@ -204,13 +200,11 @@ func TestNextNamespaceToDeprovision(t *testing.T) {
 		tierTemplates := []*tierTemplate{
 			{
 				templateRef: "basic-dev-abcde11",
-				revision:    "abcde11",
 				typeName:    "dev",
 				tierName:    "basic",
 			},
 			{
 				templateRef: "basic-code-abcde21",
-				revision:    "abcde21",
 				typeName:    "code",
 				tierName:    "basic",
 			},

--- a/pkg/controller/nstemplateset/namespaces_test.go
+++ b/pkg/controller/nstemplateset/namespaces_test.go
@@ -331,7 +331,7 @@ func TestEnsureNamespacesOK(t *testing.T) {
 	t.Run("should create the second namespace when the first one already exists", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(Provisioning()))
-		devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
+		devNS := newNamespace("basic", username, "dev", withTemplateRef())
 		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, devNS)
 
 		// when
@@ -384,7 +384,7 @@ func TestEnsureNamespacesOK(t *testing.T) {
 	t.Run("ensure inner resources for code namespace if the dev is already provisioned", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(Provisioning()))
-		devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
+		devNS := newNamespace("basic", username, "dev", withTemplateRef())
 		codeNS := newNamespace("", username, "code") // NS exist but it is not complete yet
 		rb := newRoleBinding(devNS.Name, "user-edit")
 		manager, fakeClient := prepareNamespacesManager(t, nsTmplSet, devNS, codeNS, rb)
@@ -543,8 +543,8 @@ func TestDeleteNamespsace(t *testing.T) {
 	namespaceName := "toolchain-member"
 	// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
 	nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withDeletionTs())
-	devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
-	codeNS := newNamespace("basic", username, "code", withTemplateRef("abcde11"))
+	devNS := newNamespace("basic", username, "dev", withTemplateRef())
+	codeNS := newNamespace("basic", username, "code", withTemplateRef())
 
 	t.Run("delete user namespace", func(t *testing.T) {
 		// given
@@ -651,7 +651,7 @@ func TestPromoteNamespaces(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
 			// create namespace (and assume it is complete since it has the expected revision number)
-			devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
+			devNS := newNamespace("basic", username, "dev", withTemplateRef())
 			ro := newRole(devNS.Name, "rbac-edit")
 			rb := newRoleBinding(devNS.Name, "user-edit")
 			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, ro, rb)
@@ -680,7 +680,7 @@ func TestPromoteNamespaces(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
 			// create namespace (and assume it is complete since it has the expected revision number)
-			devNS := newNamespace("advanced", username, "dev", withTemplateRef("abcde11"))
+			devNS := newNamespace("advanced", username, "dev", withTemplateRef())
 			rb := newRoleBinding(devNS.Name, "user-edit")
 			rbacRb := newRoleBinding(devNS.Name, "user-rbac-edit")
 			ro := newRole(devNS.Name, "rbac-edit")
@@ -711,8 +711,8 @@ func TestPromoteNamespaces(t *testing.T) {
 		t.Run("delete redundant namespace while upgrading tier", func(t *testing.T) {
 			// given 'advanced' NSTemplate only has a 'dev' namespace
 			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"))
-			devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
-			codeNS := newNamespace("basic", username, "code", withTemplateRef("abcde11"))
+			devNS := newNamespace("basic", username, "dev", withTemplateRef())
+			codeNS := newNamespace("basic", username, "code", withTemplateRef())
 			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, codeNS) // current user has also a 'code' NS
 
 			// when - should delete the code namespace
@@ -764,7 +764,7 @@ func TestPromoteNamespaces(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev"))
 			// create namespace but with an unknown tier
-			devNS := newNamespace("fail", username, "dev", withTemplateRef("abcde11"))
+			devNS := newNamespace("fail", username, "dev", withTemplateRef())
 			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS)
 
 			// when
@@ -787,8 +787,8 @@ func TestPromoteNamespaces(t *testing.T) {
 		t.Run("fail to delete redundant namespace while upgrading tier", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
-			devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
-			codeNS := newNamespace("basic", username, "code", withTemplateRef("abcde11"))
+			devNS := newNamespace("basic", username, "dev", withTemplateRef())
+			codeNS := newNamespace("basic", username, "code", withTemplateRef())
 			manager, cl := prepareNamespacesManager(t, nsTmplSet, devNS, codeNS) // current user has also a 'code' NS
 			cl.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 				return fmt.Errorf("mock error: '%T'", obj)

--- a/pkg/controller/nstemplateset/namespaces_test.go
+++ b/pkg/controller/nstemplateset/namespaces_test.go
@@ -322,7 +322,8 @@ func TestEnsureNamespacesOK(t *testing.T) {
 			HasLabel("toolchain.dev.openshift.com/owner", username).
 			HasLabel("toolchain.dev.openshift.com/type", "dev").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-			HasNoLabel("toolchain.dev.openshift.com/templateref")
+			HasNoLabel("toolchain.dev.openshift.com/templateref").
+			HasNoLabel("toolchain.dev.openshift.com/tier")
 		AssertThatNamespace(t, username+"-code", manager.client).
 			DoesNotExist()
 	})
@@ -348,7 +349,8 @@ func TestEnsureNamespacesOK(t *testing.T) {
 			HasLabel("toolchain.dev.openshift.com/owner", username).
 			HasLabel("toolchain.dev.openshift.com/type", "code").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-			HasNoLabel("toolchain.dev.openshift.com/templateref")
+			HasNoLabel("toolchain.dev.openshift.com/templateref").
+			HasNoLabel("toolchain.dev.openshift.com/tier")
 
 	})
 
@@ -372,6 +374,7 @@ func TestEnsureNamespacesOK(t *testing.T) {
 			HasLabel("toolchain.dev.openshift.com/owner", username).
 			HasLabel("toolchain.dev.openshift.com/type", "dev").
 			HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11").
+			HasLabel("toolchain.dev.openshift.com/tier", "basic").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
 			HasResource("user-edit", &authv1.RoleBinding{})
 		AssertThatNamespace(t, username+"-code", manager.client).
@@ -401,6 +404,7 @@ func TestEnsureNamespacesOK(t *testing.T) {
 				HasLabel("toolchain.dev.openshift.com/owner", username).
 				HasLabel("toolchain.dev.openshift.com/type", nsType).
 				HasLabel("toolchain.dev.openshift.com/templateref", "basic-"+nsType+"-abcde11").
+				HasLabel("toolchain.dev.openshift.com/tier", "basic").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
 				HasResource("user-edit", &authv1.RoleBinding{})
 		}
@@ -665,6 +669,7 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasNoOwnerReference().
 				HasLabel("toolchain.dev.openshift.com/owner", username).
 				HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde11"). // upgraded
+				HasLabel("toolchain.dev.openshift.com/tier", "advanced").
 				HasLabel("toolchain.dev.openshift.com/type", "dev").
 				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
 				HasResource("user-edit", &authv1.RoleBinding{}).
@@ -695,6 +700,7 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasLabel("toolchain.dev.openshift.com/owner", username).
 				HasLabel("toolchain.dev.openshift.com/type", "dev").
 				HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11"). // downgraded
+				HasLabel("toolchain.dev.openshift.com/tier", "basic").
 				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
 				HasResource("user-edit", &authv1.RoleBinding{}).
 				HasNoResource("rbac-edit", &rbacv1.Role{}). // role does not exist
@@ -725,7 +731,8 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasLabel("toolchain.dev.openshift.com/owner", username).
 				HasLabel("toolchain.dev.openshift.com/type", "dev").
 				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-				HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11") // not upgraded yet
+				HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11"). // not upgraded yet
+				HasLabel("toolchain.dev.openshift.com/tier", "basic")
 
 			t.Run("uprade dev namespace when there is no other namespace to be deleted", func(t *testing.T) {
 
@@ -743,6 +750,7 @@ func TestPromoteNamespaces(t *testing.T) {
 					HasLabel("toolchain.dev.openshift.com/owner", username).
 					HasLabel("toolchain.dev.openshift.com/type", "dev").
 					HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde11"). // upgraded
+					HasLabel("toolchain.dev.openshift.com/tier", "advanced").
 					HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
 					HasResource("user-edit", &authv1.RoleBinding{}).
 					HasResource("rbac-edit", &rbacv1.Role{})
@@ -772,7 +780,8 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasLabel("toolchain.dev.openshift.com/owner", username).
 				HasLabel("toolchain.dev.openshift.com/type", "dev").
 				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-				HasLabel("toolchain.dev.openshift.com/templateref", "fail-dev-abcde11") // the unknown tier that caused the error
+				HasLabel("toolchain.dev.openshift.com/templateref", "fail-dev-abcde11"). // the unknown tier that caused the error
+				HasLabel("toolchain.dev.openshift.com/tier", "fail")
 		})
 
 		t.Run("fail to delete redundant namespace while upgrading tier", func(t *testing.T) {
@@ -798,13 +807,15 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasLabel("toolchain.dev.openshift.com/owner", username).
 				HasLabel("toolchain.dev.openshift.com/type", "code").
 				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-				HasLabel("toolchain.dev.openshift.com/templateref", "basic-code-abcde11") // unchanged, namespace was not deleted
+				HasLabel("toolchain.dev.openshift.com/templateref", "basic-code-abcde11"). // unchanged, namespace was not deleted
+				HasLabel("toolchain.dev.openshift.com/tier", "basic")
 			AssertThatNamespace(t, username+"-dev", cl).
 				HasNoOwnerReference().
 				HasLabel("toolchain.dev.openshift.com/owner", username).
 				HasLabel("toolchain.dev.openshift.com/type", "dev").
 				HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
-				HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11") // not upgraded
+				HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11"). // not upgraded
+				HasLabel("toolchain.dev.openshift.com/tier", "basic")
 		})
 	})
 }

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -88,8 +88,8 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"))
 		// create namespaces (and assume they are complete since they have the expected revision number)
-		devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
-		codeNS := newNamespace("basic", username, "code", withTemplateRef("abcde11"))
+		devNS := newNamespace("basic", username, "dev", withTemplateRef())
+		codeNS := newNamespace("basic", username, "code", withTemplateRef())
 		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
 
 		// when
@@ -121,8 +121,8 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// create cluster resource quotas
 		crq := newClusterResourceQuota(username, "advanced")
 		// create namespaces (and assume they are complete since they have the expected revision number)
-		devNS := newNamespace("advanced", username, "dev", withTemplateRef("abcde11"))
-		codeNS := newNamespace("advanced", username, "code", withTemplateRef("abcde11"))
+		devNS := newNamespace("advanced", username, "dev", withTemplateRef())
+		codeNS := newNamespace("advanced", username, "code", withTemplateRef())
 		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withClusterResources())
 		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, crq, devNS, codeNS)
 
@@ -190,8 +190,8 @@ func TestReconcileUpdate(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources())
 			// create namespace (and assume it is complete since it has the expected revision number)
-			devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
-			codeNS := newNamespace("basic", username, "code", withTemplateRef("abcde11"))
+			devNS := newNamespace("basic", username, "dev", withTemplateRef())
+			codeNS := newNamespace("basic", username, "code", withTemplateRef())
 			devRo := newRole(devNS.Name, "rbac-edit")
 			codeRo := newRole(codeNS.Name, "rbac-edit")
 			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS, devRo, codeRo)
@@ -363,8 +363,8 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "code")
 		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev", "code"), withDeletionTs(), withClusterResources())
 		crq := newClusterResourceQuota(username, "advanced")
-		devNS := newNamespace("advanced", username, "dev", withTemplateRef("abcde11"))
-		codeNS := newNamespace("advanced", username, "code", withTemplateRef("abcde11"))
+		devNS := newNamespace("advanced", username, "dev", withTemplateRef())
+		codeNS := newNamespace("advanced", username, "code", withTemplateRef())
 		r, _ := prepareController(t, nsTmplSet, crq, devNS, codeNS)
 
 		t.Run("reconcile after nstemplateset deletion triggers deletion of the first namespace", func(t *testing.T) {
@@ -657,9 +657,9 @@ func newNamespace(tier, username, typeName string, options ...namespaceOption) *
 
 type namespaceOption func(ns *corev1.Namespace, tier string, typeName string)
 
-func withTemplateRef(revision string) namespaceOption { // nolint: unparam
+func withTemplateRef() namespaceOption { // nolint: unparam
 	return func(ns *corev1.Namespace, tier string, typeName string) {
-		ns.ObjectMeta.Labels["toolchain.dev.openshift.com/templateref"] = NewTierTemplateName(tier, typeName, revision)
+		ns.ObjectMeta.Labels["toolchain.dev.openshift.com/templateref"] = NewTierTemplateName(tier, typeName, "abcde11")
 	}
 }
 

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -209,7 +209,7 @@ func TestReconcileUpdate(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatCluster(t, fakeClient).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
+					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-12345bb"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced")) // upgraded
 			for _, nsType := range []string{"code", "dev"} {
 				AssertThatNamespace(t, username+"-"+nsType, r.client).
@@ -255,7 +255,7 @@ func TestReconcileUpdate(t *testing.T) {
 						HasConditions(Updating())
 					AssertThatCluster(t, fakeClient).
 						HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-							WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
+							WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-12345bb"),
 							WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 					AssertThatNamespace(t, codeNS.Name, r.client).
 						DoesNotExist()
@@ -280,7 +280,7 @@ func TestReconcileUpdate(t *testing.T) {
 							HasConditions(Provisioned())
 						AssertThatCluster(t, fakeClient).
 							HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
-								WithLabel("toolchain.dev.openshift.com/templateref", "advanced-cluster-12345bb"),
+								WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-12345bb"),
 								WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 						AssertThatNamespace(t, username+"-dev", r.client).
 							HasNoOwnerReference().
@@ -621,7 +621,7 @@ func withNamespaces(types ...string) nsTmplSetOption {
 func withClusterResources() nsTmplSetOption {
 	return func(nsTmplSet *toolchainv1alpha1.NSTemplateSet) {
 		nsTmplSet.Spec.ClusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
-			TemplateRef: NewTierTemplateName(nsTmplSet.Spec.TierName, "cluster", "12345bb"),
+			TemplateRef: NewTierTemplateName(nsTmplSet.Spec.TierName, "clusterresources", "12345bb"),
 		}
 	}
 }
@@ -693,7 +693,7 @@ func newClusterResourceQuota(username, tier string) *quotav1.ClusterResourceQuot
 			Labels: map[string]string{
 				"toolchain.dev.openshift.com/provider":    "codeready-toolchain",
 				"toolchain.dev.openshift.com/owner":       username,
-				"toolchain.dev.openshift.com/templateref": NewTierTemplateName(tier, "cluster", "12345bb"),
+				"toolchain.dev.openshift.com/templateref": NewTierTemplateName(tier, "clusterresources", "12345bb"),
 				"toolchain.dev.openshift.com/tier":        tier,
 			},
 			Annotations: map[string]string{},
@@ -728,28 +728,28 @@ func getTemplateContent(decoder runtime.Decoder) func(templateRef string) (*tier
 		switch tierName {
 		case "advanced": // assume that this tier has a "cluster resources" template
 			switch typeName {
-			case "cluster":
+			case "clusterresources":
 				tmplContent = test.CreateTemplate(test.WithObjects(advancedCrq), test.WithParams(username))
 			default:
 				tmplContent = test.CreateTemplate(test.WithObjects(ns, rb, role, rbacRb), test.WithParams(username))
 			}
 		case "basic":
 			switch typeName {
-			case "cluster": // assume that this tier has no "cluster resources" template
+			case "clusterresources": // assume that this tier has no "cluster resources" template
 				return nil, nil
 			default:
 				tmplContent = test.CreateTemplate(test.WithObjects(ns, rb), test.WithParams(username))
 			}
 		case "team": // assume that this tier has a "cluster resources" template
 			switch typeName {
-			case "cluster":
+			case "clusterresources":
 				tmplContent = test.CreateTemplate(test.WithObjects(teamCrq), test.WithParams(username))
 			default:
 				tmplContent = test.CreateTemplate(test.WithObjects(ns, rb, role, rbacRb), test.WithParams(username))
 			}
 		case "withemptycrq":
 			switch typeName {
-			case "cluster":
+			case "clusterresources":
 				tmplContent = test.CreateTemplate(test.WithObjects(advancedCrq, emptyCrq), test.WithParams(username))
 			default:
 				tmplContent = test.CreateTemplate(test.WithObjects(ns, rb, role), test.WithParams(username))

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -767,7 +767,6 @@ func getTemplateContent(decoder runtime.Decoder) func(templateRef string) (*tier
 			templateRef: templateRef,
 			tierName:    tierName,
 			typeName:    typeName,
-			revision:    refParts[2],
 			template:    tmpl,
 		}, err
 	}

--- a/pkg/controller/nstemplateset/nstemplatetier.go
+++ b/pkg/controller/nstemplateset/nstemplatetier.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 )
 
+const clusterResourcesType = "clusterresources"
+
 // getTemplateFromHost retrieves the TierTemplate resource with the given name from the host cluster
 // and returns an instance of the tierTemplate type for it whose template content can be parsable.
 // The returned tierTemplate contains all data from TierTemplate including its name.

--- a/pkg/controller/nstemplateset/nstemplatetier.go
+++ b/pkg/controller/nstemplateset/nstemplatetier.go
@@ -30,7 +30,6 @@ func getTemplateFromHost(templateRef string) (*tierTemplate, error) {
 		templateRef: templateRef,
 		tierName:    tmpl.Spec.TierName,
 		typeName:    tmpl.Spec.Type,
-		revision:    tmpl.Spec.Revision,
 		template:    tmpl.Spec.Template,
 	}, nil
 }
@@ -62,7 +61,6 @@ type tierTemplate struct {
 	templateRef string
 	tierName    string
 	typeName    string
-	revision    string
 	template    templatev1.Template
 }
 

--- a/pkg/controller/nstemplateset/nstemplatetier_test.go
+++ b/pkg/controller/nstemplateset/nstemplatetier_test.go
@@ -5,7 +5,9 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	"github.com/codeready-toolchain/member-operator/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	testcommon "github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -15,11 +17,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	fedcommon "sigs.k8s.io/kubefed/pkg/apis/core/common"
 	fedv1b1 "sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 )
+
+func newTierTemplate(tier, typeName, revision string) *toolchainv1alpha1.TierTemplate {
+	return &toolchainv1alpha1.TierTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      test.NewTierTemplateName(tier, typeName, revision),
+			Namespace: "toolchain-host-operator",
+		},
+		Spec: toolchainv1alpha1.TierTemplateSpec{
+			TierName: tier,
+			Type:     typeName,
+			Revision: revision,
+			Template: templatev1.Template{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: typeName,
+				},
+			},
+		},
+	}
+}
 
 func TestGetNSTemplateTier(t *testing.T) {
 
@@ -28,124 +48,61 @@ func TestGetNSTemplateTier(t *testing.T) {
 	err := apis.AddToScheme(scheme.Scheme)
 	require.NoError(t, err)
 	logf.SetLogger(zap.Logger())
-	basicTier := &toolchainv1alpha1.NSTemplateTier{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "toolchain-host-operator",
-		},
-		Spec: toolchainv1alpha1.NSTemplateTierSpec{
-			Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-				{
-					Type:     "code",
-					Revision: "abcdef",
-					Template: templatev1.Template{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "code",
-						},
-					},
-				},
-				{
-					Type:     "dev",
-					Revision: "123456",
-					Template: templatev1.Template{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "dev",
-						},
-					},
-				},
-				{
-					Type:     "stage",
-					Revision: "1a2b3c",
-					Template: templatev1.Template{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "stage",
-						},
-					},
-				},
-			},
-		},
-	}
-	advancedTier := &toolchainv1alpha1.NSTemplateTier{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "advanced",
-			Namespace: "toolchain-host-operator",
-		},
-		Spec: toolchainv1alpha1.NSTemplateTierSpec{
-			Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-				{
-					Type:     "code",
-					Revision: "ghijkl",
-					Template: templatev1.Template{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "code",
-						},
-					},
-				},
-				{
-					Type:     "dev",
-					Revision: "789012",
-					Template: templatev1.Template{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "dev",
-						},
-					},
-				},
-				{
-					Type:     "stage",
-					Revision: "4d5e6f",
-					Template: templatev1.Template{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "stage",
-						},
-					},
-				},
-			},
-		},
-	}
-	otherTier := &toolchainv1alpha1.NSTemplateTier{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "other",
-			Namespace: "other_namespace",
-		},
-	}
-	cl := fake.NewFakeClient(basicTier, advancedTier, otherTier)
 
-	t.Run("success", func(t *testing.T) {
+	basicTierCode := newTierTemplate("basic", "code", "abcdef")
+	basicTierDev := newTierTemplate("basic", "dev", "123456")
+	basicTierStage := newTierTemplate("basic", "stage", "1a2b3c")
+	basicTierCluster := newTierTemplate("basic", "cluster", "aa11bb22")
+
+	advancedTierCode := newTierTemplate("advanced", "code", "ghijkl")
+	advancedTierDev := newTierTemplate("advanced", "dev", "789012")
+	advancedTierStage := newTierTemplate("advanced", "stage", "4d5e6f")
+
+	other := newTierTemplate("other", "other", "other")
+	other.Namespace = "other"
+
+	cl := testcommon.NewFakeClient(t, basicTierCode, basicTierDev, basicTierStage, basicTierCluster, advancedTierCode, advancedTierDev, advancedTierStage, other)
+
+	t.Run("return code for basic tier", func(t *testing.T) {
 		// given
 		hostCluster := newHostCluster(cl, fedv1b1.ClusterCondition{
 			Type:   fedcommon.ClusterReady,
 			Status: apiv1.ConditionTrue,
 		})
 		// when
-		tmpls, err := getTemplatesFromHost(hostCluster, "basic")
+		tierTmpl, err := getTierTemplate(hostCluster, "basic-code-abcdef")
 
 		// then
 		require.NoError(t, err)
-		require.Len(t, tmpls, 3)
-		assert.Equal(t, versionedTemplate{
-			Revision: "abcdef",
-			Template: templatev1.Template{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "code",
-				},
-			},
-		}, tmpls["code"])
-		assert.Equal(t, versionedTemplate{
-			Revision: "123456",
-			Template: templatev1.Template{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "dev",
-				},
-			},
-		}, tmpls["dev"])
-		assert.Equal(t, versionedTemplate{
-			Revision: "1a2b3c",
-			Template: templatev1.Template{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "stage",
-				},
-			},
-		}, tmpls["stage"])
+		assert.Equal(t, tierTmpl.Spec, basicTierCode.Spec)
+	})
+
+	t.Run("return dev for advanced tier", func(t *testing.T) {
+		// given
+		hostCluster := newHostCluster(cl, fedv1b1.ClusterCondition{
+			Type:   fedcommon.ClusterReady,
+			Status: apiv1.ConditionTrue,
+		})
+		// when
+		tierTmpl, err := getTierTemplate(hostCluster, "advanced-dev-789012")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, tierTmpl.Spec, advancedTierDev.Spec)
+	})
+
+	t.Run("return cluster type for basic tier", func(t *testing.T) {
+		// given
+		hostCluster := newHostCluster(cl, fedv1b1.ClusterCondition{
+			Type:   fedcommon.ClusterReady,
+			Status: apiv1.ConditionTrue,
+		})
+		// when
+		tierTmpl, err := getTierTemplate(hostCluster, "basic-cluster-aa11bb22")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, tierTmpl.Spec, basicTierCluster.Spec)
 	})
 
 	t.Run("failures", func(t *testing.T) {
@@ -156,7 +113,7 @@ func TestGetNSTemplateTier(t *testing.T) {
 				return nil, false
 			}
 			// when
-			_, err := getTemplatesFromHost(hostCluster, "unknown")
+			_, err := getTierTemplate(hostCluster, "unknown")
 			// then
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "unable to connect to the host cluster: unknown cluster")
@@ -169,23 +126,23 @@ func TestGetNSTemplateTier(t *testing.T) {
 				Status: apiv1.ConditionFalse,
 			})
 			// when
-			_, err := getTemplatesFromHost(hostCluster, "unknown")
+			_, err := getTierTemplate(hostCluster, "unknown")
 			// then
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "the host cluster is not ready")
 		})
 
-		t.Run("unknown tier", func(t *testing.T) {
+		t.Run("unknown templateRef", func(t *testing.T) {
 			// given
 			hostCluster := newHostCluster(cl, fedv1b1.ClusterCondition{
 				Type:   fedcommon.ClusterReady,
 				Status: apiv1.ConditionTrue,
 			})
 			// when
-			_, err := getTemplatesFromHost(hostCluster, "unknown")
+			_, err := getTierTemplate(hostCluster, "unknown")
 			// then
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "unable to retrieve the NSTemplateTier 'unknown' from 'Host' cluster")
+			assert.Contains(t, err.Error(), "unable to retrieve the TierTemplate 'unknown' from 'Host' cluster")
 		})
 
 		t.Run("tier in another namespace", func(t *testing.T) {
@@ -195,10 +152,10 @@ func TestGetNSTemplateTier(t *testing.T) {
 				Status: apiv1.ConditionTrue,
 			})
 			// when
-			_, err := getTemplatesFromHost(hostCluster, "other")
+			_, err := getTierTemplate(hostCluster, "other-other-other")
 			// then
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "unable to retrieve the NSTemplateTier 'other' from 'Host' cluster")
+			assert.Contains(t, err.Error(), "unable to retrieve the TierTemplate 'other-other-other' from 'Host' cluster")
 		})
 	})
 

--- a/pkg/controller/nstemplateset/nstemplatetier_test.go
+++ b/pkg/controller/nstemplateset/nstemplatetier_test.go
@@ -52,7 +52,7 @@ func TestGetNSTemplateTier(t *testing.T) {
 	basicTierCode := newTierTemplate("basic", "code", "abcdef")
 	basicTierDev := newTierTemplate("basic", "dev", "123456")
 	basicTierStage := newTierTemplate("basic", "stage", "1a2b3c")
-	basicTierCluster := newTierTemplate("basic", "cluster", "aa11bb22")
+	basicTierCluster := newTierTemplate("basic", "clusterresources", "aa11bb22")
 
 	advancedTierCode := newTierTemplate("advanced", "code", "ghijkl")
 	advancedTierDev := newTierTemplate("advanced", "dev", "789012")
@@ -98,7 +98,7 @@ func TestGetNSTemplateTier(t *testing.T) {
 			Status: apiv1.ConditionTrue,
 		})
 		// when
-		tierTmpl, err := getTierTemplate(hostCluster, "basic-cluster-aa11bb22")
+		tierTmpl, err := getTierTemplate(hostCluster, "basic-clusterresources-aa11bb22")
 
 		// then
 		require.NoError(t, err)

--- a/pkg/controller/nstemplateset/status_test.go
+++ b/pkg/controller/nstemplateset/status_test.go
@@ -195,8 +195,8 @@ func TestUpdateStatusToProvisionedWhenPreviouslyWasSetToFailed(t *testing.T) {
 	t.Run("when status is set to false with message, then next successful reconcile should update it to true and remove the message", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(failed))
-		devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
-		codeNS := newNamespace("basic", username, "code", withTemplateRef("abcde11"))
+		devNS := newNamespace("basic", username, "dev", withTemplateRef())
+		codeNS := newNamespace("basic", username, "code", withTemplateRef())
 		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
 
 		// when

--- a/pkg/controller/nstemplateset/status_test.go
+++ b/pkg/controller/nstemplateset/status_test.go
@@ -195,8 +195,8 @@ func TestUpdateStatusToProvisionedWhenPreviouslyWasSetToFailed(t *testing.T) {
 	t.Run("when status is set to false with message, then next successful reconcile should update it to true and remove the message", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("dev", "code"), withConditions(failed))
-		devNS := newNamespace("basic", username, "dev", withRevision("abcde11"))
-		codeNS := newNamespace("basic", username, "code", withRevision("abcde11"))
+		devNS := newNamespace("basic", username, "dev", withTemplateRef("abcde11"))
+		codeNS := newNamespace("basic", username, "code", withTemplateRef("abcde11"))
 		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, codeNS)
 
 		// when

--- a/pkg/controller/useraccount/useraccount_controller_test.go
+++ b/pkg/controller/useraccount/useraccount_controller_test.go
@@ -445,9 +445,9 @@ func TestReconcile(t *testing.T) {
 			})
 	})
 
-	t.Run("update when revision in NSTemplateSet is different", func(t *testing.T) {
+	t.Run("update when templateRef in NSTemplateSet is different", func(t *testing.T) {
 		// given
-		userAcc.Spec.NSTemplateSet.Namespaces[0].Revision = "09876"
+		userAcc.Spec.NSTemplateSet.Namespaces[0].TemplateRef = "basic-dev-09876"
 		r, req, _ := prepareReconcile(t, username, userAcc, preexistingUser, preexistingIdentity, preexistingNsTmplSet)
 
 		//when
@@ -459,7 +459,7 @@ func TestReconcile(t *testing.T) {
 		updatedNSTmplSet := &toolchainv1alpha1.NSTemplateSet{}
 		err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: req.Namespace, Name: username}, updatedNSTmplSet)
 		require.NoError(t, err)
-		assert.Equal(t, "09876", updatedNSTmplSet.Spec.Namespaces[0].Revision)
+		assert.Equal(t, "basic-dev-09876", updatedNSTmplSet.Spec.Namespaces[0].TemplateRef)
 
 		// Check that the user account status is now "provisioned"
 		updatedAcc := &toolchainv1alpha1.UserAccount{}
@@ -1144,8 +1144,8 @@ func newNSTmplSetSpec() toolchainv1alpha1.NSTemplateSetSpec {
 	return toolchainv1alpha1.NSTemplateSetSpec{
 		TierName: "basic",
 		Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{
-			{Type: "dev", Revision: "abcde11", Template: ""},
-			{Type: "code", Revision: "abcde21", Template: ""},
+			{TemplateRef: "basic-dev-abcde11"},
+			{TemplateRef: "basic-code-abcde21"},
 		},
 	}
 }
@@ -1210,8 +1210,8 @@ func checkNSTmplSet(t *testing.T, client client.Client, username string) {
 
 	assert.Equal(t, "basic", nsTmplSet.Spec.TierName)
 	assert.Equal(t, 2, len(nsTmplSet.Spec.Namespaces))
-	assert.Equal(t, nsTmplSet.Spec.Namespaces[0].Type, "dev")
-	assert.Equal(t, nsTmplSet.Spec.Namespaces[1].Type, "code")
+	assert.Equal(t, nsTmplSet.Spec.Namespaces[0].TemplateRef, "basic-dev-abcde11")
+	assert.Equal(t, nsTmplSet.Spec.Namespaces[1].TemplateRef, "basic-code-abcde21")
 }
 
 func prepareReconcile(t *testing.T, username string, initObjs ...runtime.Object) (*ReconcileUserAccount, reconcile.Request, *test.FakeClient) {

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -54,9 +56,15 @@ func (a *NSTemplateSetAssertion) HasSpecNamespaces(types ...string) *NSTemplateS
 	require.NoError(a.t, err)
 	require.Len(a.t, a.nsTmplSet.Spec.Namespaces, len(types))
 	for i, nstype := range types {
-		assert.Equal(a.t, nstype, a.nsTmplSet.Spec.Namespaces[i].Type)
+		assert.Equal(a.t, NewTierTemplateName(a.nsTmplSet.Spec.TierName, nstype, "abcde11"), a.nsTmplSet.Spec.Namespaces[i].TemplateRef)
 	}
 	return a
+}
+
+// NewTierTemplateName: a utility func to generate a TierTemplate name, based on the given tier, type and revision.
+// note: the resource name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
+func NewTierTemplateName(tier, typeName, revision string) string {
+	return strings.ToLower(fmt.Sprintf("%s-%s-%s", tier, typeName, revision))
 }
 
 func Provisioned() toolchainv1alpha1.Condition {


### PR DESCRIPTION
This PR migrates the member-operator logic to the templateRef ield in NSTemplateSet. It stops using the legacy ones. 
In additon, it replaces both labels `/tier` and `/revision` with a new one `/templateref`

api PR: https://github.com/codeready-toolchain/api/pull/136
paired PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/110