### PR TITLE
chore: call getTierTemplate function directly

### DIFF
--- a/pkg/controller/nstemplateset/cluster_resources.go
+++ b/pkg/controller/nstemplateset/cluster_resources.go
@@ -26,7 +26,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 	var tierTemplate *tierTemplate
 	var err error
 	if nsTmplSet.Spec.ClusterResources != nil {
-		tierTemplate, err = r.getTemplateContent(nsTmplSet.Spec.ClusterResources.TemplateRef)
+		tierTemplate, err = getTierTemplate(r.getHostCluster, nsTmplSet.Spec.ClusterResources.TemplateRef)
 		if err != nil {
 			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusClusterResourcesProvisionFailed, err,
 				"failed to retrieve TierTemplate for the cluster resources with the name '%s'", nsTmplSet.Spec.ClusterResources.TemplateRef)
@@ -55,7 +55,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 				return false, err
 			}
 
-			currentTierTemplate, err := r.getTemplateContent(currentTemplateRef)
+			currentTierTemplate, err := getTierTemplate(r.getHostCluster, currentTemplateRef)
 			if err != nil {
 				return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err,
 					"failed to retrieve TierTemplate for the cluster resources with the name '%s'", currentTemplateRef)
@@ -121,7 +121,7 @@ func (r *clusterResourcesManager) delete(logger logr.Logger, nsTmplSet *toolchai
 		return false, nil
 	}
 	username := nsTmplSet.Name
-	tierTemplate, err := r.getTemplateContent(nsTmplSet.Spec.ClusterResources.TemplateRef)
+	tierTemplate, err := getTierTemplate(r.getHostCluster, nsTmplSet.Spec.ClusterResources.TemplateRef)
 	if err != nil {
 		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusClusterResourcesProvisionFailed, err,
 			"failed to retrieve TierTemplate for the cluster resources with the name '%s'", nsTmplSet.Spec.ClusterResources.TemplateRef)

--- a/pkg/controller/nstemplateset/cluster_resources_test.go
+++ b/pkg/controller/nstemplateset/cluster_resources_test.go
@@ -151,10 +151,11 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to retrieve template")
+		assert.Contains(t, err.Error(), "failed to retrieve TierTemplate for the cluster resources with the name 'fail-clusterresources-12345bb'")
 		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 			HasFinalizer().
-			HasConditions(UnableToProvisionClusterResources("failed to retrieve template"))
+			HasConditions(UnableToProvisionClusterResources(
+				"unable to retrieve the TierTemplate 'fail-clusterresources-12345bb' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"fail-clusterresources-12345bb\" not found"))
 	})
 
 	t.Run("fail to create cluster resources", func(t *testing.T) {
@@ -470,7 +471,8 @@ func TestPromoteClusterResources(t *testing.T) {
 			assert.False(t, updated)
 			AssertThatNSTemplateSet(t, namespaceName, username, cl).
 				HasFinalizer().
-				HasConditions(UpdateFailed("failed to retrieve template"))
+				HasConditions(UpdateFailed(
+					"unable to retrieve the TierTemplate 'fail-clusterresources-12345bb' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"fail-clusterresources-12345bb\" not found"))
 			AssertThatCluster(t, cl).
 				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "fail-clusterresources-12345bb"),

--- a/pkg/controller/nstemplateset/namespaces.go
+++ b/pkg/controller/nstemplateset/namespaces.go
@@ -118,7 +118,7 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
 			return err
 		}
-		currentTierTemplate, err := r.getTemplateContent(currentRef)
+		currentTierTemplate, err := getTierTemplate(r.getHostCluster, currentRef)
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve current TierTemplate with name '%s'", currentRef)
 		}
@@ -184,7 +184,7 @@ func (r *namespacesManager) delete(logger logr.Logger, nsTmplSet *toolchainv1alp
 func (r *namespacesManager) getTierTemplatesForAllNamespaces(nsTmplSet *toolchainv1alpha1.NSTemplateSet) ([]*tierTemplate, error) {
 	var tmpls []*tierTemplate
 	for _, ns := range nsTmplSet.Spec.Namespaces {
-		nsTmpl, err := r.getTemplateContent(ns.TemplateRef)
+		nsTmpl, err := getTierTemplate(r.getHostCluster, ns.TemplateRef)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/nstemplateset/namespaces_test.go
+++ b/pkg/controller/nstemplateset/namespaces_test.go
@@ -507,10 +507,11 @@ func TestEnsureNamespacesFail(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to retrieve template")
+		assert.Contains(t, err.Error(), "failed to get TierTemplates for tier 'basic'")
 		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 			HasFinalizer().
-			HasConditions(UnableToProvisionNamespace("failed to retrieve template"))
+			HasConditions(UnableToProvisionNamespace(
+				"unable to retrieve the TierTemplate 'basic-fail-abcde11' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"basic-fail-abcde11\" not found"))
 	})
 
 	t.Run("fail to get template for inner resources", func(t *testing.T) {
@@ -524,10 +525,11 @@ func TestEnsureNamespacesFail(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to retrieve template")
+		assert.Contains(t, err.Error(), "failed to get TierTemplates for tier 'basic'")
 		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 			HasFinalizer().
-			HasConditions(UnableToProvisionNamespace("failed to retrieve template"))
+			HasConditions(UnableToProvisionNamespace(
+				"unable to retrieve the TierTemplate 'basic-fail-abcde11' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"basic-fail-abcde11\" not found"))
 	})
 
 }
@@ -768,7 +770,8 @@ func TestPromoteNamespaces(t *testing.T) {
 			require.Error(t, err)
 			AssertThatNSTemplateSet(t, namespaceName, username, cl).
 				HasFinalizer().
-				HasConditions(UpdateFailed("failed to retrieve template"))
+				HasConditions(UpdateFailed(
+					"unable to retrieve the TierTemplate 'fail-dev-abcde11' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"fail-dev-abcde11\" not found"))
 			AssertThatNamespace(t, username+"-dev", cl).
 				HasNoOwnerReference().
 				HasLabel("toolchain.dev.openshift.com/owner", username).

--- a/pkg/controller/nstemplateset/nstemplateset_controller.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller.go
@@ -5,6 +5,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/configuration"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commoncontroller "github.com/codeready-toolchain/toolchain-common/pkg/controller"
 	"github.com/go-logr/logr"
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -30,9 +31,9 @@ var log = logf.Log.WithName("controller_nstemplateset")
 // Add creates a new NSTemplateSetReconciler and starts it (ie, watches resources and reconciles the cluster state)
 func Add(mgr manager.Manager, _ *configuration.Config) error {
 	return add(mgr, newReconciler(&apiClient{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		getTemplateContent: getTemplateFromHost,
+		client:         mgr.GetClient(),
+		scheme:         mgr.GetScheme(),
+		getHostCluster: cluster.GetHostCluster,
 	}))
 }
 
@@ -80,9 +81,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 var _ reconcile.Reconciler = &NSTemplateSetReconciler{}
 
 type apiClient struct {
-	client             client.Client
-	scheme             *runtime.Scheme
-	getTemplateContent getTemplateFromHostFunc
+	client         client.Client
+	scheme         *runtime.Scheme
+	getHostCluster cluster.GetHostClusterFunc
 }
 
 // NSTemplateSetReconciler the NSTemplateSet reconciler
@@ -92,9 +93,6 @@ type NSTemplateSetReconciler struct {
 	clusterResources *clusterResourcesManager
 	status           *statusManager
 }
-
-// getTemplateFromHostFunc is a function that returns a TierTemplate for a given templateRef
-type getTemplateFromHostFunc func(templateRef string) (*tierTemplate, error)
 
 // Reconcile reads that state of the cluster for a NSTemplateSet object and makes changes based on the state read
 // and what is in the NSTemplateSet.Spec

--- a/pkg/controller/nstemplateset/nstemplatetier.go
+++ b/pkg/controller/nstemplateset/nstemplatetier.go
@@ -15,14 +15,9 @@ import (
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 )
 
-// getTemplateFromHost retrieves the TierTemplate resource with the given name from the host cluster
+// getTierTemplate retrieves the TierTemplate resource with the given name from the host cluster
 // and returns an instance of the tierTemplate type for it whose template content can be parsable.
 // The returned tierTemplate contains all data from TierTemplate including its name.
-func getTemplateFromHost(templateRef string) (*tierTemplate, error) {
-	return getTierTemplate(cluster.GetHostCluster, templateRef)
-}
-
-// getTierTemplate gets tierTemplate for the given source and templateRef
 func getTierTemplate(hostClusterFunc cluster.GetHostClusterFunc, templateRef string) (*tierTemplate, error) {
 	if templateRef == "" {
 		return nil, fmt.Errorf("templateRef is not provided - it's not possible to fetch related TierTemplate resource")

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -1,0 +1,37 @@
+package test
+
+import (
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kubefed/pkg/apis/core/common"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
+)
+
+// NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.FedCluster
+// that is returned by the function then contains the given client and the given status.
+// If ok == false, then the function returns nil for the cluster.
+func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) cluster.GetHostClusterFunc {
+	if !ok {
+		return func() (*cluster.FedCluster, bool) {
+			return nil, false
+		}
+	}
+	return func() (fedCluster *cluster.FedCluster, b bool) {
+		return &cluster.FedCluster{
+			Client:            cl,
+			Type:              cluster.Host,
+			OperatorNamespace: test.HostOperatorNs,
+			OwnerClusterName:  test.MemberClusterName,
+			ClusterStatus: &v1beta1.KubeFedClusterStatus{
+				Conditions: []v1beta1.ClusterCondition{{
+					Type:   common.ClusterReady,
+					Status: status,
+				}},
+			},
+		}, true
+	}
+
+}


### PR DESCRIPTION
This is kind of follow-up of the fix from https://github.com/codeready-toolchain/member-operator/commit/1ab8fac311d1fc6ee43c945e897e770d3640a421

This PR changes the way the controller (and managers) retrieve the `TierTemplate` from the host-cluster. Now it calls the `getTierTemplate` function directly (instead of calling via another mockable function) by passing the `cluster.GetHostCluster` function. With this change we are able to properly test the error cases in the whole flow of the reconcile loop. 

In addition, it will help us also with testing the cache functionality that will come in the next PR (I just thought that it would be better to provide smaller PRs with fewer changes in the code)

To be honest, I wanted to change this way of mocking a long time ago, I just haven't had a chance. The failure/bug from the previous week is the reason why I'm changing it now to avoid similar situations in the future. 

The PR also contains commits from the PR https://github.com/codeready-toolchain/member-operator/pull/160 - I want to avoid fixing conflixt as soon as #160 is merged :-)