### PR TITLE
feat: cache TierTemplates retrieved from the host cluster

### DIFF
--- a/pkg/controller/nstemplateset/nstemplatetier.go
+++ b/pkg/controller/nstemplateset/nstemplatetier.go
@@ -83,24 +83,25 @@ func (t *tierTemplate) process(scheme *runtime.Scheme, username string, filters 
 
 type tierTemplateCache struct {
 	sync.RWMutex
-	tierTemplates map[string]*tierTemplate
+	// tierTemplatesByTemplateRef contains tierTemplatesByTemplateRef mapped by TemplateRef key
+	tierTemplatesByTemplateRef map[string]*tierTemplate
 }
 
 func newTierTemplateCache() *tierTemplateCache {
 	return &tierTemplateCache{
-		tierTemplates: map[string]*tierTemplate{},
+		tierTemplatesByTemplateRef: map[string]*tierTemplate{},
 	}
 }
 
 func (c *tierTemplateCache) get(templateRef string) (*tierTemplate, bool) {
 	c.RLock()
 	defer c.RUnlock()
-	tierTemplate, ok := c.tierTemplates[templateRef]
+	tierTemplate, ok := c.tierTemplatesByTemplateRef[templateRef]
 	return tierTemplate, ok
 }
 
 func (c *tierTemplateCache) add(tierTemplate *tierTemplate) {
 	c.Lock()
 	defer c.Unlock()
-	c.tierTemplates[tierTemplate.templateRef] = tierTemplate
+	c.tierTemplatesByTemplateRef[tierTemplate.templateRef] = tierTemplate
 }

--- a/pkg/controller/nstemplateset/nstemplatetier_test.go
+++ b/pkg/controller/nstemplateset/nstemplatetier_test.go
@@ -62,6 +62,7 @@ func TestGetTierTemplate(t *testing.T) {
 	t.Run("return code for basic tier", func(t *testing.T) {
 		// given
 		hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+		defer resetCache()
 		// when
 		tierTmpl, err := getTierTemplate(hostCluster, "basic-code-abcdef")
 
@@ -73,6 +74,7 @@ func TestGetTierTemplate(t *testing.T) {
 	t.Run("return dev for advanced tier", func(t *testing.T) {
 		// given
 		hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+		defer resetCache()
 		// when
 		tierTmpl, err := getTierTemplate(hostCluster, "advanced-dev-789012")
 
@@ -84,6 +86,7 @@ func TestGetTierTemplate(t *testing.T) {
 	t.Run("return cluster type for basic tier", func(t *testing.T) {
 		// given
 		hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+		defer resetCache()
 		// when
 		tierTmpl, err := getTierTemplate(hostCluster, "basic-clusterresources-aa11bb22")
 
@@ -92,13 +95,75 @@ func TestGetTierTemplate(t *testing.T) {
 		assertThatTierTemplateIsSameAs(t, basicTierCluster, tierTmpl)
 	})
 
+	t.Run("test cache", func(t *testing.T) {
+		// given
+		hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+		defer resetCache()
+		_, err := getTierTemplate(hostCluster, "basic-code-abcdef")
+		require.NoError(t, err)
+
+		t.Run("return cached TierTemplate even when for the second call doesn't exist", func(t *testing.T) {
+
+			emptyHost := test.NewGetHostCluster(testcommon.NewFakeClient(t), true, apiv1.ConditionTrue)
+
+			// when
+			tierTmpl, err := getTierTemplate(emptyHost, "basic-code-abcdef")
+
+			// then
+			require.NoError(t, err)
+			assertThatTierTemplateIsSameAs(t, basicTierCode, tierTmpl)
+		})
+
+		t.Run("return cached TierTemplate even when the host cluster was removed", func(t *testing.T) {
+			// given
+			noCluster := test.NewGetHostCluster(cl, false, apiv1.ConditionFalse)
+
+			// when
+			tierTmpl, err := getTierTemplate(noCluster, "basic-code-abcdef")
+
+			// then
+			require.NoError(t, err)
+			assertThatTierTemplateIsSameAs(t, basicTierCode, tierTmpl)
+		})
+
+		t.Run("return cached TierTemplate even when the host cluster is not ready", func(t *testing.T) {
+			// given
+			noCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionFalse)
+
+			// when
+			tierTmpl, err := getTierTemplate(noCluster, "basic-code-abcdef")
+
+			// then
+			require.NoError(t, err)
+			assertThatTierTemplateIsSameAs(t, basicTierCode, tierTmpl)
+		})
+
+		t.Run("return cached TierTemplate even when the host cluster is not ready", func(t *testing.T) {
+			// given
+			noCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionFalse)
+
+			// when
+			tierTmpl, err := getTierTemplate(noCluster, "basic-code-abcdef")
+
+			// then
+			require.NoError(t, err)
+			assertThatTierTemplateIsSameAs(t, basicTierCode, tierTmpl)
+		})
+	})
+
 	t.Run("failures", func(t *testing.T) {
+		// given - no matter if one TierTemplate is cached
+		hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+		defer resetCache()
+		_, err := getTierTemplate(hostCluster, "basic-code-abcdef")
+		require.NoError(t, err)
 
 		t.Run("host cluster not available", func(t *testing.T) {
 			// given
 			hostCluster := test.NewGetHostCluster(cl, false, apiv1.ConditionFalse)
+			defer resetCache()
 			// when
-			_, err := getTierTemplate(hostCluster, "unknown")
+			_, err := getTierTemplate(hostCluster, "advanced-dev-789012")
 			// then
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "unable to connect to the host cluster: unknown cluster")
@@ -107,8 +172,9 @@ func TestGetTierTemplate(t *testing.T) {
 		t.Run("host cluster not ready", func(t *testing.T) {
 			// given
 			hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionFalse)
+			defer resetCache()
 			// when
-			_, err := getTierTemplate(hostCluster, "unknown")
+			_, err := getTierTemplate(hostCluster, "advanced-dev-789012")
 			// then
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "the host cluster is not ready")
@@ -117,6 +183,7 @@ func TestGetTierTemplate(t *testing.T) {
 		t.Run("unknown templateRef", func(t *testing.T) {
 			// given
 			hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+			defer resetCache()
 			// when
 			_, err := getTierTemplate(hostCluster, "unknown")
 			// then
@@ -127,6 +194,7 @@ func TestGetTierTemplate(t *testing.T) {
 		t.Run("tier in another namespace", func(t *testing.T) {
 			// given
 			hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+			defer resetCache()
 			// when
 			_, err := getTierTemplate(hostCluster, "other-other-other")
 			// then
@@ -134,9 +202,10 @@ func TestGetTierTemplate(t *testing.T) {
 			assert.Contains(t, err.Error(), "unable to retrieve the TierTemplate 'other-other-other' from 'Host' cluster")
 		})
 
-		t.Run("tier in another namespace", func(t *testing.T) {
+		t.Run("templateRef is not provided", func(t *testing.T) {
 			// given
 			hostCluster := test.NewGetHostCluster(cl, true, apiv1.ConditionTrue)
+			defer resetCache()
 			// when
 			_, err := getTierTemplate(hostCluster, "")
 			// then
@@ -144,6 +213,14 @@ func TestGetTierTemplate(t *testing.T) {
 			assert.Contains(t, err.Error(), "templateRef is not provided - it's not possible to fetch related TierTemplate resource")
 		})
 	})
+}
+
+func resetCache() func() {
+	reset := func() {
+		cachedTierTemplates = map[string]*tierTemplate{}
+	}
+	reset()
+	return reset
 }
 
 func assertThatTierTemplateIsSameAs(t *testing.T, expected *toolchainv1alpha1.TierTemplate, actual *tierTemplate) {


### PR DESCRIPTION
This PR adds a cache for TierTemplates retrieved from the host cluster. When a TierTemplate is retrieved from the host cluster, then it's stored in a map indexed by its name and for all future calls it uses only the cache instead of calling the host cluster again.