### PR TITLE
chore: use operator-sdk 0.17.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ go:
 
 before_install:
 - pyenv shell 3.6.3
-- OPERATOR_SDK_VERSION=v0.16.0
+- OPERATOR_SDK_VERSION=v0.17.1
 - SKIP_TOOLS=true
 
 install:
 - curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk
 - curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc
-- gpg --keyserver keyserver.ubuntu.com --recv-key 09FCE996
+- gpg --keyserver keyserver.ubuntu.com --recv-key 9AF46519
 - gpg --verify operator-sdk.asc
 - chmod +x operator-sdk
 - cp operator-sdk /home/travis/bin/operator-sdk

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ To run this operator locally you need to have at least one Minishift profile sta
 $ minishift start --profile member
 ```
 
-Then you can run the operator locally with the help of `operator-sdk` (you need version v0.10.0 or higher):
+Then you can run the operator locally with the help of `operator-sdk` (you need version v0.17.1 or higher):
 
 ```bash
 $ make up-local

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -9,7 +9,7 @@ ENV LANG=en_US.utf8 \
     PATH=$PATH:$GOPATH/bin \
     GIT_COMMITTER_NAME=devtools \
     GIT_COMMITTER_EMAIL=devtools@redhat.com \
-    OPERATOR_SDK_VERSION=v0.16.0
+    OPERATOR_SDK_VERSION=v0.17.1
 
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/member-operator
 
@@ -64,7 +64,7 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
 # download, verify and install operator-sdk
 RUN curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk \
     && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc \
-    && gpg --keyserver keyserver.ubuntu.com --recv-key 09FCE996 \
+    && gpg --keyserver keyserver.ubuntu.com --recv-key 9AF46519 \
     && gpg --verify operator-sdk.asc \
     && chmod +x operator-sdk \
     && cp operator-sdk /usr/bin/operator-sdk \


### PR DESCRIPTION
Changes the version of operator-sdk from 0.16.0 to 0.17.1