### PR TITLE
Add member controller

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	"github.com/codeready-toolchain/member-operator/pkg/configuration"
 	"github.com/codeready-toolchain/member-operator/pkg/controller"
+	"github.com/codeready-toolchain/member-operator/pkg/controller/memberstatus"
 	"github.com/codeready-toolchain/member-operator/version"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -164,6 +166,22 @@ func main() {
 	}
 
 	log.Info("Starting the Cmd.")
+
+	go func() {
+		log.Info("Waiting for cache to sync")
+		if !mgr.GetCache().WaitForCacheSync(stopChannel) {
+			log.Error(errors.New("timed out waiting for caches to sync"), "")
+			os.Exit(1)
+		}
+
+		// create or update Member status during the operator deployment
+		log.Info("Creating/updating the MemberStatus resource")
+		if err := memberstatus.CreateOrUpdateResources(mgr.GetClient(), mgr.GetScheme(), namespace); err != nil {
+			log.Error(err, "cannot create/update MemberStatus resource")
+			os.Exit(1)
+		}
+		log.Info("Created/updated the MemberStatus resource")
+	}()
 
 	// Start the Cmd
 	if err := mgr.Start(stopChannel); err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -163,7 +163,8 @@ func main() {
 
 		// create or update Member status during the operator deployment
 		log.Info("Creating/updating the MemberStatus resource")
-		if err := memberstatus.CreateOrUpdateResources(mgr.GetClient(), mgr.GetScheme(), namespace); err != nil {
+		memberStatusName := crtConfig.GetMemberStatusName()
+		if err := memberstatus.CreateOrUpdateResources(mgr.GetClient(), mgr.GetScheme(), namespace, memberStatusName); err != nil {
 			log.Error(err, "cannot create/update MemberStatus resource")
 			os.Exit(1)
 		}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -23,6 +23,12 @@ const (
 
 	// DefaultIdentityProvider the default value used for the identity provider (IdP) for newly created users
 	DefaultIdentityProvider = "rhd"
+
+	// MemberStatusName specifies the name of the toolchain member status resource that provides information about the toolchain components in this cluster
+	MemberStatusName = "member.status"
+
+	// DefaultMemberStatusName the default name for the member status resource created during initialization of the operator
+	DefaultMemberStatusName = "toolchain-member-status"
 )
 
 // Kubefed configuration constants
@@ -71,6 +77,7 @@ func LoadConfig() *Config {
 func (c *Config) setConfigDefaults() {
 	c.member.SetTypeByDefaultValue(true)
 	c.member.SetDefault(IdentityProvider, DefaultIdentityProvider)
+	c.member.SetDefault(MemberStatusName, DefaultMemberStatusName)
 	c.member.SetDefault(ClusterHealthCheckPeriod, DefaultClusterHealthCheckPeriod)
 	c.member.SetDefault(ClusterHealthCheckTimeout, DefaultClusterHealthCheckTimeout)
 	c.member.SetDefault(ClusterHealthCheckFailureThreshold, DefaultClusterHealthCheckFailureThreshold)
@@ -99,6 +106,11 @@ func (c *Config) GetAllMemberParameters() map[string]string {
 // Openshift clusters can be configured with multiple IdPs. This config option allows admins to specify which IdP should be used by the toolchain operator.
 func (c *Config) GetIdP() string {
 	return c.member.GetString(IdentityProvider)
+}
+
+// GetMemberStatusName returns the configured name of the member status resource
+func (c *Config) GetMemberStatusName() string {
+	return c.member.GetString(MemberStatusName)
 }
 
 // GetClusterHealthCheckPeriod returns the configured cluster health check period

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -69,6 +69,27 @@ func TestGetIdP(t *testing.T) {
 	})
 }
 
+func TestGetMemberClusterName(t *testing.T) {
+	key := MemberEnvPrefix + "_MEMBER_STATUS"
+	resetFunc := test.UnsetEnvVarAndRestore(t, key)
+	defer resetFunc()
+
+	t.Run("default", func(t *testing.T) {
+		resetFunc := test.UnsetEnvVarAndRestore(t, key)
+		defer resetFunc()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, "toolchain-member-status", config.GetMemberStatusName())
+	})
+
+	t.Run("env overwrite", func(t *testing.T) {
+		restore := test.SetEnvVarsAndRestore(t,
+			test.Env(key, "testingMemberStatusName"))
+		defer restore()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, "testingMemberStatusName", config.GetMemberStatusName())
+	})
+}
+
 func TestGetClusterHealthCheckPeriod(t *testing.T) {
 	key := MemberEnvPrefix + "_CLUSTER_HEALTHCHECK_PERIOD"
 	resetFunc := test.UnsetEnvVarAndRestore(t, key)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/codeready-toolchain/member-operator/pkg/configuration"
+	"github.com/codeready-toolchain/member-operator/pkg/controller/memberstatus"
 	"github.com/codeready-toolchain/member-operator/pkg/controller/nstemplateset"
 	"github.com/codeready-toolchain/member-operator/pkg/controller/useraccount"
 	"github.com/codeready-toolchain/member-operator/pkg/controller/useraccountstatus"
@@ -12,6 +13,7 @@ import (
 var addToManagerFuncs []func(manager.Manager, *configuration.Config) error
 
 func init() {
+	addToManagerFuncs = append(addToManagerFuncs, memberstatus.Add)
 	addToManagerFuncs = append(addToManagerFuncs, useraccount.Add)
 	addToManagerFuncs = append(addToManagerFuncs, useraccountstatus.Add)
 	addToManagerFuncs = append(addToManagerFuncs, nstemplateset.Add)

--- a/pkg/controller/memberstatus/creation.go
+++ b/pkg/controller/memberstatus/creation.go
@@ -9,15 +9,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateOrUpdateResources(client client.Client, s *runtime.Scheme, namespace string) error {
+func CreateOrUpdateResources(client client.Client, s *runtime.Scheme, namespace, memberStatusName string) error {
 	memberStatus := &v1alpha1.MemberStatus{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: namespace,
-			Name:      defaultMemberStatusName,
+			Name:      memberStatusName,
 		},
 		Spec: v1alpha1.MemberStatusSpec{},
 	}
-	commonclient := commonclient.NewApplyClient(client, s)
-	_, err := commonclient.CreateOrUpdateObject(memberStatus, false, nil)
+	cl := commonclient.NewApplyClient(client, s)
+	_, err := cl.CreateOrUpdateObject(memberStatus, false, nil)
 	return err
 }

--- a/pkg/controller/memberstatus/creation.go
+++ b/pkg/controller/memberstatus/creation.go
@@ -1,0 +1,23 @@
+package memberstatus
+
+import (
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	commonclient "github.com/codeready-toolchain/toolchain-common/pkg/client"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateOrUpdateResources(client client.Client, s *runtime.Scheme, namespace string) error {
+	memberStatus := &v1alpha1.MemberStatus{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      defaultMemberStatusName,
+		},
+		Spec: v1alpha1.MemberStatusSpec{},
+	}
+	commonclient := commonclient.NewApplyClient(client, s)
+	_, err := commonclient.CreateOrUpdateObject(memberStatus, false, nil)
+	return err
+}

--- a/pkg/controller/memberstatus/creation_test.go
+++ b/pkg/controller/memberstatus/creation_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	"github.com/codeready-toolchain/member-operator/pkg/configuration"
+	. "github.com/codeready-toolchain/member-operator/test"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/require"
 
@@ -25,15 +27,13 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		cl := NewFakeClient(t)
 
 		// when
-		err = CreateOrUpdateResources(cl, s, MemberOperatorNs)
+		err = CreateOrUpdateResources(cl, s, MemberOperatorNs, configuration.DefaultMemberStatusName)
 
 		// then
 		require.NoError(t, err)
 
 		// check that the MemberStatus exists now
-		memberStatus := newMemberStatus()
-		err = cl.Get(context.TODO(), NamespacedName(MemberOperatorNs, defaultMemberStatusName), memberStatus)
-		require.NoError(t, err)
+		AssertThatMemberStatus(t, MemberOperatorNs, "toolchain-member-status", cl).Exists()
 	})
 
 	t.Run("should return an error if creation fails ", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 
 		// when
-		err = CreateOrUpdateResources(cl, s, MemberOperatorNs)
+		err = CreateOrUpdateResources(cl, s, MemberOperatorNs, configuration.DefaultMemberStatusName)
 
 		// then
 		require.Error(t, err)

--- a/pkg/controller/memberstatus/creation_test.go
+++ b/pkg/controller/memberstatus/creation_test.go
@@ -1,0 +1,47 @@
+package memberstatus
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCreateOrUpdateResources(t *testing.T) {
+	// given
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+
+	t.Run("creation", func(t *testing.T) {
+		// given
+		cl := NewFakeClient(t)
+
+		// when
+		err = CreateOrUpdateResources(cl, s, MemberOperatorNs)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("should return an error if creation fails ", func(t *testing.T) {
+		// given
+		cl := NewFakeClient(t)
+		cl.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+			return fmt.Errorf("creation failed")
+		}
+
+		// when
+		err = CreateOrUpdateResources(cl, s, MemberOperatorNs)
+
+		// then
+		require.Error(t, err)
+	})
+}

--- a/pkg/controller/memberstatus/creation_test.go
+++ b/pkg/controller/memberstatus/creation_test.go
@@ -29,6 +29,11 @@ func TestCreateOrUpdateResources(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
+
+		// check that the MemberStatus exists now
+		memberStatus := newMemberStatus()
+		err = cl.Get(context.TODO(), NamespacedName(MemberOperatorNs, defaultMemberStatusName), memberStatus)
+		require.NoError(t, err)
 	})
 
 	t.Run("should return an error if creation fails ", func(t *testing.T) {
@@ -43,5 +48,6 @@ func TestCreateOrUpdateResources(t *testing.T) {
 
 		// then
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to create resource")
 	})
 }

--- a/pkg/controller/memberstatus/memberstatus_assertion.go
+++ b/pkg/controller/memberstatus/memberstatus_assertion.go
@@ -1,0 +1,67 @@
+package memberstatus
+
+import (
+	"context"
+	"fmt"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MemberStatusAssertion struct {
+	memberStatus   *toolchainv1alpha1.MemberStatus
+	client         client.Client
+	namespacedName types.NamespacedName
+	t              test.T
+}
+
+func (a *MemberStatusAssertion) loadMemberStatus() error {
+	memberStatus := &toolchainv1alpha1.MemberStatus{}
+	err := a.client.Get(context.TODO(), a.namespacedName, memberStatus)
+	a.memberStatus = memberStatus
+	return err
+}
+
+func AssertThatMemberStatus(t test.T, namespace, name string, client client.Client) *MemberStatusAssertion {
+	return &MemberStatusAssertion{
+		client:         client,
+		namespacedName: test.NamespacedName(namespace, name),
+		t:              t,
+	}
+}
+
+func (a *MemberStatusAssertion) HasNoConditions() *MemberStatusAssertion {
+	err := a.loadMemberStatus()
+	require.NoError(a.t, err)
+	require.Empty(a.t, a.memberStatus.Status.Conditions)
+	return a
+}
+
+func (a *MemberStatusAssertion) HasCondition(expected toolchainv1alpha1.Condition) *MemberStatusAssertion {
+	err := a.loadMemberStatus()
+	require.NoError(a.t, err)
+	test.AssertConditionsMatch(a.t, a.memberStatus.Status.Conditions, expected)
+	return a
+}
+
+func ComponentsReady() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.ConditionReady,
+		Status: corev1.ConditionTrue,
+		Reason: toolchainv1alpha1.MemberStatusAllComponentsReady,
+	}
+}
+
+func ComponentsNotReady(components ...statusComponentTag) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.MemberStatusComponentsNotReady,
+		Message: fmt.Sprintf("Components not ready: %v", components),
+	}
+}

--- a/pkg/controller/memberstatus/memberstatus_controller.go
+++ b/pkg/controller/memberstatus/memberstatus_controller.go
@@ -49,10 +49,6 @@ const (
 	reasonNoDeployment        = "DeploymentNotFound"
 	errMsgCannotGetDeployment = "unable to get the member operator deployment"
 
-	// deployment has unavailable replicas
-	reasonUnavailableReplicas = "DeploymentUnavailableReplicas"
-	errMsgUnavailableReplicas = "the member operator deployment has unavailable replicas"
-
 	// deployment not ready
 	reasonDeploymentConditionNotReady = "DeploymentNotReady"
 	errMsgDeploymentConditionNotReady = "member operator deployment has unready status conditions"
@@ -282,14 +278,6 @@ func (r *ReconcileMemberStatus) memberOperatorHandleStatus(reqLogger logr.Logger
 		return err
 	}
 	operatorStatus.Deployment.Name = memberDeployment.Name
-
-	// check replicas
-	if memberDeployment.Status.UnavailableReplicas > 0 {
-		errCondition := newComponentErrorCondition(reasonUnavailableReplicas, errMsgUnavailableReplicas)
-		operatorStatus.Conditions = []toolchainv1alpha1.Condition{*errCondition}
-		memberStatus.Status.MemberOperator = operatorStatus
-		return fmt.Errorf(errMsgUnavailableReplicas)
-	}
 
 	// get and check conditions
 	for _, condition := range memberDeployment.Status.Conditions {

--- a/pkg/controller/memberstatus/memberstatus_controller.go
+++ b/pkg/controller/memberstatus/memberstatus_controller.go
@@ -1,0 +1,236 @@
+package memberstatus
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/member-operator/pkg/configuration"
+	"github.com/codeready-toolchain/member-operator/version"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+
+	"github.com/go-logr/logr"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/kubefed/pkg/controller/util"
+)
+
+var log = logf.Log.WithName("controller_memberstatus")
+
+// general memberstatus constants
+const (
+	defaultMemberStatusName      = "toolchain-member-status"
+	memberOperatorDeploymentName = "member-operator"
+
+	defaultRequeueTime = time.Second * 10
+)
+
+// statusComponentTags are used in the overall condition to point out which components are not ready
+type statusComponentTag string
+
+const (
+	memberOperator statusComponentTag = "memberOperator"
+	hostConnection statusComponentTag = "hostConnection"
+)
+
+// Add creates a new MemberStatus Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, _ *configuration.Config) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) *ReconcileMemberStatus {
+	return &ReconcileMemberStatus{
+		client:         mgr.GetClient(),
+		scheme:         mgr.GetScheme(),
+		getHostCluster: cluster.GetHostCluster,
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r *ReconcileMemberStatus) error {
+	// create a new controller
+	c, err := controller.New("memberstatus-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// watch for changes to primary resource MemberStatus
+	err = c.Watch(&source.Kind{Type: &toolchainv1alpha1.MemberStatus{}}, &handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileMemberStatus implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileMemberStatus{}
+
+// ReconcileMemberStatus reconciles a MemberStatus object
+type ReconcileMemberStatus struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client         client.Client
+	scheme         *runtime.Scheme
+	getHostCluster func() (*cluster.FedCluster, bool)
+}
+
+// Reconcile reads the state of toolchain member cluster components and updates the MemberStatus resource with information useful for observation or troubleshooting
+func (r *ReconcileMemberStatus) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling MemberStatus")
+
+	// fetch the MemberStatus
+	memberStatus := &toolchainv1alpha1.MemberStatus{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, memberStatus)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// MemberStatus resource not found, log error and return
+			reqLogger.Error(err, "MemberStatus resource was not found")
+		}
+		return reconcile.Result{}, nil
+	}
+
+	err = r.aggregateAndUpdateStatus(reqLogger, memberStatus)
+	if err != nil {
+		reqLogger.Error(err, "Failed to update status")
+	}
+
+	reqLogger.Info(fmt.Sprintf("Finished updating MemberStatus, requeueing after %v", defaultRequeueTime))
+	return reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
+}
+
+type statusHandler struct {
+	Name         statusComponentTag
+	handleStatus func(logger logr.Logger, memberStatus *toolchainv1alpha1.MemberStatus) error
+}
+
+func (r *ReconcileMemberStatus) aggregateAndUpdateStatus(reqLogger logr.Logger, memberStatus *toolchainv1alpha1.MemberStatus) error {
+
+	memberOperatorStatusHandler := statusHandler{Name: memberOperator, handleStatus: r.memberOperatorHandleStatus}
+	hostConnectionStatusHandler := statusHandler{Name: hostConnection, handleStatus: r.hostConnectionHandleStatus}
+
+	statusHandlers := []statusHandler{memberOperatorStatusHandler, hostConnectionStatusHandler}
+
+	// track components that are not ready
+	unreadyComponents := []string{}
+
+	// retrieve component statuses eg. kubefed, member deployment
+	for _, handler := range statusHandlers {
+		err := handler.handleStatus(reqLogger, memberStatus)
+		if err != nil {
+			reqLogger.Error(err, "status update problem")
+			unreadyComponents = append(unreadyComponents, string(handler.Name))
+		}
+	}
+
+	// if any components were not ready then set the overall status to not ready
+	if len(unreadyComponents) > 0 {
+		err := fmt.Errorf("Components not ready: %v", unreadyComponents)
+		return r.setStatusNotReady(memberStatus, err.Error())
+	}
+	return r.setStatusReady(memberStatus)
+}
+
+func (r *ReconcileMemberStatus) hostConnectionHandleStatus(reqLogger logr.Logger, memberStatus *toolchainv1alpha1.MemberStatus) error {
+	// look up host connection status
+	fedCluster, ok := r.getHostCluster()
+	if !ok {
+		return fmt.Errorf("the host connection was not found")
+	}
+	memberStatus.Status.HostConnection = *fedCluster.ClusterStatus.DeepCopy()
+
+	// check conditions of host connection
+	if !util.IsClusterReady(fedCluster.ClusterStatus) {
+		return fmt.Errorf("the host connection is not ready")
+	}
+
+	return nil
+}
+
+func (r *ReconcileMemberStatus) memberOperatorHandleStatus(reqLogger logr.Logger, memberStatus *toolchainv1alpha1.MemberStatus) error {
+	operatorStatus := toolchainv1alpha1.MemberOperatorStatus{
+		Version:        version.Version,
+		Revision:       version.Commit,
+		BuildTimestamp: version.BuildTime,
+	}
+
+	// look up status of member deployment
+	memberDeploymentName := types.NamespacedName{Namespace: memberStatus.Namespace, Name: memberOperatorDeploymentName}
+	memberDeployment := &appsv1.Deployment{}
+	err := r.client.Get(context.TODO(), memberDeploymentName, memberDeployment)
+	if err != nil {
+		return fmt.Errorf("the member operator deployment was not found")
+	}
+
+	// get and check conditions of member deployment
+	conditionsReady := true
+	deploymentConditions := []appsv1.DeploymentCondition{}
+	for _, condition := range memberDeployment.Status.Conditions {
+		deploymentConditions = append(deploymentConditions, condition)
+		conditionsReady = conditionsReady && condition.Status == corev1.ConditionTrue
+	}
+
+	// update member status
+	operatorStatus.Deployment.Name = memberDeployment.Name
+	operatorStatus.Deployment.DeploymentConditions = deploymentConditions
+	memberStatus.Status.MemberOperator = operatorStatus
+
+	if !conditionsReady {
+		return fmt.Errorf("the member operator deployment is not ready")
+	}
+
+	return nil
+}
+
+// updateStatusConditions updates Member status conditions with the new conditions
+func (r *ReconcileMemberStatus) updateStatusConditions(memberStatus *toolchainv1alpha1.MemberStatus, newConditions ...toolchainv1alpha1.Condition) error {
+	// the controller should always update at least the last updated timestamp of the status so the status should be updated regardless of whether
+	// any specific fields were updated. This way a problem with the controller can be indicated if the last updated timestamp was not updated.
+	conditionsWithTimestamps := []toolchainv1alpha1.Condition{}
+	for _, condition := range newConditions {
+		condition.LastTransitionTime = metav1.Now()
+		condition.LastUpdatedTime = &metav1.Time{Time: condition.LastTransitionTime.Time}
+		conditionsWithTimestamps = append(conditionsWithTimestamps, condition)
+	}
+	memberStatus.Status.Conditions = conditionsWithTimestamps
+	return r.client.Status().Update(context.TODO(), memberStatus)
+}
+
+func (r *ReconcileMemberStatus) setStatusReady(memberStatus *toolchainv1alpha1.MemberStatus) error {
+	return r.updateStatusConditions(
+		memberStatus,
+		toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionTrue,
+			Reason: toolchainv1alpha1.MemberStatusAllComponentsReady,
+		})
+}
+
+func (r *ReconcileMemberStatus) setStatusNotReady(memberStatus *toolchainv1alpha1.MemberStatus, message string) error {
+	return r.updateStatusConditions(
+		memberStatus,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.MemberStatusComponentsNotReady,
+			Message: message,
+		})
+}

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -1,0 +1,235 @@
+package memberstatus
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/api/pkg/apis"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	. "github.com/codeready-toolchain/member-operator/test"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var requeueResult = reconcile.Result{RequeueAfter: defaultRequeueTime}
+
+func TestNoMemberStatusFound(t *testing.T) {
+	t.Run("No memberstatus resource found", func(t *testing.T) {
+		// given
+		requestName := "bad-name"
+		getHostClusterFunc := newGetHostClusterReady
+		reconciler, req, _ := prepareReconcile(t, requestName, getHostClusterFunc)
+
+		// when
+		res, err := reconciler.Reconcile(req)
+
+		// then - there should not be any error, the controller should only log that the resource was not found
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, res)
+	})
+}
+
+func TestOverallStatusCondition(t *testing.T) {
+	t.Run("All components ready", func(t *testing.T) {
+		// given
+		requestName := defaultMemberStatusName
+		memberOperatorDeployment := newMemberDeploymentWithConditions(MemberDeploymentReadyCondition(), MemberDeploymentProgressingCondition())
+		memberStatus := newMemberStatus()
+		getHostClusterFunc := newGetHostClusterReady
+		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, memberOperatorDeployment, memberStatus)
+
+		// when
+		res, err := reconciler.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, requeueResult, res)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
+			HasCondition(ComponentsReady())
+	})
+
+	t.Run("Host connection not found", func(t *testing.T) {
+		// given
+		requestName := defaultMemberStatusName
+		memberOperatorDeployment := newMemberDeploymentWithConditions(MemberDeploymentReadyCondition(), MemberDeploymentProgressingCondition())
+		memberStatus := newMemberStatus()
+		getHostClusterFunc := newGetHostClusterNotExist
+		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, memberOperatorDeployment, memberStatus)
+
+		// when
+		res, err := reconciler.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, requeueResult, res)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
+			HasCondition(ComponentsNotReady(hostConnection))
+	})
+
+	t.Run("Host connection not ready", func(t *testing.T) {
+		// given
+		requestName := defaultMemberStatusName
+		memberOperatorDeployment := newMemberDeploymentWithConditions(MemberDeploymentReadyCondition(), MemberDeploymentProgressingCondition())
+		memberStatus := newMemberStatus()
+		getHostClusterFunc := newGetHostClusterNotReady
+		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, memberOperatorDeployment, memberStatus)
+
+		// when
+		res, err := reconciler.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, requeueResult, res)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
+			HasCondition(ComponentsNotReady(hostConnection))
+	})
+
+	t.Run("Member operator deployment not found", func(t *testing.T) {
+		// given
+		requestName := defaultMemberStatusName
+		memberStatus := newMemberStatus()
+		getHostClusterFunc := newGetHostClusterReady
+		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, memberStatus)
+
+		// when
+		res, err := reconciler.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, requeueResult, res)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
+			HasCondition(ComponentsNotReady(memberOperator))
+	})
+
+	t.Run("Member operator deployment not ready", func(t *testing.T) {
+		// given
+		requestName := defaultMemberStatusName
+		memberOperatorDeployment := newMemberDeploymentWithConditions(MemberDeploymentNotReadyCondition(), MemberDeploymentProgressingCondition())
+		memberStatus := newMemberStatus()
+		getHostClusterFunc := newGetHostClusterReady
+		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, memberOperatorDeployment, memberStatus)
+
+		// when
+		res, err := reconciler.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, requeueResult, res)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
+			HasCondition(ComponentsNotReady(memberOperator))
+	})
+
+	t.Run("Member operator deployment not progressing", func(t *testing.T) {
+		// given
+		requestName := defaultMemberStatusName
+		memberOperatorDeployment := newMemberDeploymentWithConditions(MemberDeploymentReadyCondition(), MemberDeploymentNotProgressingCondition())
+		memberStatus := newMemberStatus()
+		getHostClusterFunc := newGetHostClusterReady
+		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, memberOperatorDeployment, memberStatus)
+
+		// when
+		res, err := reconciler.Reconcile(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, requeueResult, res)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
+			HasCondition(ComponentsNotReady(memberOperator))
+	})
+}
+
+func newMemberStatus() *toolchainv1alpha1.MemberStatus {
+	return &toolchainv1alpha1.MemberStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultMemberStatusName,
+			Namespace: test.MemberOperatorNs,
+		},
+	}
+}
+
+func newMemberDeploymentWithConditions(deploymentConditions ...appsv1.DeploymentCondition) *appsv1.Deployment {
+	replicas := int32(1)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      memberOperatorDeploymentName,
+			Namespace: test.MemberOperatorNs,
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: deploymentConditions,
+		},
+	}
+}
+
+func newGetHostClusterReady(fakeClient client.Client) cluster.GetHostClusterFunc {
+	return NewGetHostCluster(fakeClient, true, corev1.ConditionTrue)
+}
+
+func newGetHostClusterNotReady(fakeClient client.Client) cluster.GetHostClusterFunc {
+	return NewGetHostCluster(fakeClient, true, corev1.ConditionFalse)
+}
+
+func newGetHostClusterNotExist(fakeClient client.Client) cluster.GetHostClusterFunc {
+	return NewGetHostCluster(fakeClient, false, corev1.ConditionFalse)
+}
+
+func prepareReconcile(t *testing.T, requestName string, getHostClusterFunc func(fakeClient client.Client) cluster.GetHostClusterFunc, initObjs ...runtime.Object) (*ReconcileMemberStatus, reconcile.Request, *test.FakeClient) {
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	fakeClient := test.NewFakeClient(t, initObjs...)
+
+	r := &ReconcileMemberStatus{
+		client:         fakeClient,
+		scheme:         s,
+		getHostCluster: getHostClusterFunc(fakeClient),
+	}
+	return r, reconcile.Request{test.NamespacedName(test.MemberOperatorNs, requestName)}, fakeClient
+}
+
+func MemberDeploymentReadyCondition() appsv1.DeploymentCondition {
+	return appsv1.DeploymentCondition{
+		Type:   appsv1.DeploymentAvailable,
+		Status: corev1.ConditionTrue,
+	}
+}
+
+func MemberDeploymentNotReadyCondition() appsv1.DeploymentCondition {
+	return appsv1.DeploymentCondition{
+		Type:   appsv1.DeploymentAvailable,
+		Status: corev1.ConditionFalse,
+	}
+}
+
+func MemberDeploymentProgressingCondition() appsv1.DeploymentCondition {
+	return appsv1.DeploymentCondition{
+		Type:   appsv1.DeploymentProgressing,
+		Status: corev1.ConditionTrue,
+	}
+}
+
+func MemberDeploymentNotProgressingCondition() appsv1.DeploymentCondition {
+	return appsv1.DeploymentCondition{
+		Type:   appsv1.DeploymentProgressing,
+		Status: corev1.ConditionFalse,
+	}
+}

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -56,7 +56,7 @@ func TestNoMemberStatusFound(t *testing.T) {
 		// when
 		res, err := reconciler.Reconcile(req)
 
-		// then - there should not be any error, the controller should only log that the resource was not found
+		// then
 		require.Error(t, err)
 		require.Equal(t, expectedErrMsg, err.Error())
 		assert.Equal(t, reconcile.Result{}, res)
@@ -100,7 +100,7 @@ func TestOverallStatusCondition(t *testing.T) {
 		assert.Equal(t, requeueResult, res)
 		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
 			HasCondition(ComponentsNotReady(string(hostConnection)))
-		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).HasHostConnectionConditionErrorMsg(errMsgHostConnectionNotFound)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).HasHostConnectionConditionErrorMsg("the host connection was not found")
 	})
 
 	t.Run("Host connection not ready", func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestOverallStatusCondition(t *testing.T) {
 		assert.Equal(t, requeueResult, res)
 		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
 			HasCondition(ComponentsNotReady(string(memberOperator)))
-		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).HasMemberOperatorConditionErrorMsg(errMsgCannotGetDeployment)
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).HasMemberOperatorConditionErrorMsg("unable to get the member operator deployment")
 	})
 
 	t.Run("Member operator deployment not found", func(t *testing.T) {

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -181,25 +181,6 @@ func TestOverallStatusCondition(t *testing.T) {
 			HasCondition(ComponentsNotReady(string(memberOperator)))
 	})
 
-	t.Run("Member operator deployment replicas unavailable", func(t *testing.T) {
-		// given
-		requestName := defaultMemberStatusName
-		memberOperatorDeployment := newMemberDeploymentWithConditions(t, MemberDeploymentReadyCondition(), MemberDeploymentProgressingCondition())
-		memberOperatorDeployment.Status.UnavailableReplicas = 1
-		memberStatus := newMemberStatus()
-		getHostClusterFunc := newGetHostClusterReady
-		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, memberOperatorDeployment, memberStatus)
-
-		// when
-		res, err := reconciler.Reconcile(req)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, requeueResult, res)
-		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
-			HasCondition(ComponentsNotReady(string(memberOperator)))
-	})
-
 	t.Run("Member operator deployment not ready", func(t *testing.T) {
 		// given
 		requestName := defaultMemberStatusName

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -4,6 +4,8 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
@@ -29,6 +31,33 @@ func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) clu
 				Conditions: []v1beta1.ClusterCondition{{
 					Type:   common.ClusterReady,
 					Status: status,
+				}},
+			},
+		}, true
+	}
+
+}
+
+// NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.FedCluster
+// that is returned by the function then contains the given client and the given status and lastProbeTime.
+// If ok == false, then the function returns nil for the cluster.
+func NewGetHostClusterWithProbe(cl client.Client, ok bool, status v1.ConditionStatus, lastProbeTime metav1.Time) cluster.GetHostClusterFunc {
+	if !ok {
+		return func() (*cluster.FedCluster, bool) {
+			return nil, false
+		}
+	}
+	return func() (fedCluster *cluster.FedCluster, b bool) {
+		return &cluster.FedCluster{
+			Client:            cl,
+			Type:              cluster.Host,
+			OperatorNamespace: test.HostOperatorNs,
+			OwnerClusterName:  test.MemberClusterName,
+			ClusterStatus: &v1beta1.KubeFedClusterStatus{
+				Conditions: []v1beta1.ClusterCondition{{
+					Type:          common.ClusterReady,
+					Status:        status,
+					LastProbeTime: lastProbeTime,
 				}},
 			},
 		}, true

--- a/test/memberstatus_assertion.go
+++ b/test/memberstatus_assertion.go
@@ -1,4 +1,4 @@
-package memberstatus
+package test
 
 import (
 	"context"
@@ -57,7 +57,7 @@ func ComponentsReady() toolchainv1alpha1.Condition {
 	}
 }
 
-func ComponentsNotReady(components ...statusComponentTag) toolchainv1alpha1.Condition {
+func ComponentsNotReady(components ...string) toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:    toolchainv1alpha1.ConditionReady,
 		Status:  corev1.ConditionFalse,

--- a/test/memberstatus_assertion.go
+++ b/test/memberstatus_assertion.go
@@ -49,6 +49,20 @@ func (a *MemberStatusAssertion) HasCondition(expected toolchainv1alpha1.Conditio
 	return a
 }
 
+func (a *MemberStatusAssertion) HasMemberOperatorConditionErrorMsg(msg string) *MemberStatusAssertion {
+	err := a.loadMemberStatus()
+	require.NoError(a.t, err)
+	require.Contains(a.t, a.memberStatus.Status.MemberOperator.Conditions[0].Message, msg)
+	return a
+}
+
+func (a *MemberStatusAssertion) HasHostConnectionConditionErrorMsg(msg string) *MemberStatusAssertion {
+	err := a.loadMemberStatus()
+	require.NoError(a.t, err)
+	require.Contains(a.t, *a.memberStatus.Status.HostConnection.Conditions[0].Message, msg)
+	return a
+}
+
 func ComponentsReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,

--- a/test/memberstatus_assertion.go
+++ b/test/memberstatus_assertion.go
@@ -35,6 +35,12 @@ func AssertThatMemberStatus(t test.T, namespace, name string, client client.Clie
 	}
 }
 
+func (a *MemberStatusAssertion) Exists() *MemberStatusAssertion {
+	err := a.loadMemberStatus()
+	require.NoError(a.t, err)
+	return a
+}
+
 func (a *MemberStatusAssertion) HasNoConditions() *MemberStatusAssertion {
 	err := a.loadMemberStatus()
 	require.NoError(a.t, err)
@@ -76,6 +82,6 @@ func ComponentsNotReady(components ...string) toolchainv1alpha1.Condition {
 		Type:    toolchainv1alpha1.ConditionReady,
 		Status:  corev1.ConditionFalse,
 		Reason:  toolchainv1alpha1.MemberStatusComponentsNotReady,
-		Message: fmt.Sprintf("Components not ready: %v", components),
+		Message: fmt.Sprintf("components not ready: %v", components),
 	}
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-667

Link to PR tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/128

This PR adds a controller for the new MemberStatus resource. Its responsibility is to read the state of toolchain member cluster components and update the MemberStatus resource with information useful for observation or troubleshooting. For more details about the MemberStatus resource see the related issue.

Example:
```
apiVersion: toolchain.dev.openshift.com/v1alpha1
kind: MemberStatus
metadata:
  annotations:
    toolchain.dev.openshift.com/last-applied-configuration: '{"metadata":{"name":"toolchain-member-status","namespace":"rsenthil-member-operator","creationTimestamp":null},"spec":{},"status":{"memberOperator":{"version":"","revision":"","buildTimestamp":"","deployment":{"name":""}},"hostConnection":{"conditions":null}}}'
  creationTimestamp: "2020-06-30T02:36:55Z"
  generation: 1
  name: toolchain-member-status
  namespace: rsenthil-member-operator
  resourceVersion: "1840440"
  selfLink: /apis/toolchain.dev.openshift.com/v1alpha1/namespaces/rsenthil-member-operator/memberstatuses/toolchain-member-status
  uid: d19e0e89-5eb8-4cd6-abd1-7e1bc96ca4d4
spec: {}
status:
  conditions:
  - lastTransitionTime: "2020-06-30T09:48:29Z"
    lastUpdatedTime: "2020-06-30T09:48:29Z"
    message: 'components not ready: [memberOperator hostConnection]'
    reason: ComponentsNotReady
    status: "False"
    type: Ready
  hostConnection:
    conditions:
    - lastProbeTime: "2020-06-30T09:48:19Z"
      lastTransitionTime: "2020-06-30T09:46:59Z"
      message: /healthz responded with ok
      reason: ClusterReady
      status: "True"
      type: Ready
    - lastProbeTime: "2020-06-30T09:48:19Z"
      message: 'exceeded the maximum duration since the last probe: 39s'
      reason: KubefedLastProbeTimeExceeded
      status: "False"
      type: Ready
    region: ""
  memberOperator:
    buildTimestamp: "2020-06-30T19:58:59Z"
    conditions:
    - lastTransitionTime: "2020-06-30T09:48:29Z"
      lastUpdatedTime: "2020-06-30T09:48:29Z"
      message: the member operator deployment has unavailable replicas
      reason: DeploymentUnavailableReplicas
      status: "False"
      type: Ready
    deployment:
      name: member-operator
    revision: e38ad2d0883e3295ae32a26d96c04dfc7a9cb57c-dirty
    version: 0.0.1
```