### PR TITLE
Generated files for memberstatus Host field

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -80,6 +80,46 @@ spec:
               x-kubernetes-list-map-keys:
               - type
               x-kubernetes-list-type: map
+            host:
+              description: Host is the status of the connection with the host cluster
+              properties:
+                conditions:
+                  description: 'Conditions is an array of current member operator
+                    status conditions Supported condition types: ConditionReady'
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transit from one status
+                          to another.
+                        format: date-time
+                        type: string
+                      lastUpdatedTime:
+                        description: Last time the condition was updated
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human readable message indicating details about
+                          last transition.
+                        type: string
+                      reason:
+                        description: (brief) reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        type: string
+                      type:
+                        description: Type of condition
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - type
+                  x-kubernetes-list-type: map
+              type: object
             hostConnection:
               description: HostConnection is the status of the connection with the
                 host cluster

--- a/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -80,6 +80,46 @@ spec:
               x-kubernetes-list-map-keys:
               - type
               x-kubernetes-list-type: map
+            host:
+              description: Host is the status of the connection with the host cluster
+              properties:
+                conditions:
+                  description: 'Conditions is an array of current member operator
+                    status conditions Supported condition types: ConditionReady'
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transit from one status
+                          to another.
+                        format: date-time
+                        type: string
+                      lastUpdatedTime:
+                        description: Last time the condition was updated
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human readable message indicating details about
+                          last transition.
+                        type: string
+                      reason:
+                        description: (brief) reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False,
+                          Unknown.
+                        type: string
+                      type:
+                        description: Type of condition
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - type
+                  x-kubernetes-list-type: map
+              type: object
             hostConnection:
               description: HostConnection is the status of the connection with the
                 host cluster

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -213,6 +213,46 @@ data:
                     x-kubernetes-list-map-keys:
                     - type
                     x-kubernetes-list-type: map
+                  host:
+                    description: Host is the status of the connection with the host cluster
+                    properties:
+                      conditions:
+                        description: 'Conditions is an array of current member operator
+                          status conditions Supported condition types: ConditionReady'
+                        items:
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transit from one status
+                                to another.
+                              format: date-time
+                              type: string
+                            lastUpdatedTime:
+                              description: Last time the condition was updated
+                              format: date-time
+                              type: string
+                            message:
+                              description: Human readable message indicating details about
+                                last transition.
+                              type: string
+                            reason:
+                              description: (brief) reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of condition
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
+                    type: object
                   hostConnection:
                     description: HostConnection is the status of the connection with the
                       host cluster


### PR DESCRIPTION
This PR contains generated files for the new Host field of the MemberStatus API that will be used to report the host connection status with toolchain Condition type instead of Kubefed types.