### PR TITLE
Use new member status api for host connection and update component error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/member-operator
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20200723153455-d67a817098f1
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200717175027-3b8c7e68e409
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200727132335-45a8b65706a7
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
@@ -30,7 +30,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.17.4 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200724174544-dcc42a88fe4f
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200723191159-d586549bf973
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200724174544-dcc42a88fe4f
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd
+	github.com/codeready-toolchain/api v0.0.0-20200723153455-d67a817098f1
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.2.0+incompatible
@@ -30,5 +30,7 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.17.4 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200723191159-d586549bf973
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20200723153455-d67a817098f1 h1:zirUdxPny2qjb43035mkobKpVI4/DS+qu942C4cCveU=
 github.com/codeready-toolchain/api v0.0.0-20200723153455-d67a817098f1/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200727132335-45a8b65706a7 h1:RTHVKHr6SdvAoiyuYNofXY4tvlhbMobopR1Zbn3phfU=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200727132335-45a8b65706a7/go.mod h1:6LLJnPS0JrwsfGzLlTceZPs0EuCatrj0an04af1yBCc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -744,8 +746,6 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/toolchain-common v0.0.0-20200724174544-dcc42a88fe4f h1:Qgb9WOga0eVEkdhYPZpHmQCNfi577BONuNFoqXgd1yc=
-github.com/rajivnathan/toolchain-common v0.0.0-20200724174544-dcc42a88fe4f/go.mod h1:6LLJnPS0JrwsfGzLlTceZPs0EuCatrj0an04af1yBCc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/go.sum
+++ b/go.sum
@@ -138,10 +138,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd h1:G54EWvJPeJer/p07NuKKMYmXKscSnQcRMTH63AzWN+w=
-github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d h1:N9CxG2CBZk4JQsFR5lI96Km0dNBNIgxBWlCRB/UooB0=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d/go.mod h1:IC9kx4UmJCII7dEmH2ChvgGYcmZ/o9P6F/b89UvEHOw=
+github.com/codeready-toolchain/api v0.0.0-20200723153455-d67a817098f1 h1:zirUdxPny2qjb43035mkobKpVI4/DS+qu942C4cCveU=
+github.com/codeready-toolchain/api v0.0.0-20200723153455-d67a817098f1/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -745,6 +743,8 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/toolchain-common v0.0.0-20200723191159-d586549bf973 h1:Zk9UFxJpBHHTWQXZa9AmdMR+3djlRoPpUwWf8Kc9n1w=
+github.com/rajivnathan/toolchain-common v0.0.0-20200723191159-d586549bf973/go.mod h1:6LLJnPS0JrwsfGzLlTceZPs0EuCatrj0an04af1yBCc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/toolchain-common v0.0.0-20200723191159-d586549bf973 h1:Zk9UFxJpBHHTWQXZa9AmdMR+3djlRoPpUwWf8Kc9n1w=
-github.com/rajivnathan/toolchain-common v0.0.0-20200723191159-d586549bf973/go.mod h1:6LLJnPS0JrwsfGzLlTceZPs0EuCatrj0an04af1yBCc=
+github.com/rajivnathan/toolchain-common v0.0.0-20200724174544-dcc42a88fe4f h1:Qgb9WOga0eVEkdhYPZpHmQCNfi577BONuNFoqXgd1yc=
+github.com/rajivnathan/toolchain-common v0.0.0-20200724174544-dcc42a88fe4f/go.mod h1:6LLJnPS0JrwsfGzLlTceZPs0EuCatrj0an04af1yBCc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -106,7 +106,7 @@ func TestOverallStatusCondition(t *testing.T) {
 		assert.Equal(t, requeueResult, res)
 		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
 			HasCondition(ComponentsNotReady(string(hostConnection)))
-		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).HasHostConnectionConditionErrorMsg("the cluster connection was not found")
+		AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).HasHostConditionErrorMsg("the cluster connection was not found")
 	})
 
 	t.Run("Host connection not ready", func(t *testing.T) {

--- a/test/memberstatus_assertion.go
+++ b/test/memberstatus_assertion.go
@@ -63,11 +63,11 @@ func (a *MemberStatusAssertion) HasMemberOperatorConditionErrorMsg(expected stri
 	return a
 }
 
-func (a *MemberStatusAssertion) HasHostConnectionConditionErrorMsg(expected string) *MemberStatusAssertion {
+func (a *MemberStatusAssertion) HasHostConditionErrorMsg(expected string) *MemberStatusAssertion {
 	err := a.loadMemberStatus()
 	require.NoError(a.t, err)
-	require.Len(a.t, a.memberStatus.Status.HostConnection.Conditions, 1)
-	require.Equal(a.t, expected, *a.memberStatus.Status.HostConnection.Conditions[0].Message)
+	require.Len(a.t, a.memberStatus.Status.Host.Conditions, 1)
+	require.Equal(a.t, expected, a.memberStatus.Status.Host.Conditions[0].Message)
 	return a
 }
 


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/toolchain-common/pull/118

This PR updates the member status controller to use the new memberStatus.Status.Host field which now uses Toolchain Conditions instead of Kubefed conditions. It also updates to use `ValidateComponentConditionReady` to get errors directly from the component conditions.