### PR TITLE
removing key/value prefix strings when logging

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -258,7 +258,7 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 func printConfig(cfg *configuration.Config) {
 	logWithValuesMemberOperator := log
 	for key, value := range cfg.GetAllMemberParameters() {
-		logWithValuesMemberOperator = logWithValuesMemberOperator.WithValues("key", key, "value", value)
+		logWithValuesMemberOperator = logWithValuesMemberOperator.WithValues(key, value)
 	}
 	logWithValuesMemberOperator.Info("Member operator configuration variables:")
 }


### PR DESCRIPTION
This PR makes printing the config the same as what is done in the host-operator - https://github.com/codeready-toolchain/host-operator/blob/master/cmd/manager/main.go#L277-L289 

It removes "key": "key1", "value":"value1" and replaces with "key1":"value1"