### PR TITLE
fix: start metrics server at operator startup

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -239,11 +239,7 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 	}
 
 	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
-	if err != nil {
-		return err
-	}
-	return nil
+	return kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 }
 
 func printConfig(cfg *configuration.Config) {

--- a/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain-member-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain-member-operator.clusterserviceversion.yaml
@@ -279,6 +279,7 @@ spec:
           resources:
           - pods
           - services
+          - services/finalizers
           - endpoints
           - persistentvolumeclaims
           - events

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -8,6 +8,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -1113,6 +1113,7 @@ data:
                 resources:
                 - pods
                 - services
+                - services/finalizers
                 - endpoints
                 - persistentvolumeclaims
                 - events


### PR DESCRIPTION
add missing role on `services/finalizers`

E2E Tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/143

(similar to https://github.com/codeready-toolchain/host-operator/pull/262)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
