### PR TITLE
reset syncindex on MasterUserRecord when UserAccount is deleted

### DIFF
--- a/pkg/controller/nstemplateset/cluster_resources.go
+++ b/pkg/controller/nstemplateset/cluster_resources.go
@@ -310,7 +310,7 @@ func (r *clusterResourcesManager) delete(logger logr.Logger, nsTmplSet *toolchai
 				continue
 			}
 
-			logger.Info("deleting cluster resource", "name", toDelete.GetName())
+			logger.Info("deleting cluster resource", "name", toDelete.GetName(), "kind", toDelete.GetGvk().Kind)
 			if err := r.client.Delete(context.TODO(), toDelete.GetRuntimeObject()); err != nil && errors.IsNotFound(err) {
 				// ignore case where the resource did not exist anymore, move to the next one to delete
 				continue

--- a/pkg/controller/nstemplateset/namespaces_test.go
+++ b/pkg/controller/nstemplateset/namespaces_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	. "github.com/codeready-toolchain/member-operator/test"
@@ -564,7 +563,7 @@ func TestDeleteNamespsace(t *testing.T) {
 		cl.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 			if obj, ok := obj.(*corev1.Namespace); ok {
 				// mark namespaces as deleted...
-				deletionTS := metav1.NewTime(time.Now())
+				deletionTS := metav1.Now()
 				obj.SetDeletionTimestamp(&deletionTS)
 				// ... but replace them in the fake client cache yet instead of deleting them
 				return cl.Client.Update(ctx, obj)

--- a/pkg/controller/nstemplateset/nstemplateset_controller_test.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
@@ -1120,7 +1119,7 @@ func withoutFinalizer() nsTmplSetOption {
 
 func withDeletionTs() nsTmplSetOption {
 	return func(nsTmplSet *toolchainv1alpha1.NSTemplateSet) {
-		deletionTS := metav1.NewTime(time.Now())
+		deletionTS := metav1.Now()
 		nsTmplSet.SetDeletionTimestamp(&deletionTS)
 	}
 }

--- a/pkg/controller/useraccountstatus/useraccount_status_controller_test.go
+++ b/pkg/controller/useraccountstatus/useraccount_status_controller_test.go
@@ -3,7 +3,6 @@ package useraccountstatus
 import (
 	"context"
 	"testing"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
@@ -47,7 +46,7 @@ func TestUpdateMasterUserRecordWithSingleEmbeddedUserAccount(t *testing.T) {
 		t.Run("should reset the syncIndex", func(t *testing.T) {
 			// given
 			userAcc := newUserAccount("foo", "222222")
-			now := metav1.NewTime(time.Now())
+			now := metav1.Now()
 			userAcc.DeletionTimestamp = &now
 			cntrl, hostClient := newReconcileStatus(t, userAcc, mur, true, v1.ConditionTrue)
 


### PR DESCRIPTION
Reset to "0" the SyncIndex on the MasterUserRecord.
The MasterUserRecord Controller will react accordingly.

Also, smaller changes:
- reorder return parameters
- add logger to display more messages
- reword error message
- reorganize subtests in categories (success vs failure)

Updates https://issues.redhat.com/browse/CRT-778

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
