### PR TITLE
feat: make MemberStatus requeue/refresh time configurable

### DIFF
--- a/deploy/env/e2e-tests.yaml
+++ b/deploy/env/e2e-tests.yaml
@@ -1,2 +1,3 @@
 member-operator:
   cluster-healthcheck-period: '5s'
+  memberstatus-refresh-time: '1s'

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a
+	github.com/codeready-toolchain/api v0.0.0-20200907133933-475266b2a386
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.3.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,10 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a h1:bkbQYgp0jmiLoUPrn/8xbcaxZxBaeJQyxElpIhdBvz8=
 github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
+github.com/codeready-toolchain/api v0.0.0-20200907133933-475266b2a386 h1:VRSALNcztJg+/bBr4QTTCLMgwnpq+UPpa+QA5kk8jUw=
+github.com/codeready-toolchain/api v0.0.0-20200907133933-475266b2a386/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886 h1:q+oeKCBgOij4NeO12YizGPOU/PNXPWNP39T8qXzOXzM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -867,8 +871,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
-github.com/xcoulon/toolchain-common v0.0.0-20200902135505-09e93be9559a h1:9ZmPejkMV67l9bPhvzMCBy0oyMiudstNdYHAs0AyLxw=
-github.com/xcoulon/toolchain-common v0.0.0-20200902135505-09e93be9559a/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -26,6 +26,12 @@ const (
 
 	// DefaultMemberStatusName the default name for the member status resource created during initialization of the operator
 	DefaultMemberStatusName = "toolchain-member-status"
+
+	// varMemberStatusRefreshTime specifies how often the MemberStatus should load and refresh the current member cluster status
+	varMemberStatusRefreshTime = "memberstatus.refresh.time"
+
+	// defaultMemberStatusRefreshTime is the default refresh period for MemberStatus
+	defaultMemberStatusRefreshTime = "5s"
 )
 
 // ToolchainCluster configuration constants
@@ -75,6 +81,7 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(clusterHealthCheckPeriod, defaultClusterHealthCheckPeriod)
 	c.member.SetDefault(toolchainClusterTimeout, defaultClusterHealthCheckTimeout)
 	c.member.SetDefault(identityProviderName, defaultIdentityProviderName)
+	c.member.SetDefault(varMemberStatusRefreshTime, defaultMemberStatusRefreshTime)
 }
 
 // GetAllMemberParameters returns the map with key-values pairs of parameters that have MEMBER_OPERATOR prefix
@@ -112,4 +119,9 @@ func (c *Config) GetClusterHealthCheckPeriod() time.Duration {
 // GetToolchainClusterTimeout returns the configured cluster health check timeout
 func (c *Config) GetToolchainClusterTimeout() time.Duration {
 	return c.member.GetDuration(toolchainClusterTimeout)
+}
+
+// GetMemberStatusRefreshTime returns the time how often the MemberStatus should load and refresh the current hosted-toolchain status
+func (c *Config) GetMemberStatusRefreshTime() time.Duration {
+	return c.member.GetDuration(varMemberStatusRefreshTime)
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -198,3 +198,26 @@ func TestGetClusterHealthCheckTimeout(t *testing.T) {
 		assert.Equal(t, cast.ToDuration("30s"), config.GetToolchainClusterTimeout())
 	})
 }
+
+func TestGetMemberStatusRefreshTime(t *testing.T) {
+	key := MemberEnvPrefix + "_" + "MEMBERSTATUS_REFRESH_TIME"
+	resetFunc := test.UnsetEnvVarAndRestore(t, key)
+	defer resetFunc()
+
+	t.Run("default", func(t *testing.T) {
+		resetFunc := test.UnsetEnvVarAndRestore(t, key)
+		defer resetFunc()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, cast.ToDuration("5s"), config.GetMemberStatusRefreshTime())
+	})
+
+	t.Run("env overwrite", func(t *testing.T) {
+		restore := test.SetEnvVarAndRestore(t, key, "1s")
+		defer restore()
+
+		restore = test.SetEnvVarAndRestore(t, MemberEnvPrefix+"_"+"ANY_CONFIG", "20s")
+		defer restore()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, cast.ToDuration("1s"), config.GetMemberStatusRefreshTime())
+	})
+}

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var requeueResult = reconcile.Result{RequeueAfter: defaultRequeueTime}
+var requeueResult = reconcile.Result{RequeueAfter: 5 * time.Second}
 
 const defaultMemberOperatorName = "member-operator"
 


### PR DESCRIPTION
make MemberStatus requeue/refresh time configurable so we don't need to wait for the updates 5 seconds