### PR TITLE
Idler: don't watch all namespaces/pods

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	// Set default manager options
 	options := manager.Options{
-		Namespace:          "", // Watch all namespaces! Idler needs to watch Pods from all namespaces
+		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	}
 

--- a/pkg/controller/idler/idler_controller.go
+++ b/pkg/controller/idler/idler_controller.go
@@ -101,9 +101,10 @@ func (r *ReconcileIdler) Reconcile(request reconcile.Request) (reconcile.Result,
 	// Find the earlier pod to kill and requeue with the delay of one hour
 	// or with the earlier timout left for the next pod to delete whichever is the earliest.
 	d := nextPodToBeKilledAfter(idler)
-	oneHour := time.Hour
-	if d == nil || *d > oneHour {
-		d = &oneHour
+	if d == nil {
+		// No pods tracked. Requeue after the idler timout so we don't miss new pods created withing the timeout.
+		timeout := time.Duration(idler.Spec.TimeoutSeconds) * time.Second
+		d = &timeout
 	}
 	return reconcile.Result{
 		Requeue:      true,

--- a/pkg/controller/idler/idler_controller.go
+++ b/pkg/controller/idler/idler_controller.go
@@ -101,17 +101,14 @@ func (r *ReconcileIdler) Reconcile(request reconcile.Request) (reconcile.Result,
 	// Find the earlier pod to kill and requeue with the delay of one hour
 	// or with the earlier timout left for the next pod to delete whichever is the earliest.
 	d := nextPodToBeKilledAfter(idler)
-	if d != nil {
-		h := time.Hour
-		if *d > h {
-			d = &h
-		}
-		return reconcile.Result{
-			Requeue:      true,
-			RequeueAfter: *d,
-		}, r.setStatusReady(idler)
+	oneHour := time.Hour
+	if d == nil || *d > oneHour {
+		d = &oneHour
 	}
-	return reconcile.Result{}, r.setStatusReady(idler)
+	return reconcile.Result{
+		Requeue:      true,
+		RequeueAfter: *d,
+	}, r.setStatusReady(idler)
 }
 
 func (r *ReconcileIdler) ensureIdling(logger logr.Logger, idler *toolchainv1alpha1.Idler) error {

--- a/pkg/controller/idler/idler_controller.go
+++ b/pkg/controller/idler/idler_controller.go
@@ -98,8 +98,7 @@ func (r *ReconcileIdler) Reconcile(request reconcile.Request) (reconcile.Result,
 		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(logger, idler, r.setStatusFailed, err,
 			"failed to ensure idling '%s'", idler.Name)
 	}
-	// Find the earlier pod to kill and requeue with the delay of one hour
-	// or with the earlier timout left for the next pod to delete whichever is the earliest.
+	// Find the earlier pod to kill
 	d := nextPodToBeKilledAfter(idler)
 	if d == nil {
 		// No pods tracked. Requeue after the idler timout so we don't miss new pods created withing the timeout.

--- a/pkg/controller/idler/idler_controller.go
+++ b/pkg/controller/idler/idler_controller.go
@@ -101,7 +101,7 @@ func (r *ReconcileIdler) Reconcile(request reconcile.Request) (reconcile.Result,
 	// Find the earlier pod to kill
 	d := nextPodToBeKilledAfter(idler)
 	if d == nil {
-		// No pods tracked. Requeue after the idler timout so we don't miss new pods created withing the timeout.
+		// No pods tracked. Requeue after the idler timout so we don't miss new pods created within the timeout.
 		timeout := time.Duration(idler.Spec.TimeoutSeconds) * time.Second
 		d = &timeout
 	}

--- a/pkg/controller/idler/idler_controller_test.go
+++ b/pkg/controller/idler/idler_controller_test.go
@@ -102,7 +102,11 @@ func TestEnsureIdling(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, res)
+		// requeue after the idler timeout
+		assert.Equal(t, reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: 30 * time.Second,
+		}, res)
 		memberoperatortest.AssertThatIdler(t, idler.Name, cl).HasConditions(memberoperatortest.Running())
 	})
 
@@ -236,8 +240,11 @@ func TestEnsureIdling(t *testing.T) {
 						memberoperatortest.AssertThatIdler(t, idler.Name, cl).
 							TracksPods([]*corev1.Pod{}).
 							HasConditions(memberoperatortest.Running())
-
-						assert.Equal(t, reconcile.Result{}, res)
+						// requeue after the idler timeout
+						assert.Equal(t, reconcile.Result{
+							Requeue:      true,
+							RequeueAfter: time.Minute,
+						}, res)
 					})
 				})
 			})

--- a/pkg/controller/idler/idler_controller_test.go
+++ b/pkg/controller/idler/idler_controller_test.go
@@ -222,7 +222,7 @@ func TestEnsureIdling(t *testing.T) {
 					assert.True(t, res.Requeue)
 					assert.Less(t, int64(res.RequeueAfter), int64(time.Duration(idler.Spec.TimeoutSeconds)*time.Second))
 
-					t.Run("No pods. No requeue.", func(t *testing.T) {
+					t.Run("No pods - requeue after the idler timeout", func(t *testing.T) {
 						//given
 						// cleanup remaining pods
 						pods := append(podsTooEarlyToKill.allPods, podsRunningForTooLong.controlledPods...)


### PR DESCRIPTION
This is an implementation of the @MatousJobanek's idea of watching the Idler only and not watching pods at all. So, we could stop watching all namespaces for now.

TODO:
- [x] adjust tests
