### PR TITLE
Revert "Idler: don't watch all namespaces/pods (#201)"

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	// Set default manager options
 	options := manager.Options{
-		Namespace:          namespace,
+		Namespace:          "", // Watch all namespaces! Idler needs to watch Pods from all namespaces
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	}
 

--- a/pkg/controller/idler/idler_controller_test.go
+++ b/pkg/controller/idler/idler_controller_test.go
@@ -102,11 +102,7 @@ func TestEnsureIdling(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		// requeue after the idler timeout
-		assert.Equal(t, reconcile.Result{
-			Requeue:      true,
-			RequeueAfter: 30 * time.Second,
-		}, res)
+		assert.Equal(t, reconcile.Result{}, res)
 		memberoperatortest.AssertThatIdler(t, idler.Name, cl).HasConditions(memberoperatortest.Running())
 	})
 
@@ -222,7 +218,7 @@ func TestEnsureIdling(t *testing.T) {
 					assert.True(t, res.Requeue)
 					assert.Less(t, int64(res.RequeueAfter), int64(time.Duration(idler.Spec.TimeoutSeconds)*time.Second))
 
-					t.Run("No pods - requeue after the idler timeout", func(t *testing.T) {
+					t.Run("No pods. No requeue.", func(t *testing.T) {
 						//given
 						// cleanup remaining pods
 						pods := append(podsTooEarlyToKill.allPods, podsRunningForTooLong.controlledPods...)
@@ -240,11 +236,8 @@ func TestEnsureIdling(t *testing.T) {
 						memberoperatortest.AssertThatIdler(t, idler.Name, cl).
 							TracksPods([]*corev1.Pod{}).
 							HasConditions(memberoperatortest.Running())
-						// requeue after the idler timeout
-						assert.Equal(t, reconcile.Result{
-							Requeue:      true,
-							RequeueAfter: time.Minute,
-						}, res)
+
+						assert.Equal(t, reconcile.Result{}, res)
 					})
 				})
 			})


### PR DESCRIPTION
Unfortunately this solution doesn't work.
If we set the manager option to the specific namespace instead of "" (all namespaces) then it affects not only watchers but also `List()` in the client. It seems to return an empty list if we try to list from a different namespace.
We do use `Get()` in NSTemaplateSet controller which seems to be working with other namespaces. Not sure why `List()` works differently though.
It requires additional investigation. We also really have to add some e2e tests for the idler. It's impossible to test it properly in unit tests.

Until this is fixed properly I think we have to revert this.