### PR TITLE
fix: don't watch all namespaces 2.0 - use rest client this time

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	// Set default manager options
 	options := manager.Options{
-		Namespace:          "", // Watch all namespaces! Idler needs to watch Pods from all namespaces
+		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.5.1
+	gopkg.in/h2non/gock.v1 v1.0.14
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.3
 	k8s.io/apiextensions-apiserver v0.18.3

--- a/pkg/controller/idler/idler_controller.go
+++ b/pkg/controller/idler/idler_controller.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -34,12 +35,11 @@ var log = logf.Log.WithName("controller_idler")
 // Add creates a new Idler Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, config *configuration.Config) error {
-	k8sConfig := mgr.GetConfig()
-	restClient, err := rest.RESTClientFor(k8sConfig)
+	clientset, err := kubeclientset.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return err
 	}
-	return add(mgr, newReconciler(mgr, config, restClient))
+	return add(mgr, newReconciler(mgr, config, clientset.RESTClient()))
 }
 
 func newReconciler(mgr manager.Manager, config *configuration.Config, restClient rest.Interface) reconcile.Reconciler {


### PR DESCRIPTION
Use REST client for listing pods from users' namespaces, so we don't have to watch all namespaces but only the operator's one \o/