### PR TITLE
fix: don't watch all namespaces 2.0 - use rest client this time

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -108,7 +108,7 @@ func main() {
 
 	// Set default manager options
 	options := manager.Options{
-		Namespace:          "", // Watch all namespaces! Idler needs to watch Pods from all namespaces
+		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.5.1
+	gopkg.in/h2non/gock.v1 v1.0.14
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.3
 	k8s.io/apiextensions-apiserver v0.18.3

--- a/pkg/controller/idler/idler_controller.go
+++ b/pkg/controller/idler/idler_controller.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -34,12 +35,11 @@ var log = logf.Log.WithName("controller_idler")
 // Add creates a new Idler Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, config *configuration.Config) error {
-	k8sConfig := mgr.GetConfig()
-	restClient, err := rest.RESTClientFor(k8sConfig)
+	clientset, err := kubeclientset.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return err
 	}
-	return add(mgr, newReconciler(mgr, config, restClient))
+	return add(mgr, newReconciler(mgr, config, clientset.RESTClient()))
 }
 
 func newReconciler(mgr manager.Manager, config *configuration.Config, restClient rest.Interface) reconcile.Reconciler {

--- a/pkg/controller/idler/idler_controller.go
+++ b/pkg/controller/idler/idler_controller.go
@@ -106,11 +106,12 @@ func (r *ReconcileIdler) Reconcile(request reconcile.Request) (reconcile.Result,
 	}
 	// Find the earlier pod to kill
 	d := nextPodToBeKilledAfter(idler)
-	if d == nil {
+	if d == nil || *d < time.Duration(0) {
 		// No pods tracked. Requeue after the idler timout so we don't miss new pods created within the timeout.
 		timeout := time.Duration(idler.Spec.TimeoutSeconds) * time.Second
 		d = &timeout
 	}
+	log.Info("requeueing in", "durarion", d)
 	return reconcile.Result{
 		Requeue:      true,
 		RequeueAfter: *d,
@@ -135,7 +136,6 @@ func (r *ReconcileIdler) ensureIdling(logger logr.Logger, idler *toolchainv1alph
 		podLogger.Info("Pod", "Pod.Phase", pod.Status.Phase)
 		if trackedPod := findPodByName(idler, pod.Name); trackedPod != nil {
 			// Already tracking this pod. Check the timeout.
-			newStatusPods = append(newStatusPods, *trackedPod) // keep tracking
 			if time.Now().After(trackedPod.StartTime.Add(time.Duration(idler.Spec.TimeoutSeconds) * time.Second)) {
 				podLogger.Info("Pod running for too long. Killing the pod.")
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
@@ -144,11 +144,14 @@ func (r *ReconcileIdler) ensureIdling(logger logr.Logger, idler *toolchainv1alph
 					return err
 				}
 				if !deletedByController { // Pod not managed by a controller. We can just delete the pod.
+					logger.Info("Deleting pod without controller")
 					if err := r.client.Delete(context.TODO(), &pod); err != nil {
 						return err
 					}
 					podLogger.Info("Pod deleted")
 				}
+			} else {
+				newStatusPods = append(newStatusPods, *trackedPod) // keep tracking
 			}
 		} else if pod.Status.StartTime != nil { // Ignore pods without StartTime
 			podLogger.Info("New pod detected. Start tracking.")
@@ -166,9 +169,11 @@ func (r *ReconcileIdler) ensureIdling(logger logr.Logger, idler *toolchainv1alph
 // and scales the owner down to zero and returns "true".
 // Otherwise returns "false".
 func (r *ReconcileIdler) scaleControllerToZero(logger logr.Logger, meta metav1.ObjectMeta) (bool, error) {
+	logger.Info("Scaling controller to zero", "name", meta.Name)
 	owners := meta.GetOwnerReferences()
 	for _, owner := range owners {
 		if owner.Controller != nil && *owner.Controller {
+			log.Info("owner", "owner", owner.Kind)
 			switch owner.Kind {
 			case "Deployment":
 				return r.scaleDeploymentToZero(logger, meta.Namespace, owner)
@@ -191,6 +196,7 @@ func (r *ReconcileIdler) scaleControllerToZero(logger logr.Logger, meta metav1.O
 }
 
 func (r *ReconcileIdler) scaleDeploymentToZero(logger logr.Logger, namespace string, owner metav1.OwnerReference) (bool, error) {
+	logger.Info("Scaling deployment to zero", "name", owner.Name)
 	d := &appsv1.Deployment{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: owner.Name}, d); err != nil {
 		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
@@ -208,11 +214,14 @@ func (r *ReconcileIdler) scaleDeploymentToZero(logger logr.Logger, namespace str
 }
 
 func (r *ReconcileIdler) scaleReplicaSetToZero(logger logr.Logger, namespace string, owner metav1.OwnerReference) (bool, error) {
+	logger.Info("Scaling replica set to zero", "name", owner.Name)
 	rs := &appsv1.ReplicaSet{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: owner.Name}, rs); err != nil {
 		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+			log.Error(err, "replica set is not found; ignoring: it might be already deleted")
 			return true, nil
 		}
+		log.Error(err, "error deleting rs")
 		return false, err
 	}
 	deletedByController, err := r.scaleControllerToZero(logger, rs.ObjectMeta) // Check if the ReplicaSet has another controller which owns it (i.g. Deployment)


### PR DESCRIPTION
Based on https://github.com/codeready-toolchain/member-operator/pull/203

TODO:
- [ ] Use the rest client for all namespace workloads: Deployment, ReplicaSet, etc. Not only for Pods.

e2e tests: 