### PR TITLE
Routes in memberstatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
+replace github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20201013003743-eed55bb9315f
+
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
-replace github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20201013003743-eed55bb9315f
+replace github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20201013014555-9dd6144cdd45
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167
+	github.com/codeready-toolchain/api v0.0.0-20201020192959-6783bbcae79d
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.3.0+incompatible
@@ -24,8 +24,6 @@ require (
 	k8s.io/metrics v0.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
 )
-
-replace github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20201013014555-9dd6144cdd45
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alexeykazakov/api v0.0.0-20201013003743-eed55bb9315f/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
-github.com/alexeykazakov/api v0.0.0-20201013012757-cf4a405bd767/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
@@ -148,6 +146,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167 h1:SpP0O1myYOMZieSwPh9/wy3OeYnO+rOphpZahdrB3NA=
 github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/api v0.0.0-20201020192959-6783bbcae79d h1:ZnxXTIf86UsjoVYHSCusuvvtVgtkd/W0wOYva4OdUZI=
+github.com/codeready-toolchain/api v0.0.0-20201020192959-6783bbcae79d/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5 h1:Z+oKsj4+0WWY0+Zlvc46NX7syYN1uZekjZWPhFFkfIA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5/go.mod h1:TC5Q5FtNUwzpHNMLAkJXaxkifHwPJlZtrvnTWKIY+2M=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -260,6 +260,7 @@ github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -273,6 +274,7 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-bindata/go-bindata v3.1.2+incompatible h1:5vjJMVhowQdPzjE1LdxyFF7YFTXg5IgGVW4gBr5IbvE=
 github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-bindata/go-bindata/v3 v3.1.3/go.mod h1:1/zrpXsLD8YDIbhZRqXzm1Ghc7NhEvIN9+Z6R5/xH4I=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -354,6 +356,7 @@ github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSC
 github.com/gobuffalo/envy v1.7.1/go.mod h1:FurDp9+EDPE4aIUS3ZLyD+7/9fpx7YRt/ukY6jIHf0w=
 github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
+github.com/gobuffalo/flect v0.2.1 h1:GPoRjEN0QObosV4XwuoWvSd5uSiL0N3e91/xqyY4crQ=
 github.com/gobuffalo/flect v0.2.1/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/gobuffalo/logger v1.0.1/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8ze5s8JvPs=
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
@@ -512,6 +515,7 @@ github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
@@ -586,6 +590,7 @@ github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHef
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.7 h1:bQGKb3vps/j0E9GfJQ03JyhRuxsvdAanXlT9BTw3mdw=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -595,6 +600,7 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.6/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -841,6 +847,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -1324,6 +1331,7 @@ k8s.io/client-go v0.18.3/go.mod h1:4a/dpQEvzAhT1BbuWW09qvIaGw6Gbu1gZYiQZIi1DMw=
 k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269/go.mod h1:V5BD6M4CyaN5m+VthcclXWsVcT1Hu+glwa1bi3MIsyE=
 k8s.io/code-generator v0.18.0/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
 k8s.io/code-generator v0.18.2/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
+k8s.io/code-generator v0.18.3 h1:5H57pYEbkMMXCLKD16YQH3yDPAbVLweUsB1M3m70D1c=
 k8s.io/code-generator v0.18.3/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/component-base v0.0.0-20190918160511-547f6c5d7090/go.mod h1:933PBGtQFJky3TEwYx4aEPZ4IxqhWh3R6DCmzqIn1hA=
 k8s.io/component-base v0.0.0-20191122220729-2684fb322cb9/go.mod h1:NFuUusy/X4Tk21m21tcNUihnmp4OI7lXU7/xA+rYXkc=
@@ -1332,6 +1340,7 @@ k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmD
 k8s.io/component-base v0.18.3/go.mod h1:bp5GzGR0aGkYEfTj+eTY0AN/vXTgkJdQXjNTTVUaa3k=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1370,6 +1379,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT
 sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvOk9NM=
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
+sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alexeykazakov/api v0.0.0-20201013003743-eed55bb9315f/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
+github.com/alexeykazakov/api v0.0.0-20201013012757-cf4a405bd767/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -7,6 +7,7 @@ import (
 	authv1 "github.com/openshift/api/authorization/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,7 +33,8 @@ func AddToScheme(s *runtime.Scheme) error {
 		appsv1.AddToScheme,
 		openshiftappsv1.Install,
 		batchv1.AddToScheme,
-		metrics.AddToScheme)
+		metrics.AddToScheme,
+		routev1.Install)
 
 	return addToSchemes.AddToScheme(s)
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -32,6 +32,30 @@ const (
 
 	// defaultMemberStatusRefreshTime is the default refresh period for MemberStatus
 	defaultMemberStatusRefreshTime = "5s"
+
+	// varConsoleNamespace is the console route namespace
+	varConsoleNamespace = "console.namespace"
+
+	// defaultConsoleNamespace is the default console route namespace
+	defaultConsoleNamespace = "openshift-console"
+
+	// varConsoleRouteName is the console route name
+	varConsoleRouteName = "console.route.name"
+
+	// defaultConsoleRouteName is the default console route name
+	defaultConsoleRouteName = "console"
+
+	// varCheNamespace is the che route namespace
+	varCheNamespace = "che.namespace"
+
+	// defaultCheNamespace is the default che route namespace
+	defaultCheNamespace = "toolchain-che"
+
+	// varCheRouteName is the che dashboard route
+	varCheRouteName = "che.route.name"
+
+	// defaultCheRouteName is the default che dashboard route
+	defaultCheRouteName = "che"
 )
 
 // ToolchainCluster configuration constants
@@ -82,6 +106,10 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(toolchainClusterTimeout, defaultClusterHealthCheckTimeout)
 	c.member.SetDefault(identityProviderName, defaultIdentityProviderName)
 	c.member.SetDefault(varMemberStatusRefreshTime, defaultMemberStatusRefreshTime)
+	c.member.SetDefault(varConsoleNamespace, defaultConsoleNamespace)
+	c.member.SetDefault(varConsoleRouteName, defaultConsoleRouteName)
+	c.member.SetDefault(varCheNamespace, defaultCheNamespace)
+	c.member.SetDefault(varCheRouteName, defaultCheRouteName)
 }
 
 // GetAllMemberParameters returns the map with key-values pairs of parameters that have MEMBER_OPERATOR prefix
@@ -124,4 +152,24 @@ func (c *Config) GetToolchainClusterTimeout() time.Duration {
 // GetMemberStatusRefreshTime returns the time how often the MemberStatus should load and refresh the current hosted-toolchain status
 func (c *Config) GetMemberStatusRefreshTime() time.Duration {
 	return c.member.GetDuration(varMemberStatusRefreshTime)
+}
+
+// GetConsoleNamespace returns the console route namespace
+func (c *Config) GetConsoleNamespace() string {
+	return c.member.GetString(varConsoleNamespace)
+}
+
+// GetConsoleRouteName returns the console route name
+func (c *Config) GetConsoleRouteName() string {
+	return c.member.GetString(varConsoleRouteName)
+}
+
+// GetCheNamespace returns the Che route namespace
+func (c *Config) GetCheNamespace() string {
+	return c.member.GetString(varCheNamespace)
+}
+
+// GetCheRouteName returns the name of the Che dashboard route
+func (c *Config) GetCheRouteName() string {
+	return c.member.GetString(varCheRouteName)
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -46,7 +46,9 @@ const (
 	defaultConsoleRouteName = "console"
 
 	// varCheRequired is set to true if Che/CRW operator is expected to be installed on the cluster. May be used in monitoring.
-	varCheRequired     = "che.required"
+	varCheRequired = "che.required"
+
+	// defaultCheRequired is the default value for che.required param
 	defaultCheRequired = false
 
 	// varCheNamespace is the che route namespace
@@ -60,12 +62,6 @@ const (
 
 	// defaultCheRouteName is the default che dashboard route
 	defaultCheRouteName = "che"
-
-	// varEnvironment specifies the member-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
-	varEnvironment = "environment"
-
-	// defaultEnvironment is the default member-operator environment
-	defaultEnvironment = "prod"
 )
 
 // ToolchainCluster configuration constants
@@ -121,7 +117,6 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(varCheNamespace, defaultCheNamespace)
 	c.member.SetDefault(varCheRequired, defaultCheRequired)
 	c.member.SetDefault(varCheRouteName, defaultCheRouteName)
-	c.member.SetDefault(varEnvironment, defaultEnvironment)
 }
 
 // GetAllMemberParameters returns the map with key-values pairs of parameters that have MEMBER_OPERATOR prefix
@@ -189,9 +184,4 @@ func (c *Config) GetCheNamespace() string {
 // GetCheRouteName returns the name of the Che dashboard route
 func (c *Config) GetCheRouteName() string {
 	return c.member.GetString(varCheRouteName)
-}
-
-// GetEnvironment returns the member-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
-func (c *Config) GetEnvironment() string {
-	return c.member.GetString(varEnvironment)
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -45,6 +45,10 @@ const (
 	// defaultConsoleRouteName is the default console route name
 	defaultConsoleRouteName = "console"
 
+	// varCheRequired is set to true if Che/CRW operator is expected to be installed on the cluster. May be used in monitoring.
+	varCheRequired     = "che.required"
+	defaultCheRequired = false
+
 	// varCheNamespace is the che route namespace
 	varCheNamespace = "che.namespace"
 
@@ -115,6 +119,7 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(varConsoleNamespace, defaultConsoleNamespace)
 	c.member.SetDefault(varConsoleRouteName, defaultConsoleRouteName)
 	c.member.SetDefault(varCheNamespace, defaultCheNamespace)
+	c.member.SetDefault(varCheRequired, defaultCheRequired)
 	c.member.SetDefault(varCheRouteName, defaultCheRouteName)
 	c.member.SetDefault(varEnvironment, defaultEnvironment)
 }
@@ -169,6 +174,11 @@ func (c *Config) GetConsoleNamespace() string {
 // GetConsoleRouteName returns the console route name
 func (c *Config) GetConsoleRouteName() string {
 	return c.member.GetString(varConsoleRouteName)
+}
+
+// GetCheRequired returns true if the Che operator is expected to be installed. May be used in monitoring.
+func (c *Config) IsCheRequired() bool {
+	return c.member.GetBool(varCheRequired)
 }
 
 // GetCheNamespace returns the Che route namespace

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -56,6 +56,12 @@ const (
 
 	// defaultCheRouteName is the default che dashboard route
 	defaultCheRouteName = "che"
+
+	// varEnvironment specifies the member-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
+	varEnvironment = "environment"
+
+	// defaultEnvironment is the default member-operator environment
+	defaultEnvironment = "prod"
 )
 
 // ToolchainCluster configuration constants
@@ -110,6 +116,7 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(varConsoleRouteName, defaultConsoleRouteName)
 	c.member.SetDefault(varCheNamespace, defaultCheNamespace)
 	c.member.SetDefault(varCheRouteName, defaultCheRouteName)
+	c.member.SetDefault(varEnvironment, defaultEnvironment)
 }
 
 // GetAllMemberParameters returns the map with key-values pairs of parameters that have MEMBER_OPERATOR prefix
@@ -172,4 +179,9 @@ func (c *Config) GetCheNamespace() string {
 // GetCheRouteName returns the name of the Che dashboard route
 func (c *Config) GetCheRouteName() string {
 	return c.member.GetString(varCheRouteName)
+}
+
+// GetEnvironment returns the member-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
+func (c *Config) GetEnvironment() string {
+	return c.member.GetString(varEnvironment)
 }

--- a/test/memberstatus_assertion.go
+++ b/test/memberstatus_assertion.go
@@ -95,6 +95,16 @@ func (a *MemberStatusAssertion) HasMemoryUsage(usages ...AddUsage) *MemberStatus
 	return a
 }
 
+func (a *MemberStatusAssertion) HasRoutes(consoleUrl, cheUrl string, expCondition toolchainv1alpha1.Condition) *MemberStatusAssertion {
+	err := a.loadMemberStatus()
+	require.NoError(a.t, err)
+	require.NotNil(a.t, a.memberStatus.Status.Routes)
+	require.Equal(a.t, consoleUrl, a.memberStatus.Status.Routes.ConsoleURL)
+	require.Equal(a.t, cheUrl, a.memberStatus.Status.Routes.CheDashboardURL)
+	test.AssertConditionsMatch(a.t, a.memberStatus.Status.Routes.Conditions, expCondition)
+	return a
+}
+
 func ComponentsReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,


### PR DESCRIPTION
Retrieves the Console and Che routes and stores them in `MemberStatus`. This will be used in the host operator instead of directly retrieving them from the member cluster.
Most of the commits were taken from https://github.com/codeready-toolchain/member-operator/pull/208

Paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/185