### PR TITLE
Add Che client with token cache

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -11,6 +11,7 @@ import (
 
 	api "github.com/codeready-toolchain/api/pkg/apis"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	"github.com/codeready-toolchain/member-operator/pkg/che"
 	"github.com/codeready-toolchain/member-operator/pkg/configuration"
 	"github.com/codeready-toolchain/member-operator/pkg/controller"
 	"github.com/codeready-toolchain/member-operator/pkg/controller/memberstatus"
@@ -142,6 +143,9 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
+
+	// initialize che client
+	che.InitDefaultCheClient(crtConfig, allNamespacesClient)
 
 	// Setup all Controllers
 	if err := controller.AddControllersToManager(mgr, crtConfig, allNamespacesClient); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
+	gopkg.in/h2non/gock.v1 v1.0.14
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.3
 	k8s.io/apiextensions-apiserver v0.18.3

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	crtConfig "github.com/codeready-toolchain/member-operator/pkg/configuration"
+	crtcfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,13 +19,13 @@ var DefaultClient *Client
 
 // Client is a client for interacting with Che services
 type Client struct {
-	config     *crtConfig.Config
+	config     *crtcfg.Config
 	k8sClient  client.Client
 	tokenCache *tokenCache
 }
 
 // InitDefaultCheClient initializes the default Che service instance
-func InitDefaultCheClient(cfg *crtConfig.Config, cl client.Client) {
+func InitDefaultCheClient(cfg *crtcfg.Config, cl client.Client) {
 	DefaultClient = &Client{
 		config:     cfg,
 		k8sClient:  cl,

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -1,13 +1,8 @@
 package che
 
 import (
-	"context"
-	"fmt"
-
 	crtcfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
 
-	routev1 "github.com/openshift/api/route/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -31,18 +26,4 @@ func InitDefaultCheClient(cfg *crtcfg.Config, cl client.Client) {
 		k8sClient:  cl,
 		tokenCache: newTokenCache(),
 	}
-}
-
-func getRouteURL(cl client.Client, namespace, name string) (string, error) {
-	route := &routev1.Route{}
-	namespacedName := types.NamespacedName{Namespace: namespace, Name: name}
-	err := cl.Get(context.TODO(), namespacedName, route)
-	if err != nil {
-		return "", err
-	}
-	scheme := "https"
-	if route.Spec.TLS == nil || *route.Spec.TLS == (routev1.TLSConfig{}) {
-		scheme = "http"
-	}
-	return fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, route.Spec.Path), nil
 }

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -1,0 +1,48 @@
+package che
+
+import (
+	"context"
+	"fmt"
+
+	crtConfig "github.com/codeready-toolchain/member-operator/pkg/configuration"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("che-client")
+
+// DefaultClient is a default implementation of a CheClient
+var DefaultClient *Client
+
+// Client is a client for interacting with Che services
+type Client struct {
+	config     *crtConfig.Config
+	k8sClient  client.Client
+	tokenCache *tokenCache
+}
+
+// InitDefaultCheClient initializes the default Che service instance
+func InitDefaultCheClient(cfg *crtConfig.Config, cl client.Client) {
+	DefaultClient = &Client{
+		config:     cfg,
+		k8sClient:  cl,
+		tokenCache: newTokenCache(),
+	}
+}
+
+func getRouteURL(cl client.Client, namespace, name string) (string, error) {
+	route := &routev1.Route{}
+	namespacedName := types.NamespacedName{Namespace: namespace, Name: name}
+	err := cl.Get(context.TODO(), namespacedName, route)
+	if err != nil {
+		return "", err
+	}
+	scheme := "https"
+	if route.Spec.TLS == nil || *route.Spec.TLS == (routev1.TLSConfig{}) {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, route.Spec.Path), nil
+}

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -37,14 +37,17 @@ func newTokenCache() *tokenCache {
 
 // getToken returns the token needed to use Che user APIs, or an error if there was a problem getting the token
 func (tc *tokenCache) getToken(cl client.Client, cfg *crtcfg.Config) (TokenSet, error) {
-	defer tc.RUnlock()
 	tc.RLock()
 	// use the cached credentials if they are still valid
 	if !tokenExpired(tc.token) {
+		defer tc.RUnlock()
 		log.Info("Reusing token")
 		return *tc.token, nil
 	}
 
+	tc.RUnlock()
+	defer tc.Unlock()
+	tc.Lock()
 	// get the credentials
 	user, pass := cfg.GetCheAdminUsername(), cfg.GetCheAdminPassword()
 	if user == "" || pass == "" {

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -90,7 +90,7 @@ func (tc *tokenCache) obtainAndCacheNewToken(cl client.Client, cfg *crtcfg.Confi
 
 	defer rest.CloseResponse(res)
 	if res.StatusCode != http.StatusOK {
-		bodyString := rest.ReadBody(res.Body)
+		bodyString, _ := rest.ReadBody(res.Body)
 		return TokenSet{}, errors.Errorf("unable to obtain access token for che, Response status: %s. Response body: %s", res.Status, bodyString)
 	}
 	tokenSet, err := readTokenSet(res)

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -141,9 +141,9 @@ func readTokenSetFromJSON(jsonString string) (*TokenSet, error) {
 	return &token, nil
 }
 
-// tokenExpired return false if the token is not nil and good for at least one more minute
+// tokenExpired return false if the token is not nil and good for at least thirty more seconds
 func tokenExpired(token *TokenSet) bool {
-	return token == nil || time.Now().After(time.Unix(token.Expiration-60, 0))
+	return token == nil || time.Now().After(time.Unix(token.Expiration-30, 0))
 }
 
 // newHTTPClient returns a new HTTP client with some timeout and TLS values configured

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -15,6 +15,7 @@ import (
 
 	crtcfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
 	"github.com/codeready-toolchain/member-operator/pkg/rest"
+	"github.com/codeready-toolchain/member-operator/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/pkg/errors"
@@ -44,10 +45,9 @@ func (tc *tokenCache) getToken(cl client.Client, cfg *crtcfg.Config) (TokenSet, 
 		log.Info("Reusing token")
 		return *tc.token, nil
 	}
-
 	tc.RUnlock()
-	defer tc.Unlock()
-	tc.Lock()
+
+	// no valid token, retrieve a new one
 	// get the credentials
 	user, pass := cfg.GetCheAdminUsername(), cfg.GetCheAdminPassword()
 	if user == "" || pass == "" {
@@ -55,22 +55,20 @@ func (tc *tokenCache) getToken(cl client.Client, cfg *crtcfg.Config) (TokenSet, 
 	}
 
 	// get keycloak URL
-	cheKeycloakURL, err := getRouteURL(cl, cfg.GetCheNamespace(), cfg.GetCheKeycloakRouteName())
+	cheKeycloakURL, err := utils.GetRouteURL(cl, cfg.GetCheNamespace(), cfg.GetCheKeycloakRouteName())
 	if err != nil {
 		return TokenSet{}, err
 	}
 	log.Info("Che Keycloak Route", "URL", cheKeycloakURL)
 
-	// get che user token
-	if err = tc.obtainNewToken(cheKeycloakURL+tokenPath, user, pass); err != nil {
-		return TokenSet{}, err
-	}
-
-	return *tc.token, nil
+	return tc.obtainNewToken(cheKeycloakURL+tokenPath, user, pass)
 }
 
-// obtainNewToken obtains an access token from the provided authentication URL and returns it, otherwise returns an error
-func (tc *tokenCache) obtainNewToken(authURL, user, pass string) error {
+// obtainNewToken obtains an access token from the provided authentication URL, updates the cache and returns the token, otherwise returns an error
+func (tc *tokenCache) obtainNewToken(authURL, user, pass string) (TokenSet, error) {
+	defer tc.Unlock()
+	tc.Lock()
+
 	reqData := url.Values{}
 	reqData.Set("username", user)
 	reqData.Set("password", pass)
@@ -80,28 +78,30 @@ func (tc *tokenCache) obtainNewToken(authURL, user, pass string) error {
 	log.Info("Obtaining new token", "URL", authURL)
 	res, err := tc.httpClient.PostForm(authURL, reqData)
 	if err != nil {
-		return err
+		return TokenSet{}, err
 	}
 
 	defer rest.CloseResponse(res)
 	if res.StatusCode != http.StatusOK {
 		bodyString := rest.ReadBody(res.Body)
-		return errors.Errorf("unable to obtain access token for che, Response status: %s. Response body: %s", res.Status, bodyString)
+		return TokenSet{}, errors.Errorf("unable to obtain access token for che, Response status: %s. Response body: %s", res.Status, bodyString)
 	}
 	tokenSet, err := readTokenSet(res)
 	if err != nil {
-		return err
+		return TokenSet{}, err
 	}
 	if tokenSet.AccessToken == "" {
-		return errors.New("unable to obtain access token for che. Access Token is missing in the response")
+		return TokenSet{}, errors.New("unable to obtain access token for che. Access Token is missing in the response")
 	}
 	if tokenSet.Expiration == 0 && tokenSet.ExpiresIn > 0 {
 		timeLeft := time.Duration(tokenSet.ExpiresIn) * time.Second
 		tokenSet.Expiration = time.Now().Add(timeLeft).Unix()
 	}
 	log.Info("Token expiry", "expiration", tokenSet.Expiration, "expires_in", tokenSet.ExpiresIn)
+
+	// update token cache
 	tc.token = tokenSet
-	return nil
+	return *tc.token, nil
 }
 
 // TokenSet represents a set of Access and Refresh tokens

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -1,0 +1,153 @@
+package che
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	crtCfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
+	"github.com/codeready-toolchain/member-operator/pkg/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/pkg/errors"
+)
+
+const tokenPath = "auth/realms/che/protocol/openid-connect/token"
+
+// tokenCache manages retrieving, caching and renewing the authentication token required for invoking Che APIs
+type tokenCache struct {
+	sync.RWMutex
+	httpClient *http.Client
+	token      *TokenSet
+}
+
+func newTokenCache() *tokenCache {
+	return &tokenCache{
+		httpClient: newHTTPClient(),
+	}
+}
+
+// getToken returns the token needed to use Che user APIs, or an error if there was a problem getting the token
+func (tc *tokenCache) getToken(cl client.Client, cfg *crtCfg.Config) (TokenSet, error) {
+	defer tc.RUnlock()
+	tc.RLock()
+	// use the cached credentials if they are still valid
+	if !tokenExpired(tc.token) {
+		log.Info("Reusing token")
+		return *tc.token, nil
+	}
+
+	// get the credentials
+	user, pass := cfg.GetCheAdminUsername(), cfg.GetCheAdminPassword()
+	if user == "" || pass == "" {
+		return TokenSet{}, fmt.Errorf("the che admin username and/or password are not configured")
+	}
+
+	// get keycloak URL
+	cheKeycloakURL, err := getRouteURL(cl, cfg.GetCheNamespace(), cfg.GetCheKeycloakRouteName())
+	if err != nil {
+		return TokenSet{}, err
+	}
+	log.Info("Che Keycloak Route", "URL", cheKeycloakURL)
+
+	// get che user token
+	if err = tc.obtainNewToken(cheKeycloakURL+tokenPath, user, pass); err != nil {
+		return TokenSet{}, err
+	}
+
+	return *tc.token, nil
+}
+
+// obtainNewToken obtains an access token from the provided authentication URL and returns it, otherwise returns an error
+func (tc *tokenCache) obtainNewToken(authURL, user, pass string) error {
+	reqData := url.Values{}
+	reqData.Set("username", user)
+	reqData.Set("password", pass)
+	reqData.Set("grant_type", "password")
+	reqData.Set("client_id", "che-public")
+
+	log.Info("Obtaining new token", "URL", authURL)
+	res, err := tc.httpClient.PostForm(authURL, reqData)
+	if err != nil {
+		return err
+	}
+
+	defer rest.CloseResponse(res)
+	if res.StatusCode != http.StatusOK {
+		bodyString := rest.ReadBody(res.Body)
+		return errors.Errorf("unable to obtain access token for che, Response status: %s. Response body: %s", res.Status, bodyString)
+	}
+	tokenSet, err := readTokenSet(res)
+	if err != nil {
+		return err
+	}
+	if tokenSet.AccessToken == "" {
+		return errors.New("unable to obtain access token for che. Access Token is missing in the response")
+	}
+	if tokenSet.Expiration == 0 && tokenSet.ExpiresIn > 0 {
+		timeLeft := time.Duration(tokenSet.ExpiresIn) * time.Second
+		tokenSet.Expiration = time.Now().Add(timeLeft).Unix()
+	}
+	log.Info("Token expiry", "expiration", tokenSet.Expiration, "expires_in", tokenSet.ExpiresIn)
+	tc.token = tokenSet
+	return nil
+}
+
+// TokenSet represents a set of Access and Refresh tokens
+type TokenSet struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	Expiration   int64  `json:"expiration"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+}
+
+// readTokenSet extracts json with token data from the response
+func readTokenSet(res *http.Response) (*TokenSet, error) {
+	buf := new(bytes.Buffer)
+	_, err := io.Copy(buf, res.Body)
+	if err != nil {
+		return nil, err
+	}
+	jsonString := strings.TrimSpace(buf.String())
+	return readTokenSetFromJSON(jsonString)
+}
+
+// readTokenSetFromJSON parses json with a token set
+func readTokenSetFromJSON(jsonString string) (*TokenSet, error) {
+	var token TokenSet
+	err := json.Unmarshal([]byte(jsonString), &token)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error when unmarshal json with access token %s ", jsonString)
+	}
+	return &token, nil
+}
+
+// tokenExpired return false if the token is not nil and good for at least one more minute
+func tokenExpired(token *TokenSet) bool {
+	return token == nil || time.Now().After(time.Unix(token.Expiration-60, 0))
+}
+
+// newHTTPClient returns a new HTTP client with some timeout and TLS values configured
+func newHTTPClient() *http.Client {
+	var netTransport = &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 5 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 5 * time.Second,
+		TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+	}
+	var httpClient = &http.Client{
+		Timeout:   time.Second * 10,
+		Transport: netTransport,
+	}
+	return httpClient
+}

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	crtCfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
+	crtcfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
 	"github.com/codeready-toolchain/member-operator/pkg/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,7 +36,7 @@ func newTokenCache() *tokenCache {
 }
 
 // getToken returns the token needed to use Che user APIs, or an error if there was a problem getting the token
-func (tc *tokenCache) getToken(cl client.Client, cfg *crtCfg.Config) (TokenSet, error) {
+func (tc *tokenCache) getToken(cl client.Client, cfg *crtcfg.Config) (TokenSet, error) {
 	defer tc.RUnlock()
 	tc.RLock()
 	// use the cached credentials if they are still valid

--- a/pkg/che/tokencache_test.go
+++ b/pkg/che/tokencache_test.go
@@ -1,0 +1,380 @@
+package che
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	crtCfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (client.Client, *crtCfg.Config) {
+	logf.SetLogger(zap.Logger(true))
+
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+
+	fakeClient := test.NewFakeClient(t, initObjs...)
+	config, err := crtCfg.LoadConfig(fakeClient)
+	require.NoError(t, err)
+
+	return fakeClient, config
+}
+
+func TestGetToken(t *testing.T) {
+	// given
+	url := "https://keycloak-toolchain-che.member-cluster"
+	testSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "toolchain-member",
+		},
+		Data: map[string][]byte{
+			"che.admin.username": []byte("test-che-user"),
+			"che.admin.password": []byte("test-che-password"),
+		},
+	}
+
+	t.Run("missing configuration", func(t *testing.T) {
+		// given
+		tokenCache := newTokenCache()
+		cl, cfg := prepareClientAndConfig(t)
+
+		// when
+		tok, err := tokenCache.getToken(cl, cfg)
+
+		// then
+		require.EqualError(t, err, "the che admin username and/or password are not configured")
+		require.Empty(t, tok)
+	})
+
+	t.Run("with configuration", func(t *testing.T) {
+
+		restore := test.SetEnvVarsAndRestore(t,
+			test.Env("WATCH_NAMESPACE", "toolchain-member"),
+			test.Env("MEMBER_OPERATOR_SECRET_NAME", "test-secret"),
+		)
+		defer restore()
+
+		t.Run("no keycloak route", func(t *testing.T) {
+			// given
+			tokenCache := newTokenCache()
+			cl, cfg := prepareClientAndConfig(t, testSecret)
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			require.EqualError(t, err, `routes.route.openshift.io "keycloak" not found`)
+			require.Empty(t, tok)
+		})
+
+		t.Run("keycloak route returns error", func(t *testing.T) {
+			// given
+			tokenCache := newTokenCache()
+			cl, cfg := prepareClientAndConfig(t, testSecret)
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			require.EqualError(t, err, `routes.route.openshift.io "keycloak" not found`)
+			require.Empty(t, tok)
+		})
+
+		t.Run("expired token received", func(t *testing.T) {
+			// given
+			tokenCache := &tokenCache{
+				httpClient: http.DefaultClient,
+			}
+			expiredToken := &TokenSet{
+				AccessToken:  "abc.123.xyz",
+				Expiration:   time.Now().Unix(),
+				ExpiresIn:    300,
+				RefreshToken: "111.222.333",
+				TokenType:    "bearer",
+			}
+			tokenCache.token = expiredToken
+			cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+			defer gock.OffAll()
+			gock.New(url).
+				Post("auth/realms/che/protocol/openid-connect/token").
+				MatchHeader("Content-Type", "application/x-www-form-urlencoded").
+				Persist().
+				Reply(200).
+				BodyString(`{
+					"access_token":"aaa.bbb.ccc",
+					"expires_in":300,
+					"refresh_expires_in":1800,
+					"refresh_token":"111.222.333",
+					"token_type":"bearer",
+					"not-before-policy":0,
+					"session_state":"a2fa1448-687a-414f-af40-3b6b3f5a873a",
+					"scope":"profile email"
+					}`)
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			expected := TokenSet{
+				AccessToken:  "aaa.bbb.ccc",
+				ExpiresIn:    300,
+				Expiration:   1605165761,
+				RefreshToken: "111.222.333",
+				TokenType:    "bearer",
+			}
+			require.NoError(t, err)
+			require.NotEqual(t, expiredToken.Expiration, tok.Expiration) // should receive a new token with new expiry
+			expectToken(t, expected, tok)                                // the rest of the token values should be the same
+		})
+
+		t.Run("keycloak route returns bad status code", func(t *testing.T) {
+			// given
+			tokenCache := &tokenCache{
+				httpClient: http.DefaultClient,
+			}
+			cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+			defer gock.OffAll()
+			gock.New(url).
+				Post("auth/realms/che/protocol/openid-connect/token").
+				MatchHeader("Content-Type", "application/x-www-form-urlencoded").
+				Persist().
+				Reply(404)
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			require.EqualError(t, err, "unable to obtain access token for che, Response status: 404 Not Found. Response body: ")
+			require.Empty(t, tok)
+		})
+
+		t.Run("bad token received", func(t *testing.T) {
+			// given
+			tokenCache := &tokenCache{
+				httpClient: http.DefaultClient,
+			}
+			cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+			defer gock.OffAll()
+			gock.New(url).
+				Post("auth/realms/che/protocol/openid-connect/token").
+				MatchHeader("Content-Type", "application/x-www-form-urlencoded").
+				Persist().
+				Reply(200).
+				BodyString(`error`)
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			require.Error(t, err, "there should be an unmarshal error")
+			require.Empty(t, tok)
+		})
+
+		t.Run("missing access token", func(t *testing.T) {
+			// given
+			tokenCache := &tokenCache{
+				httpClient: http.DefaultClient,
+			}
+			noAccessToken := &TokenSet{
+				Expiration:   time.Now().Unix(),
+				ExpiresIn:    300,
+				RefreshToken: "111.222.333",
+				TokenType:    "bearer",
+			}
+			tokenCache.token = noAccessToken
+			cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+			defer gock.OffAll()
+			gock.New(url).
+				Post("auth/realms/che/protocol/openid-connect/token").
+				MatchHeader("Content-Type", "application/x-www-form-urlencoded").
+				Persist().
+				Reply(200).
+				BodyString(`{
+					"access_token":"",
+					"expires_in":300,
+					"refresh_expires_in":1800,
+					"refresh_token":"111.222.333",
+					"token_type":"bearer",
+					"not-before-policy":0,
+					"session_state":"a2fa1448-687a-414f-af40-3b6b3f5a873a",
+					"scope":"profile email"
+					}`)
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			require.EqualError(t, err, "unable to obtain access token for che. Access Token is missing in the response")
+			require.Empty(t, tok)
+		})
+
+		t.Run("new valid token returned", func(t *testing.T) {
+			// given
+			tokenCache := &tokenCache{
+				httpClient: http.DefaultClient,
+			}
+			cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+			defer gock.OffAll()
+			gock.New(url).
+				Post("auth/realms/che/protocol/openid-connect/token").
+				MatchHeader("Content-Type", "application/x-www-form-urlencoded").
+				Persist().
+				Reply(200).
+				BodyString(`{
+					"access_token":"aaa.bbb.ccc",
+					"expires_in":300,
+					"refresh_expires_in":1800,
+					"refresh_token":"111.222.333",
+					"token_type":"bearer",
+					"not-before-policy":0,
+					"session_state":"a2fa1448-687a-414f-af40-3b6b3f5a873a",
+					"scope":"profile email"
+					}`)
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			expected := TokenSet{
+				AccessToken:  "aaa.bbb.ccc",
+				ExpiresIn:    300,
+				RefreshToken: "111.222.333",
+				TokenType:    "bearer",
+			}
+			require.NoError(t, err)
+			expectToken(t, expected, tok)
+		})
+
+		t.Run("token is valid so it is reused", func(t *testing.T) {
+			// given
+			tokenCache := &tokenCache{
+				httpClient: http.DefaultClient,
+			}
+			cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+
+			expTime := time.Now().Add(120 * time.Second).Unix()
+			goodToken := &TokenSet{
+				AccessToken:  "abc.123.xyz",
+				Expiration:   expTime,
+				ExpiresIn:    300,
+				RefreshToken: "111.222.333",
+				TokenType:    "bearer",
+			}
+			tokenCache.token = goodToken
+
+			// when
+			tok, err := tokenCache.getToken(cl, cfg)
+
+			// then
+			expected := TokenSet{
+				AccessToken:  "abc.123.xyz",
+				ExpiresIn:    300,
+				RefreshToken: "111.222.333",
+				TokenType:    "bearer",
+			}
+			require.NoError(t, err)
+			expectToken(t, expected, tok)
+			require.Equal(t, expTime, tok.Expiration) // token should be the reused so expiration should be the same
+		})
+
+	})
+
+}
+
+func TestTokenExpired(t *testing.T) {
+	t.Run("nil token", func(t *testing.T) {
+		// given
+		var token *TokenSet = nil
+
+		// when
+		result := tokenExpired(token)
+
+		// then
+		require.True(t, result)
+	})
+
+	t.Run("expiration not set", func(t *testing.T) {
+		// given
+		token := &TokenSet{
+			Expiration: 0,
+		}
+
+		// when
+		result := tokenExpired(token)
+
+		// then
+		require.True(t, result)
+	})
+
+	t.Run("not expired", func(t *testing.T) {
+		// given
+		offset := 61 * time.Second
+		token := &TokenSet{
+			Expiration: time.Now().Add(offset).Unix(),
+		}
+
+		// when
+		result := tokenExpired(token)
+
+		// then
+		require.False(t, result)
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		// given
+		offset := 59 * time.Second
+		token := &TokenSet{
+			Expiration: time.Now().Add(offset).Unix(),
+		}
+
+		// when
+		result := tokenExpired(token)
+
+		// then
+		require.True(t, result)
+	})
+}
+
+func keycloackRoute(tls bool) *routev1.Route {
+	r := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keycloak",
+			Namespace: "toolchain-che",
+		},
+		Spec: routev1.RouteSpec{
+			Host: fmt.Sprintf("keycloak-toolchain-che.%s", test.MemberClusterName),
+			Path: "",
+		},
+	}
+	if tls {
+		r.Spec.TLS = &routev1.TLSConfig{
+			Termination: "edge",
+		}
+	}
+	return r
+}
+
+func expectToken(t *testing.T, expected, actual TokenSet) {
+	require.Equal(t, expected.AccessToken, actual.AccessToken)
+	require.Equal(t, expected.ExpiresIn, actual.ExpiresIn)
+	require.Equal(t, expected.RefreshToken, actual.RefreshToken)
+	require.Equal(t, expected.TokenType, actual.TokenType)
+}

--- a/pkg/che/tokencache_test.go
+++ b/pkg/che/tokencache_test.go
@@ -340,7 +340,7 @@ func TestTokenExpired(t *testing.T) {
 
 	t.Run("expired", func(t *testing.T) {
 		// given
-		offset := 59 * time.Second
+		offset := 29 * time.Second
 		token := &TokenSet{
 			Expiration: time.Now().Add(offset).Unix(),
 		}

--- a/pkg/che/tokencache_test.go
+++ b/pkg/che/tokencache_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
-	crtCfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
+	crtcfg "github.com/codeready-toolchain/member-operator/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (client.Client, *crtCfg.Config) {
+func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (client.Client, *crtcfg.Config) {
 	logf.SetLogger(zap.Logger(true))
 
 	s := scheme.Scheme
@@ -31,7 +31,7 @@ func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (client.Cl
 	require.NoError(t, err)
 
 	fakeClient := test.NewFakeClient(t, initObjs...)
-	config, err := crtCfg.LoadConfig(fakeClient)
+	config, err := crtcfg.LoadConfig(fakeClient)
 	require.NoError(t, err)
 
 	return fakeClient, config

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -66,6 +66,12 @@ const (
 	// defaultCheRouteName is the default che dashboard route
 	defaultCheRouteName = "che"
 
+	// varCheKeycloakRouteName is the che keycloak route
+	varCheKeycloakRouteName = "che.keycloak.route.name"
+
+	// defaultCheKeycloakRouteName is the default che keycloak route
+	defaultCheKeycloakRouteName = "keycloak"
+
 	// varCheAdminUsername is the che admin user username
 	varCheAdminUsername = "che.admin.username"
 
@@ -134,6 +140,7 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(varCheNamespace, defaultCheNamespace)
 	c.member.SetDefault(varCheRequired, defaultCheRequired)
 	c.member.SetDefault(varCheRouteName, defaultCheRouteName)
+	c.member.SetDefault(varCheKeycloakRouteName, defaultCheKeycloakRouteName)
 }
 
 func (c *Config) Print() {
@@ -211,12 +218,17 @@ func (c *Config) GetCheRouteName() string {
 	return c.member.GetString(varCheRouteName)
 }
 
-// GetCheAdminUsername returns the member cluster's che admin username
+// GetCheKeycloakRouteName returns the name of Che's keycloak route
+func (c *Config) GetCheKeycloakRouteName() string {
+	return c.member.GetString(varCheKeycloakRouteName)
+}
+
+// GetCheAdminUsername returns the member cluster's Che admin username
 func (c *Config) GetCheAdminUsername() string {
 	return c.secretValues[varCheAdminUsername]
 }
 
-// GetCheAdminPassword returns the member cluster's che admin password
+// GetCheAdminPassword returns the member cluster's Che admin password
 func (c *Config) GetCheAdminPassword() string {
 	return c.secretValues[varCheAdminPassword]
 }

--- a/pkg/rest/rest.go
+++ b/pkg/rest/rest.go
@@ -1,0 +1,21 @@
+package rest
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// ReadBody reads body from a ReadCloser and returns it as a string
+func ReadBody(body io.ReadCloser) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(body)
+	return buf.String()
+}
+
+// CloseResponse reads the body and close the response. To be used to prevent file descriptor leaks.
+func CloseResponse(response *http.Response) {
+	ioutil.ReadAll(response.Body)
+	response.Body.Close()
+}

--- a/pkg/rest/rest.go
+++ b/pkg/rest/rest.go
@@ -8,14 +8,14 @@ import (
 )
 
 // ReadBody reads body from a ReadCloser and returns it as a string
-func ReadBody(body io.ReadCloser) string {
+func ReadBody(body io.ReadCloser) (string, error) {
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(body)
-	return buf.String()
+	_, err := buf.ReadFrom(body)
+	return buf.String(), err
 }
 
 // CloseResponse reads the body and close the response. To be used to prevent file descriptor leaks.
 func CloseResponse(response *http.Response) {
-	ioutil.ReadAll(response.Body)
+	_, _ = ioutil.ReadAll(response.Body)
 	response.Body.Close()
 }

--- a/pkg/utils/route.go
+++ b/pkg/utils/route.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetRouteURL gets the URL of the route with the given name and namespace using the given client
+func GetRouteURL(cl client.Client, namespace, name string) (string, error) {
+	route := &routev1.Route{}
+	namespacedName := types.NamespacedName{Namespace: namespace, Name: name}
+	err := cl.Get(context.TODO(), namespacedName, route)
+	if err != nil {
+		return "", err
+	}
+	scheme := "https"
+	if route.Spec.TLS == nil || *route.Spec.TLS == (routev1.TLSConfig{}) {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, route.Spec.Path), nil
+}


### PR DESCRIPTION
Adds a Che client to the member operator that does the following:

- looks up the Che Keycloak server
- uses credentials from the member-operator-secret to request a token from Che's Keycloak server
- retrieves the token from the server and caches it
- reuses the cached token until it expires

More functions will be added to che.go in PRs to come. (eg. Find user and Delete user functions)

Related issue: https://issues.redhat.com/browse/CRT-846