### PR TITLE
feat: introduce webhook template & add permissions & configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ tags
 out/
 
 tmp/
+
+# generated files
+*_assets.go

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -77,6 +77,7 @@ rules:
   verbs:
   - "get"
   - "list"
+  - "watch"
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -117,3 +118,23 @@ rules:
   - jobs
   verbs:
   - "*"
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+  - "create"
+  - "update"
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+  - "create"
+  - "update"

--- a/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain-member-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain-member-operator.clusterserviceversion.yaml
@@ -206,6 +206,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - networking.k8s.io
           resources:
@@ -246,6 +247,26 @@ spec:
           - jobs
           verbs:
           - '*'
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
         serviceAccountName: member-operator
       deployments:
       - name: member-operator
@@ -274,6 +295,8 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: member-operator
+                - name: MEMBER_OPERATOR_WEBHOOK_IMAGE
+                  value: REPLACE_MEMBER_OPERATOR_WEBHOOK_IMAGE
                 image: REPLACE_IMAGE
                 imagePullPolicy: IfNotPresent
                 name: member-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,6 +31,8 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: "member-operator"
+        - name: MEMBER_OPERATOR_WEBHOOK_IMAGE
+          value: REPLACE_MEMBER_OPERATOR_WEBHOOK_IMAGE
         resources:
           requests:
             cpu: "500m"

--- a/deploy/webhook/member-operator-webhook.yaml
+++ b/deploy/webhook/member-operator-webhook.yaml
@@ -53,10 +53,10 @@ objects:
           imagePullPolicy: IfNotPresent
           resources:
             limits:
-              cpu: 500m
+              cpu: 300m
               memory: 500Mi
             requests:
-              cpu: 250m
+              cpu: 75m
               memory: 128Mi
           volumeMounts:
           - name: webhook-certs

--- a/deploy/webhook/member-operator-webhook.yaml
+++ b/deploy/webhook/member-operator-webhook.yaml
@@ -1,0 +1,107 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: member-operator-webhook
+objects:
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  metadata:
+    name: sandbox-users-pods
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+  value: -10
+  globalDefault: false
+  description: "Priority class for pods in users' namespaces"
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: member-operator-webhook
+    namespace: ${NAMESPACE}
+    labels:
+      app: member-operator-webhook
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+  spec:
+    ports:
+    - port: 443
+      targetPort: 8443
+    selector:
+      app: member-operator-webhook
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: member-operator-webhook
+    namespace: ${NAMESPACE}
+    labels:
+      app: member-operator-webhook
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: member-operator-webhook
+    template:
+      metadata:
+        name: member-operator-webhook
+        labels:
+          app: member-operator-webhook
+      spec:
+        containers:
+        - name: mutator
+          image: ${IMAGE}
+          command:
+          - member-operator-webhook
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500Mi
+            requests:
+              cpu: 250m
+              memory: 128Mi
+          volumeMounts:
+          - name: webhook-certs
+            mountPath: /etc/webhook/certs
+            readOnly: true
+        volumes:
+        - name: webhook-certs
+          secret:
+            secretName: webhook-certs
+- apiVersion: admissionregistration.k8s.io/v1
+  kind: MutatingWebhookConfiguration
+  metadata:
+    name: member-operator-webhook
+    labels:
+      app: member-operator-webhook
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+  webhooks:
+  - name: users.pods.webhook.sandbox
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: ${CA_BUNDLE}
+      service:
+        name: member-operator-webhook
+        namespace: ${NAMESPACE}
+        path: "/mutate-users-pods"
+        port: 443
+    matchPolicy: Equivalent
+    rules:
+    - operations: ["CREATE", "UPDATE"]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      scope: "Namespaced"
+    sideEffects: None
+    timeoutSeconds: 5
+    reinvocationPolicy: Never
+    failurePolicy: Ignore
+    namespaceSelector:
+      matchLabels:
+        toolchain.dev.openshift.com/provider: codeready-toolchain
+parameters:
+- name: NAMESPACE
+  value: 'toolchain-member-operator'
+- name: IMAGE
+  value: quay.io/matousjobanek/member-operator-webhook:latest
+- name: CA_BUNDLE
+  required: true

--- a/deploy/webhook/member-operator-webhook.yaml
+++ b/deploy/webhook/member-operator-webhook.yaml
@@ -102,6 +102,6 @@ parameters:
 - name: NAMESPACE
   value: 'toolchain-member-operator'
 - name: IMAGE
-  value: quay.io/matousjobanek/member-operator-webhook:latest
+  required: true
 - name: CA_BUNDLE
   required: true

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -1033,6 +1033,7 @@ data:
                 verbs:
                 - get
                 - list
+                - watch
               - apiGroups:
                 - networking.k8s.io
                 resources:
@@ -1073,6 +1074,26 @@ data:
                 - jobs
                 verbs:
                 - '*'
+              - apiGroups:
+                - admissionregistration.k8s.io
+                resources:
+                - mutatingwebhookconfigurations
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+              - apiGroups:
+                - scheduling.k8s.io
+                resources:
+                - priorityclasses
+                verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
               serviceAccountName: member-operator
             deployments:
             - name: member-operator
@@ -1101,6 +1122,8 @@ data:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: member-operator
+                      - name: MEMBER_OPERATOR_WEBHOOK_IMAGE
+                        value: REPLACE_MEMBER_OPERATOR_WEBHOOK_IMAGE
                       image: REPLACE_IMAGE
                       imagePullPolicy: IfNotPresent
                       name: member-operator

--- a/make/go.mk
+++ b/make/go.mk
@@ -8,7 +8,7 @@ export GO111MODULE
 
 .PHONY: build
 ## Build the operator
-build: $(OUT_DIR)/operator
+build: generate-assets $(OUT_DIR)/operator
 
 $(OUT_DIR)/operator:
 	$(Q)CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
@@ -25,3 +25,11 @@ $(OUT_DIR)/operator:
 .PHONY: vendor
 vendor:
 	$(Q)go mod vendor
+
+.PHONY: generate-assets
+generate-assets:
+	@go install github.com/go-bindata/go-bindata/...
+	@echo "generating users pods mutating webhook template data..."
+	@rm ./pkg/webhook/deploy/userspodswebhook/template_assets.go 2>/dev/null || true
+	@$(GOPATH)/bin/go-bindata -pkg userspodswebhook -o ./pkg/webhook/deploy/userspodswebhook/template_assets.go -nocompress -prefix deploy/webhook deploy/webhook
+

--- a/make/test.mk
+++ b/make/test.mk
@@ -6,7 +6,7 @@
 
 .PHONY: test
 ## runs the tests without coverage and excluding E2E tests
-test:
+test: generate-assets 
 	@echo "running the tests without coverage and excluding E2E tests..."
 	$(Q)go test ${V_FLAG} -race $(shell go list ./... | grep -v /test/e2e) -failfast
 	
@@ -21,7 +21,7 @@ COV_DIR = $(OUT_DIR)/coverage
 
 .PHONY: test-with-coverage
 ## runs the tests with coverage
-test-with-coverage: 
+test-with-coverage: generate-assets
 	@echo "running the tests with coverage..."
 	@-mkdir -p $(COV_DIR)
 	@-rm $(COV_DIR)/coverage.txt

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -2,6 +2,8 @@ package apis
 
 import (
 	"github.com/codeready-toolchain/api/pkg/apis"
+	"k8s.io/api/admissionregistration/v1"
+	v12 "k8s.io/api/scheduling/v1"
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	authv1 "github.com/openshift/api/authorization/v1"
@@ -34,7 +36,9 @@ func AddToScheme(s *runtime.Scheme) error {
 		openshiftappsv1.Install,
 		batchv1.AddToScheme,
 		metrics.AddToScheme,
-		routev1.Install)
+		routev1.Install,
+		v1.AddToScheme,
+		v12.AddToScheme)
 
 	return addToSchemes.AddToScheme(s)
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -77,6 +77,9 @@ const (
 
 	// varCheAdminPassword is the che admin user password
 	varCheAdminPassword = "che.admin.password"
+
+	// varWebhookImage contains the image location of the member-operator-webhook
+	varWebhookImage = "webhook.image"
 )
 
 // ToolchainCluster configuration constants
@@ -231,4 +234,9 @@ func (c *Config) GetCheAdminUsername() string {
 // GetCheAdminPassword returns the member cluster's Che admin password
 func (c *Config) GetCheAdminPassword() string {
 	return c.secretValues[varCheAdminPassword]
+}
+
+// GetMemberOperatorWebhookImage returns the member operator webhook image location
+func (c *Config) GetMemberOperatorWebhookImage() string {
+	return c.member.GetString(varWebhookImage)
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -327,3 +327,24 @@ func TestIsCheRequired(t *testing.T) {
 		assert.Equal(t, true, config.IsCheRequired())
 	})
 }
+
+func TestGetMemberOperatorWebhookImage(t *testing.T) {
+	key := MemberEnvPrefix + "_WEBHOOK_IMAGE"
+	resetFunc := test.UnsetEnvVarAndRestore(t, key)
+	defer resetFunc()
+
+	t.Run("default", func(t *testing.T) {
+		resetFunc := test.UnsetEnvVarAndRestore(t, key)
+		defer resetFunc()
+		config := getDefaultConfiguration(t)
+		assert.Empty(t, config.GetMemberOperatorWebhookImage())
+	})
+
+	t.Run("from var", func(t *testing.T) {
+		restore := test.SetEnvVarsAndRestore(t,
+			test.Env(key, "quay.io/cool/member-operator-webhook:123"))
+		defer restore()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, "quay.io/cool/member-operator-webhook:123", config.GetMemberOperatorWebhookImage())
+	})
+}


### PR DESCRIPTION
This PR adds:
* mutating admission webhook template
* generation of the template into an asset
* necessary permissions for deploying objects form the template
* configuration to load the member-operator-webhook image location URL

This PR doesn't introduce any real logic yet - deployment of the template as well as the logic of the webhook will come in the next PR.