### PR TITLE
Proceed with removal if user not found

### DIFF
--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -651,34 +651,16 @@ func (r *ReconcileUserAccount) lookupAndDeleteCheUser(userAcc *toolchainv1alpha1
 		return err
 	}
 
-	// If the user doesn't exist and there's no deletion in progress then there's nothing left to do.
-	// We need to check whether the deletion is in progress because in some cases the user could be reported as non-existent while the deletion is still in progress.
-	if !userExists && !condition.HasConditionReason(userAcc.Status.Conditions, toolchainv1alpha1.UserAccountCheCleanup, toolchainv1alpha1.UserAccountDeletingCheDataReason) {
+	// If the user doesn't exist then there's nothing left to do.
+	if !userExists {
+		log.Info("Che user no longer exists")
 		return nil
 	}
 
-	var cheUserID string
-
-	// Get the user ID from the status condition if it's there
-	if condition.HasConditionReason(userAcc.Status.Conditions, toolchainv1alpha1.UserAccountCheCleanup, toolchainv1alpha1.UserAccountDeletingCheDataReason) {
-		cond, found := condition.FindConditionByType(userAcc.Status.Conditions, toolchainv1alpha1.UserAccountCheCleanup)
-		if found {
-			cheUserID = cond.Message
-		}
-	}
-
-	// If the user ID is not in the status then look it up and set it in the status
-	if cheUserID == "" {
-		cheUserID, err = r.cheClient.GetUserIDByUsername(userAcc.Name)
-		if err != nil {
-			return err
-		}
-
-		// Set the Che user deletion status (store the Che user ID in the status for subsequent retries if needed)
-		// This is required because the deletion API will return an error until the user is successfully removed.
-		if err := r.setStatusCheUserDeletionInProgress(userAcc, cheUserID); err != nil {
-			return err
-		}
+	// Get the Che user ID to use in the Delete API
+	cheUserID, err := r.cheClient.GetUserIDByUsername(userAcc.Name)
+	if err != nil {
+		return err
 	}
 
 	// Delete the Che user. It is common for this call to return an error multiple times before succeeding
@@ -686,6 +668,5 @@ func (r *ReconcileUserAccount) lookupAndDeleteCheUser(userAcc *toolchainv1alpha1
 		return errs.Wrapf(err, "this error is expected if deletion is still in progress")
 	}
 
-	// Remove the Che user deletion condition when done
-	return r.removeStatusCondition(userAcc, toolchainv1alpha1.UserAccountCheCleanup)
+	return nil
 }

--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -564,27 +564,6 @@ func (r *ReconcileUserAccount) setStatusTerminating(userAcc *toolchainv1alpha1.U
 		})
 }
 
-func (r *ReconcileUserAccount) setStatusCheUserDeletionInProgress(userAcc *toolchainv1alpha1.UserAccount, message string) error {
-	return r.updateStatusConditions(
-		userAcc,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserAccountCheCleanup,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserAccountDeletingCheDataReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserAccount) removeStatusCondition(userAcc *toolchainv1alpha1.UserAccount, cType toolchainv1alpha1.ConditionType) error {
-	for i, cond := range userAcc.Status.Conditions {
-		if cond.Type == cType {
-			userAcc.Status.Conditions = append(userAcc.Status.Conditions[:i], userAcc.Status.Conditions[i+1:]...)
-			return r.client.Status().Update(context.TODO(), userAcc)
-		}
-	}
-	return nil
-}
-
 // updateStatusConditions updates user account status conditions with the new conditions
 func (r *ReconcileUserAccount) updateStatusConditions(userAcc *toolchainv1alpha1.UserAccount, newConditions ...toolchainv1alpha1.Condition) error {
 	var updated bool


### PR DESCRIPTION
Fix for bug https://issues.redhat.com/browse/CRT-891

Update the Che user deletion logic such that if the UserExists check comes back with a 404 then we won't continue further to call the DELETE API, we'll assume the Che data has been removed and continue with deactivation/removal.

It also removes the logic to remove the setting of the special condition that was used for caching the cheUserID value between attempts. We no longer need to cache the cheUserID because if we can't get it due to a 404 then it now means the user is removed, if cannot get it due to another response code then it will be an error condition set on the useraccount.