### PR TITLE
Che client status

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -42,6 +42,47 @@ spec:
             description: MemberStatusStatus defines the observed state of the toolchain
               member status
             properties:
+              che:
+                description: Che is the status of Che/CRW, such as installed and whether
+                  the member configuration for Che is correct
+                properties:
+                  conditions:
+                    description: 'Conditions is an array of current member operator
+                      status conditions Supported condition types: ConditionReady'
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transit from one status
+                            to another.
+                          format: date-time
+                          type: string
+                        lastUpdatedTime:
+                          description: Last time the condition was updated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Human readable message indicating details about
+                            last transition.
+                          type: string
+                        reason:
+                          description: (brief) reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of condition
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
               conditions:
                 description: 'Conditions is an array of current toolchain status conditions
                   Supported condition types: ConditionReady'

--- a/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -44,7 +44,7 @@ spec:
             properties:
               che:
                 description: Che is the status of Che/CRW, such as installed and whether
-                  the member configuration for Che is correct
+                  the member configuration is correct
                 properties:
                   conditions:
                     description: 'Conditions is an array of current member operator

--- a/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -47,8 +47,8 @@ spec:
                   the member configuration is correct
                 properties:
                   conditions:
-                    description: 'Conditions is an array of current member operator
-                      status conditions Supported condition types: ConditionReady'
+                    description: 'Conditions is an array of current Che status conditions
+                      Supported condition types: ConditionReady'
                     items:
                       properties:
                         lastTransitionTime:

--- a/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -42,6 +42,47 @@ spec:
             description: MemberStatusStatus defines the observed state of the toolchain
               member status
             properties:
+              che:
+                description: Che is the status of Che/CRW, such as installed and whether
+                  the member configuration for Che is correct
+                properties:
+                  conditions:
+                    description: 'Conditions is an array of current member operator
+                      status conditions Supported condition types: ConditionReady'
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transit from one status
+                            to another.
+                          format: date-time
+                          type: string
+                        lastUpdatedTime:
+                          description: Last time the condition was updated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Human readable message indicating details about
+                            last transition.
+                          type: string
+                        reason:
+                          description: (brief) reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of condition
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
               conditions:
                 description: 'Conditions is an array of current toolchain status conditions
                   Supported condition types: ConditionReady'

--- a/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -44,7 +44,7 @@ spec:
             properties:
               che:
                 description: Che is the status of Che/CRW, such as installed and whether
-                  the member configuration for Che is correct
+                  the member configuration is correct
                 properties:
                   conditions:
                     description: 'Conditions is an array of current member operator

--- a/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain_v1alpha1_memberstatus_crd.yaml
@@ -47,8 +47,8 @@ spec:
                   the member configuration is correct
                 properties:
                   conditions:
-                    description: 'Conditions is an array of current member operator
-                      status conditions Supported condition types: ConditionReady'
+                    description: 'Conditions is an array of current Che status conditions
+                      Supported condition types: ConditionReady'
                     items:
                       properties:
                         lastTransitionTime:

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/api => /Users/rajiv/go/src/github.com/codeready-toolchain/api
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20201218021903-cf2c667c66b9
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20201126155707-1094c3e32973
+	github.com/codeready-toolchain/api v0.0.0-20210106162323-f9e542b70ee3
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.3.0+incompatible
@@ -37,7 +37,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20201218021903-cf2c667c66b9
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -33,4 +33,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
+replace github.com/codeready-toolchain/api => /Users/rajiv/go/src/github.com/codeready-toolchain/api
+
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167 h1:SpP0O1myYOMZieSwPh9/wy3OeYnO+rOphpZahdrB3NA=
 github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20201126155707-1094c3e32973 h1:y6TReW2LNHM+CBa55cJIDcfjkvgcBPtz3ujhlywHGWY=
-github.com/codeready-toolchain/api v0.0.0-20201126155707-1094c3e32973/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/api v0.0.0-20210106162323-f9e542b70ee3 h1:72fCpY435uS+C20p+jtl+rn4DjBYyqofT+XtcyYmDvo=
+github.com/codeready-toolchain/api v0.0.0-20210106162323-f9e542b70ee3/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5 h1:Z+oKsj4+0WWY0+Zlvc46NX7syYN1uZekjZWPhFFkfIA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5/go.mod h1:TC5Q5FtNUwzpHNMLAkJXaxkifHwPJlZtrvnTWKIY+2M=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -798,8 +798,6 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20201218021903-cf2c667c66b9 h1:4EuvGjEcOCHumgPhwyQr0WxxFcG9W8kHc2+eGBz+pCM=
-github.com/rajivnathan/api v0.0.0-20201218021903-cf2c667c66b9/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/go.sum
+++ b/go.sum
@@ -798,6 +798,8 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/api v0.0.0-20201218021903-cf2c667c66b9 h1:4EuvGjEcOCHumgPhwyQr0WxxFcG9W8kHc2+eGBz+pCM=
+github.com/rajivnathan/api v0.0.0-20201218021903-cf2c667c66b9/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -167,6 +167,47 @@ data:
                   description: MemberStatusStatus defines the observed state of the toolchain
                     member status
                   properties:
+                    che:
+                      description: Che is the status of Che/CRW, such as installed and whether
+                        the member configuration for Che is correct
+                      properties:
+                        conditions:
+                          description: 'Conditions is an array of current member operator
+                            status conditions Supported condition types: ConditionReady'
+                          items:
+                            properties:
+                              lastTransitionTime:
+                                description: Last time the condition transit from one status
+                                  to another.
+                                format: date-time
+                                type: string
+                              lastUpdatedTime:
+                                description: Last time the condition was updated
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human readable message indicating details about
+                                  last transition.
+                                type: string
+                              reason:
+                                description: (brief) reason for the condition's last transition.
+                                type: string
+                              status:
+                                description: Status of the condition, one of True, False,
+                                  Unknown.
+                                type: string
+                              type:
+                                description: Type of condition
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - type
+                          x-kubernetes-list-type: map
+                      type: object
                     conditions:
                       description: 'Conditions is an array of current toolchain status conditions
                         Supported condition types: ConditionReady'

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -172,8 +172,8 @@ data:
                         the member configuration is correct
                       properties:
                         conditions:
-                          description: 'Conditions is an array of current member operator
-                            status conditions Supported condition types: ConditionReady'
+                          description: 'Conditions is an array of current Che status conditions
+                            Supported condition types: ConditionReady'
                           items:
                             properties:
                               lastTransitionTime:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -169,7 +169,7 @@ data:
                   properties:
                     che:
                       description: Che is the status of Che/CRW, such as installed and whether
-                        the member configuration for Che is correct
+                        the member configuration is correct
                       properties:
                         conditions:
                           description: 'Conditions is an array of current member operator

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -166,6 +166,12 @@ func (c *Client) cheRequest(method, endpoint string, queryParams url.Values) (*h
 	return c.httpClient.Do(req)
 }
 
+// IsCheIntegrationEnabled if the Che required configuration is set to 'true' and the Che admin username is set
+// then the member operator's che integration is enabled. Returns false otherwise
+func (c *Client) IsCheIntegrationEnabled() bool {
+	return c.config.IsCheRequired() && c.config.GetCheAdminUsername() != ""
+}
+
 // User holds the user data retrieved from the Che user API
 type User struct {
 	Name string `json:"name"`

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -166,10 +166,10 @@ func (c *Client) cheRequest(method, endpoint string, queryParams url.Values) (*h
 	return c.httpClient.Do(req)
 }
 
-// IsCheIntegrationEnabled if the Che required configuration is set to 'true' and the Che admin username is set
-// then the member operator's che integration is enabled. Returns false otherwise
+// IsCheIntegrationEnabled returns true if and only if IsCheRequired is 'true' and the Che admin username
+// and password are both set and not empty. Returns false otherwise
 func (c *Client) IsCheIntegrationEnabled() bool {
-	return c.config.IsCheRequired() && c.config.GetCheAdminUsername() != ""
+	return c.config.IsCheRequired() && c.config.GetCheAdminUsername() != "" && c.config.GetCheAdminPassword() != ""
 }
 
 // User holds the user data retrieved from the Che user API

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -166,12 +166,6 @@ func (c *Client) cheRequest(method, endpoint string, queryParams url.Values) (*h
 	return c.httpClient.Do(req)
 }
 
-// IsCheIntegrationEnabled returns true if and only if IsCheRequired is 'true' and the Che admin username
-// and password are both set and not empty. Returns false otherwise
-func (c *Client) IsCheIntegrationEnabled() bool {
-	return c.config.IsCheRequired() && c.config.GetCheAdminUsername() != "" && c.config.GetCheAdminPassword() != ""
-}
-
 // User holds the user data retrieved from the Che user API
 type User struct {
 	Name string `json:"name"`

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -120,6 +120,24 @@ func (c *Client) DeleteUser(userID string) error {
 	return err
 }
 
+// UserAPICheck returns an error if the Che user API cannot be reached successfully, returns nil otherwise
+func (c *Client) UserAPICheck() error {
+	reqData := url.Values{}
+	res, err := c.cheRequest(http.MethodGet, cheUserPath, reqData)
+	if err != nil {
+		return errors.Wrapf(err, "che user API check failed")
+	}
+	defer rest.CloseResponse(res)
+	if res.StatusCode == http.StatusOK {
+		return nil
+	}
+	resBody, readError := rest.ReadBody(res.Body)
+	if readError != nil {
+		log.Error(readError, "error while reading body of the che user API check response")
+	}
+	return errors.Errorf("che user API check failed, Response status: '%s' Body: '%s'", res.Status, resBody)
+}
+
 func (c *Client) cheRequest(method, endpoint string, queryParams url.Values) (*http.Response, error) {
 	// get Che route URL
 	cheURL, err := route.GetRouteURL(c.k8sClient, c.config.GetCheNamespace(), c.config.GetCheRouteName())

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -32,8 +32,14 @@ type TokenCache struct {
 
 // NewTokenCache creates a new instance of a TokenCache
 func NewTokenCache(cl *http.Client) *TokenCache {
+	return NewTokenCacheWithToken(cl, nil)
+}
+
+// NewTokenCacheWithToken creates a new instance of a TokenCache
+func NewTokenCacheWithToken(cl *http.Client, t *TokenSet) *TokenCache {
 	return &TokenCache{
 		httpClient: cl,
+		token:      t,
 	}
 }
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -55,7 +55,7 @@ const (
 	defaultCheRequired = false
 
 	// varCheUserDeletionEnabled is a way to turn the Che user deletion logic on/off
-	varCheUserDeletionEnabled = "che.user.deletion.enabled"
+	varCheUserDeletionEnabled = "che.user_deletion_enabled"
 
 	// defaultCheUserDeletionEnabled is the default value for che.required param
 	defaultCheUserDeletionEnabled = false

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -54,6 +54,12 @@ const (
 	// defaultCheRequired is the default value for che.required param
 	defaultCheRequired = false
 
+	// varCheUserDeletionEnabled is a way to turn the Che user deletion logic on/off
+	varCheUserDeletionEnabled = "che.user.deletion.enabled"
+
+	// defaultCheUserDeletionEnabled is the default value for che.required param
+	defaultCheUserDeletionEnabled = false
+
 	// varCheNamespace is the che route namespace
 	varCheNamespace = "che.namespace"
 
@@ -142,6 +148,7 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(varConsoleRouteName, defaultConsoleRouteName)
 	c.member.SetDefault(varCheNamespace, defaultCheNamespace)
 	c.member.SetDefault(varCheRequired, defaultCheRequired)
+	c.member.SetDefault(varCheUserDeletionEnabled, defaultCheUserDeletionEnabled)
 	c.member.SetDefault(varCheRouteName, defaultCheRouteName)
 	c.member.SetDefault(varCheKeycloakRouteName, defaultCheKeycloakRouteName)
 }
@@ -209,6 +216,11 @@ func (c *Config) GetConsoleRouteName() string {
 // IsCheRequired returns true if the Che operator is expected to be installed. May be used in monitoring.
 func (c *Config) IsCheRequired() bool {
 	return c.member.GetBool(varCheRequired)
+}
+
+// IsCheUserDeletionEnabled returns true if Che user deletion should be handled by the member operator
+func (c *Config) IsCheUserDeletionEnabled() bool {
+	return c.member.GetBool(varCheUserDeletionEnabled)
 }
 
 // GetCheNamespace returns the Che route namespace

--- a/pkg/controller/memberstatus/memberstatus_controller.go
+++ b/pkg/controller/memberstatus/memberstatus_controller.go
@@ -311,7 +311,7 @@ func (r *ReconcileMemberStatus) cheIntegrationHandleStatus(reqLogger logr.Logger
 		return nil
 	}
 
-	if r.config.GetCheAdminUsername() == "" || r.config.GetCheAdminPassword() == "" {
+	if !r.isCheAdminUserConfigured() {
 		err := fmt.Errorf("Che admin user credentials are not configured")
 		errCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberStatusCheAdminUserNotConfiguredReason, err.Error())
 		memberStatus.Status.Che.Conditions = []toolchainv1alpha1.Condition{*errCondition}

--- a/pkg/controller/memberstatus/memberstatus_controller.go
+++ b/pkg/controller/memberstatus/memberstatus_controller.go
@@ -42,7 +42,7 @@ const (
 	hostConnectionTag statusComponentTag = "hostConnection"
 	resourceUsageTag  statusComponentTag = "resourceUsage"
 	routesTag         statusComponentTag = "routes"
-	cheIntegrationTag statusComponentTag = "cheIntegration"
+	cheTag            statusComponentTag = "che"
 
 	labelNodeRoleMaster = "node-role.kubernetes.io/master"
 	labelNodeRoleWorker = "node-role.kubernetes.io/worker"
@@ -141,7 +141,7 @@ func (r *ReconcileMemberStatus) aggregateAndUpdateStatus(reqLogger logr.Logger, 
 		{name: hostConnectionTag, handleStatus: r.hostConnectionHandleStatus},
 		{name: resourceUsageTag, handleStatus: r.loadCurrentResourceUsage},
 		{name: routesTag, handleStatus: r.routesHandleStatus},
-		{name: cheIntegrationTag, handleStatus: r.cheIntegrationHandleStatus},
+		{name: cheTag, handleStatus: r.cheHandleStatus},
 	}
 
 	// Track components that are not ready
@@ -296,9 +296,9 @@ func (r *ReconcileMemberStatus) routesHandleStatus(reqLogger logr.Logger, member
 	return nil
 }
 
-// cheIntegrationHandleStatus checks all necessary aspects related integration between the member operator and Che
+// cheHandleStatus checks all necessary aspects related integration between the member operator and Che
 // Returns an error if any problems are discovered.
-func (r *ReconcileMemberStatus) cheIntegrationHandleStatus(reqLogger logr.Logger, memberStatus *toolchainv1alpha1.MemberStatus) error {
+func (r *ReconcileMemberStatus) cheHandleStatus(reqLogger logr.Logger, memberStatus *toolchainv1alpha1.MemberStatus) error {
 	if memberStatus.Status.Che == nil {
 		memberStatus.Status.Che = &toolchainv1alpha1.CheStatus{}
 	}

--- a/pkg/controller/memberstatus/memberstatus_controller.go
+++ b/pkg/controller/memberstatus/memberstatus_controller.go
@@ -432,9 +432,8 @@ func (r *ReconcileMemberStatus) cheDashboardURL() (string, error) {
 	return fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, route.Spec.Path), nil
 }
 
-// IsCheAdminUserConfigured returns true if the Che admin username and password are both set and not empty.
-// Returns false otherwise. This is a way to disable the Che user deletion logic since
-// it's meant to be a temporary measure until Che is updated to handle user deletion on its own.
+// isCheAdminUserConfigured returns true if the Che admin username and password are both set and not empty.
+// Returns false otherwise.
 func (r *ReconcileMemberStatus) isCheAdminUserConfigured() bool {
 	return r.config.GetCheAdminUsername() != "" && r.config.GetCheAdminPassword() != ""
 }

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -489,7 +489,7 @@ func TestOverallStatusCondition(t *testing.T) {
 				HasCondition(ComponentsReady()).
 				HasMemoryUsage(OfNodeRole("master", 33), OfNodeRole("worker", 25)).
 				HasRoutes("https://console.member-cluster/console/", "http://codeready-codeready-workspaces-operator.member-cluster/che/", routesAvailable()).
-				HasCheConditions(cheIntegrationReady())
+				HasCheConditions(cheReady())
 		})
 
 		t.Run("che admin user not configured (no member secret)", func(t *testing.T) {
@@ -511,7 +511,7 @@ func TestOverallStatusCondition(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, requeueResult, res)
 			AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
-				HasCondition(ComponentsNotReady("cheIntegration")).
+				HasCondition(ComponentsNotReady("che")).
 				HasMemoryUsage(OfNodeRole("master", 33), OfNodeRole("worker", 25)).
 				HasRoutes("https://console.member-cluster/console/", "http://codeready-codeready-workspaces-operator.member-cluster/che/", routesAvailable()).
 				HasCheConditions(cheAdminUserNotConfigured("Che admin user credentials are not configured"))
@@ -536,7 +536,7 @@ func TestOverallStatusCondition(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, requeueResult, res)
 			AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
-				HasCondition(ComponentsNotReady("routes", "cheIntegration")).
+				HasCondition(ComponentsNotReady("routes", "che")).
 				HasMemoryUsage(OfNodeRole("master", 33), OfNodeRole("worker", 25)).
 				HasRoutes("https://console.member-cluster/console/", "", cheRouteUnavailable(`routes.route.openshift.io "codeready" not found`)).
 				HasCheConditions(cheRouteUnavailable(`routes.route.openshift.io "codeready" not found`))
@@ -561,7 +561,7 @@ func TestOverallStatusCondition(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, requeueResult, res)
 			AssertThatMemberStatus(t, req.Namespace, requestName, fakeClient).
-				HasCondition(ComponentsNotReady("cheIntegration")).
+				HasCondition(ComponentsNotReady("che")).
 				HasMemoryUsage(OfNodeRole("master", 33), OfNodeRole("worker", 25)).
 				HasRoutes("https://console.member-cluster/console/", "http://codeready-codeready-workspaces-operator.member-cluster/che/", routesAvailable()).
 				HasCheConditions(cheUserAPICheckError(`che user API check failed: Get "http://codeready-codeready-workspaces-operator.member-cluster/che/api/user": dial tcp: lookup codeready-codeready-workspaces-operator.member-cluster: no such host`))
@@ -763,7 +763,7 @@ func cheTestClient(cfg *configuration.Config, httpCl *http.Client, cl client.Cli
 	return che.NewCheClient(cfg, http.DefaultClient, cl, tokenCache)
 }
 
-func cheIntegrationReady() toolchainv1alpha1.Condition {
+func cheReady() toolchainv1alpha1.Condition {
 	return *status.NewComponentReadyCondition("CheReady")
 }
 

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -564,7 +564,7 @@ func TestOverallStatusCondition(t *testing.T) {
 				HasCondition(ComponentsNotReady("cheIntegration")).
 				HasMemoryUsage(OfNodeRole("master", 33), OfNodeRole("worker", 25)).
 				HasRoutes("https://console.member-cluster/console/", "http://codeready-codeready-workspaces-operator.member-cluster/che/", routesAvailable()).
-				HasCheConditions(cheIntegrationAPICheckError(`che user API check failed: Get "http://codeready-codeready-workspaces-operator.member-cluster/che/api/user": dial tcp: lookup codeready-codeready-workspaces-operator.member-cluster: no such host`))
+				HasCheConditions(cheUserAPICheckError(`che user API check failed: Get "http://codeready-codeready-workspaces-operator.member-cluster/che/api/user": dial tcp: lookup codeready-codeready-workspaces-operator.member-cluster: no such host`))
 		})
 	})
 }
@@ -771,6 +771,6 @@ func cheAdminUserNotConfigured(msg string) toolchainv1alpha1.Condition {
 	return *status.NewComponentErrorCondition("CheAdminUserNotConfigured", msg)
 }
 
-func cheIntegrationAPICheckError(msg string) toolchainv1alpha1.Condition {
+func cheUserAPICheckError(msg string) toolchainv1alpha1.Condition {
 	return *status.NewComponentErrorCondition("CheUserAPICheckFailed", msg)
 }

--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -641,7 +641,7 @@ func ToIdentityName(userID string, identityProvider IdentityProvider) string {
 func (r *ReconcileUserAccount) lookupAndDeleteCheUser(userAcc *toolchainv1alpha1.UserAccount) error {
 
 	// If the admin username is not set then Che user deletion is not configured, just return
-	if r.config.GetCheAdminUsername() == "" {
+	if r.cheClient.IsCheIntegrationEnabled() {
 		log.Info("Che user deletion is not configured, configure the Che admin credentials to enable it")
 		return nil
 	}

--- a/pkg/controller/useraccount/useraccount_controller.go
+++ b/pkg/controller/useraccount/useraccount_controller.go
@@ -619,9 +619,10 @@ func ToIdentityName(userID string, identityProvider IdentityProvider) string {
 
 func (r *ReconcileUserAccount) lookupAndDeleteCheUser(userAcc *toolchainv1alpha1.UserAccount) error {
 
-	// If the admin username is not set then Che user deletion is not configured, just return
-	if r.cheClient.IsCheIntegrationEnabled() {
-		log.Info("Che user deletion is not configured, configure the Che admin credentials to enable it")
+	// If Che user deletion is not required then just return, this is a way to disable this Che user deletion logic since
+	// it's meant to be a temporary measure until Che is updated to handle user deletion on its own
+	if !r.config.IsCheUserDeletionEnabled() {
+		log.Info("Che user deletion is not enabled, skipping it")
 		return nil
 	}
 

--- a/pkg/controller/useraccount/useraccount_controller_test.go
+++ b/pkg/controller/useraccount/useraccount_controller_test.go
@@ -613,6 +613,7 @@ func TestReconcile(t *testing.T) {
 		restore := test.SetEnvVarsAndRestore(t,
 			test.Env("WATCH_NAMESPACE", test.MemberOperatorNs),
 			test.Env("MEMBER_OPERATOR_SECRET_NAME", "test-secret"),
+			test.Env(configuration.MemberEnvPrefix+"_"+"CHE_USER_DELETION_ENABLED", "true"),
 			// Che has two different routes for Che & Keycloak but CRW uses a single route for both.
 			// For tests we'll assume they're two different routes.
 			test.Env(configuration.MemberEnvPrefix+"_CHE_KEYCLOAK_ROUTE_NAME", "keycloak"),
@@ -788,6 +789,7 @@ func TestReconcile(t *testing.T) {
 		restore := test.SetEnvVarsAndRestore(t,
 			test.Env("WATCH_NAMESPACE", test.MemberOperatorNs),
 			test.Env("MEMBER_OPERATOR_SECRET_NAME", "test-secret"),
+			test.Env(configuration.MemberEnvPrefix+"_"+"CHE_USER_DELETION_ENABLED", "true"),
 			// Che has two different routes for Che & Keycloak but CRW uses a single route for both.
 			// For tests we'll assume they're two different routes.
 			test.Env(configuration.MemberEnvPrefix+"_CHE_KEYCLOAK_ROUTE_NAME", "keycloak"),
@@ -1247,6 +1249,7 @@ func TestLookupAndDeleteCheUser(t *testing.T) {
 		restore := test.SetEnvVarsAndRestore(t,
 			test.Env("WATCH_NAMESPACE", test.MemberOperatorNs),
 			test.Env("MEMBER_OPERATOR_SECRET_NAME", "test-secret"),
+			test.Env(configuration.MemberEnvPrefix+"_"+"CHE_USER_DELETION_ENABLED", "true"),
 			// Che has two different routes for Che & Keycloak but CRW uses a single route for both.
 			// For tests we'll assume they're two different routes.
 			test.Env(configuration.MemberEnvPrefix+"_CHE_KEYCLOAK_ROUTE_NAME", "keycloak"),

--- a/test/memberstatus_assertion.go
+++ b/test/memberstatus_assertion.go
@@ -105,6 +105,14 @@ func (a *MemberStatusAssertion) HasRoutes(consoleUrl, cheUrl string, expConditio
 	return a
 }
 
+func (a *MemberStatusAssertion) HasCheConditions(expCondition toolchainv1alpha1.Condition) *MemberStatusAssertion {
+	err := a.loadMemberStatus()
+	require.NoError(a.t, err)
+	require.NotNil(a.t, a.memberStatus.Status.Che)
+	test.AssertConditionsMatch(a.t, a.memberStatus.Status.Che.Conditions, expCondition)
+	return a
+}
+
 func ComponentsReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,


### PR DESCRIPTION
🚨  **IMPORTANT:** 🚨 
The user deletion enabled config variable must be set to true on the member operator config maps on staging and production *before* merging this PR:

```
che:
  user_deletion_enabled: true
```

**Description:**
Adds a new section to the memberstatus specifically for any Che integrations.

**Detects the following problem conditions and exposes them as part of the member status:**
- che admin credentials not configured when Che user deletion is enabled
- che route not found
- unable to successfully access Che user API

**Additional changes:**
- adds a new config variable specifically for enabling/disabling the Che user deletion logic

**Example status:**
```
status:
  che:
    conditions:
    - lastTransitionTime: "2020-12-18T00:35:55Z"
      lastUpdatedTime: "2020-12-18T00:35:55Z"
      message: 'che user API check failed: unable to obtain access token for che,
        Response status: ''401 Unauthorized''. Response body: ''{"error":"invalid_grant","error_description":"Invalid
        user credentials"}'''
      reason: CheUserAPICheckFailed
      status: "False"
      type: Ready
  conditions:
  - lastTransitionTime: "2020-12-18T00:35:55Z"
    lastUpdatedTime: "2020-12-18T00:35:55Z"
    message: 'components not ready: [cheIntegration]'
    reason: ComponentsNotReady
    status: "False"
    type: Ready
  host:
    conditions:
    - lastTransitionTime: "2020-12-18T00:35:55Z"
      lastUpdatedTime: "2020-12-18T00:35:55Z"
      reason: HostConnectionReady
      status: "True"
      type: Ready
```