### PR TITLE
Webhook deploy config

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -167,7 +167,7 @@ func main() {
 		}
 
 		// By default the users' pods webhook will be deployed, however in some cases (eg. e2e tests) there can be multiple member operators
-		// installed in the same cluster. In those cases only 1 webhook is needed because the MutatingWebhookConfiguration is a cluster-scoped resource.
+		// installed in the same cluster. In those cases only 1 webhook is needed because the MutatingWebhookConfiguration is a cluster-scoped resource and naming can conflict.
 		if crtConfig.DoDeployWebhook() {
 			log.Info("(Re)Deploying users' pods webhook")
 			if err := deploy.Webhook(mgr.GetClient(), mgr.GetScheme(), namespace, crtConfig.GetMemberOperatorWebhookImage()); err != nil {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -86,6 +86,12 @@ const (
 
 	// varWebhookImage contains the image location of the member-operator-webhook
 	varWebhookImage = "webhook.image"
+
+	// varDeployWebhook determines whether a webhook deployment will be created
+	varDeployWebhook = "deploy.webhook"
+
+	// defaultDeployWebhook is true by default
+	defaultDeployWebhook = true
 )
 
 // ToolchainCluster configuration constants
@@ -151,6 +157,7 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(varCheUserDeletionEnabled, defaultCheUserDeletionEnabled)
 	c.member.SetDefault(varCheRouteName, defaultCheRouteName)
 	c.member.SetDefault(varCheKeycloakRouteName, defaultCheKeycloakRouteName)
+	c.member.SetDefault(varDeployWebhook, defaultDeployWebhook)
 }
 
 func (c *Config) Print() {
@@ -251,4 +258,9 @@ func (c *Config) GetCheAdminPassword() string {
 // GetMemberOperatorWebhookImage returns the member operator webhook image location
 func (c *Config) GetMemberOperatorWebhookImage() string {
 	return c.member.GetString(varWebhookImage)
+}
+
+// DoDeployWebhook returns true if the Webhook should be deployed
+func (c *Config) DoDeployWebhook() bool {
+	return c.member.GetBool(varDeployWebhook)
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -348,3 +348,23 @@ func TestGetMemberOperatorWebhookImage(t *testing.T) {
 		assert.Equal(t, "quay.io/cool/member-operator-webhook:123", config.GetMemberOperatorWebhookImage())
 	})
 }
+
+func TestDoDeployWebhook(t *testing.T) {
+	key := MemberEnvPrefix + "_DEPLOY_WEBHOOK"
+	resetFunc := test.UnsetEnvVarAndRestore(t, key)
+	defer resetFunc()
+
+	t.Run("default", func(t *testing.T) {
+		resetFunc := test.UnsetEnvVarAndRestore(t, key)
+		defer resetFunc()
+		config := getDefaultConfiguration(t)
+		assert.True(t, config.DoDeployWebhook())
+	})
+
+	t.Run("from var", func(t *testing.T) {
+		restore := test.SetEnvVarsAndRestore(t, test.Env(key, "false"))
+		defer restore()
+		config := getDefaultConfiguration(t)
+		assert.False(t, config.DoDeployWebhook())
+	})
+}


### PR DESCRIPTION
By default the users' pods webhook will be deployed, however in some cases (eg. e2e tests) there can be multiple member operators installed in the same cluster. In those cases only 1 webhook is needed because the MutatingWebhookConfiguration is a cluster-scoped resource and naming can conflict.

This PR adds a new configuration option that can toggle whether or not the member operator will deploy the webhook and create the associated `MutatingWebhookConfiguration` resource as well. It will be used by the e2e test setup to disable the deployment of the users' pods webhook.

Related issue:
https://issues.redhat.com/browse/CRT-770