### PR TITLE
Add predicate to ignore CRQ status changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210106162323-f9e542b70ee3
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6
+	github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210302144622-6e274ed57e69
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/google/go-cmp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -146,14 +146,10 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167 h1:SpP0O1myYOMZieSwPh9/wy3OeYnO+rOphpZahdrB3NA=
-github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20210106162323-f9e542b70ee3 h1:72fCpY435uS+C20p+jtl+rn4DjBYyqofT+XtcyYmDvo=
-github.com/codeready-toolchain/api v0.0.0-20210106162323-f9e542b70ee3/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5 h1:Z+oKsj4+0WWY0+Zlvc46NX7syYN1uZekjZWPhFFkfIA=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20201014231429-a44cccb4b2b5/go.mod h1:TC5Q5FtNUwzpHNMLAkJXaxkifHwPJlZtrvnTWKIY+2M=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6 h1:WyhQHwHbn1owc2kQHdujtUvUCALF1rqrWVt7s6z7rWg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210209125948-7a9e8c9e4ee6/go.mod h1:F5agtgfX0aEhhLwQC9l3kdpUiaWovOaSouhabpeIxzo=
+github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101 h1:oKHlw3jQXcMX8AbAlCdzn8ZS58jnGtjT7ItG5oaistM=
+github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210302144622-6e274ed57e69 h1:OSBZqgJ8hOJ29+qh9Qy2qsRRQX2qr7hapu4pIUGCJig=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210302144622-6e274ed57e69/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -902,8 +898,6 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
-github.com/xcoulon/toolchain-common v0.0.0-20210209111506-89a1e762b86b h1:W3ZSbKiepP+B0pylZ8abnBlbzdV3eXnyxO91JGaU0+E=
-github.com/xcoulon/toolchain-common v0.0.0-20210209111506-89a1e762b86b/go.mod h1:F5agtgfX0aEhhLwQC9l3kdpUiaWovOaSouhabpeIxzo=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/controller/nstemplateset/nstemplateset_controller.go
+++ b/pkg/controller/nstemplateset/nstemplateset_controller.go
@@ -74,16 +74,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// watch for all cluster resource kinds associated with an NSTemplateSet
 	for _, clusterResource := range clusterResourceKinds {
-		switch clusterResource.gvk.Kind {
-		case "ClusterResourceQuota":
-			// ignore status changes for ClusterResourceQuotas
-			if err := c.Watch(&source.Kind{Type: clusterResource.objectType}, commoncontroller.MapToOwnerByLabel("", toolchainv1alpha1.OwnerLabelKey), predicate.GenerationChangedPredicate{}); err != nil {
-				return err
-			}
-		default:
-			if err := c.Watch(&source.Kind{Type: clusterResource.objectType}, commoncontroller.MapToOwnerByLabel("", toolchainv1alpha1.OwnerLabelKey)); err != nil {
-				return err
-			}
+		// only reconcile generation changes for cluster resources
+		if err := c.Watch(&source.Kind{Type: clusterResource.objectType}, commoncontroller.MapToOwnerByLabel("", toolchainv1alpha1.OwnerLabelKey), predicate.GenerationChangedPredicate{}); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-941

As part of the split up of the cluster resource quotas there will be even more reconciles of the NSTemplateSet controller since it's watching for changes to cluster level resources. However, the controller is only really interested in changes to the spec so this PR adds a watch predicate for generation changes so that status changes will not trigger reconciles.