### PR TITLE
Use ubuntu-18.04 in GH Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
   binary:
     name: Build & push a new operator release
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
So, we install podman 3.0 instead of 3.1.0 which has a critical bug.