### PR TITLE
Use constant for member status name

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -184,7 +184,7 @@ func main() {
 
 		// create or update Member status during the operator deployment
 		log.Info("Creating/updating the MemberStatus resource")
-		memberStatusName := crtConfig.GetMemberStatusName()
+		memberStatusName := configuration.MemberStatusName
 		if err := memberstatus.CreateOrUpdateResources(mgr.GetClient(), mgr.GetScheme(), namespace, memberStatusName); err != nil {
 			log.Error(err, "cannot create/update MemberStatus resource")
 			os.Exit(1)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -19,17 +19,12 @@ var log = logf.Log.WithName("configuration")
 // prefixes
 const (
 	// MemberEnvPrefix will be used for member environment variable name prefixing.
-	MemberEnvPrefix = "MEMBER_OPERATOR"
+	MemberEnvPrefix  = "MEMBER_OPERATOR"
+	MemberStatusName = "toolchain-member-status"
 )
 
 // Configuration constants
 const (
-	// MemberStatusName specifies the name of the toolchain member status resource that provides information about the toolchain components in this cluster
-	MemberStatusName = "member.status"
-
-	// DefaultMemberStatusName the default name for the member status resource created during initialization of the operator
-	DefaultMemberStatusName = "toolchain-member-status"
-
 	// varMemberStatusRefreshTime specifies how often the MemberStatus should load and refresh the current member cluster status
 	varMemberStatusRefreshTime = "memberstatus.refresh.time"
 
@@ -145,7 +140,6 @@ func LoadConfig(cl client.Client) (*Config, error) {
 
 func (c *Config) setConfigDefaults() {
 	c.member.SetTypeByDefaultValue(true)
-	c.member.SetDefault(MemberStatusName, DefaultMemberStatusName)
 	c.member.SetDefault(clusterHealthCheckPeriod, defaultClusterHealthCheckPeriod)
 	c.member.SetDefault(toolchainClusterTimeout, defaultClusterHealthCheckTimeout)
 	c.member.SetDefault(identityProviderName, defaultIdentityProviderName)
@@ -188,11 +182,6 @@ func (c *Config) GetAllMemberParameters() map[string]string {
 // Openshift clusters can be configured with multiple IdPs. This config option allows admins to specify which IdP should be used by the toolchain operator.
 func (c *Config) GetIdP() string { //nolint: golint
 	return c.member.GetString(identityProviderName)
-}
-
-// GetMemberStatusName returns the configured name of the member status resource
-func (c *Config) GetMemberStatusName() string {
-	return c.member.GetString(MemberStatusName)
 }
 
 // GetClusterHealthCheckPeriod returns the configured cluster health check period

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -217,27 +217,6 @@ func TestGetIdP(t *testing.T) {
 	})
 }
 
-func TestGetMemberClusterName(t *testing.T) {
-	key := MemberEnvPrefix + "_MEMBER_STATUS"
-	resetFunc := test.UnsetEnvVarAndRestore(t, key)
-	defer resetFunc()
-
-	t.Run("default", func(t *testing.T) {
-		resetFunc := test.UnsetEnvVarAndRestore(t, key)
-		defer resetFunc()
-		config := getDefaultConfiguration(t)
-		assert.Equal(t, "toolchain-member-status", config.GetMemberStatusName())
-	})
-
-	t.Run("env overwrite", func(t *testing.T) {
-		restore := test.SetEnvVarsAndRestore(t,
-			test.Env(key, "testingMemberStatusName"))
-		defer restore()
-		config := getDefaultConfiguration(t)
-		assert.Equal(t, "testingMemberStatusName", config.GetMemberStatusName())
-	})
-}
-
 func TestGetClusterHealthCheckPeriod(t *testing.T) {
 	key := MemberEnvPrefix + "_CLUSTER_HEALTHCHECK_PERIOD"
 	resetFunc := test.UnsetEnvVarAndRestore(t, key)

--- a/pkg/controller/memberstatus/creation_test.go
+++ b/pkg/controller/memberstatus/creation_test.go
@@ -27,7 +27,7 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		cl := NewFakeClient(t)
 
 		// when
-		err = CreateOrUpdateResources(cl, s, MemberOperatorNs, configuration.DefaultMemberStatusName)
+		err = CreateOrUpdateResources(cl, s, MemberOperatorNs, configuration.MemberStatusName)
 
 		// then
 		require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestCreateOrUpdateResources(t *testing.T) {
 		}
 
 		// when
-		err = CreateOrUpdateResources(cl, s, MemberOperatorNs, configuration.DefaultMemberStatusName)
+		err = CreateOrUpdateResources(cl, s, MemberOperatorNs, configuration.MemberStatusName)
 
 		// then
 		require.Error(t, err)

--- a/pkg/controller/memberstatus/memberstatus_controller_test.go
+++ b/pkg/controller/memberstatus/memberstatus_controller_test.go
@@ -39,7 +39,7 @@ var requeueResult = reconcile.Result{RequeueAfter: 5 * time.Second}
 
 const defaultMemberOperatorName = "member-operator"
 
-const defaultMemberStatusName = configuration.DefaultMemberStatusName
+const defaultMemberStatusName = configuration.MemberStatusName
 
 // che test constants
 const (


### PR DESCRIPTION
No need for memberstatus name to be configurable, we'll just hardcode it to "toolchain-member-status"