### PR TITLE
Memberoperatorconfig controller

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -11,6 +11,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/controllers/idler"
+	"github.com/codeready-toolchain/member-operator/controllers/memberoperatorconfig"
 	"github.com/codeready-toolchain/member-operator/controllers/memberstatus"
 	"github.com/codeready-toolchain/member-operator/controllers/nstemplateset"
 	"github.com/codeready-toolchain/member-operator/controllers/useraccount"
@@ -224,6 +225,13 @@ func main() {
 		GetHostCluster: cluster.GetHostCluster,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UserAccountStatus")
+		os.Exit(1)
+	}
+	if err = (&memberoperatorconfig.Reconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "MemberOperatorConfig")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder

--- a/controllers/memberoperatorconfig/cache.go
+++ b/controllers/memberoperatorconfig/cache.go
@@ -1,0 +1,76 @@
+package memberoperatorconfig
+
+import (
+	"context"
+	"sync"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var configCache = &cache{}
+
+var cacheLog = logf.Log.WithName("cache_memberoperatorconfig")
+
+type cache struct {
+	sync.RWMutex
+	config *toolchainv1alpha1.MemberOperatorConfig
+}
+
+func (c *cache) set(config *toolchainv1alpha1.MemberOperatorConfig) {
+	c.Lock()
+	defer c.Unlock()
+	c.config = config.DeepCopy()
+}
+
+func (c *cache) get() *toolchainv1alpha1.MemberOperatorConfig {
+	c.RLock()
+	defer c.RUnlock()
+	return c.config.DeepCopy()
+}
+
+func updateConfig(config *toolchainv1alpha1.MemberOperatorConfig) {
+	configCache.set(config)
+}
+
+func loadLatest(cl client.Client, namespace string) error {
+	config := &toolchainv1alpha1.MemberOperatorConfig{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: "config"}, config); err != nil {
+		if apierrors.IsNotFound(err) {
+			cacheLog.Info("MemberOperatorConfig resource with the name 'config' wasn't found, default configuration will be used", "namespace", namespace)
+			return nil
+		}
+		return err
+	}
+	configCache.set(config)
+	return nil
+}
+
+// GetConfig returns a cached host-operator config.
+// If no config is stored in the cache, then it retrieves it from the cluster and stores in the cache.
+// If the resource is not found, then returns the default config.
+// If any failure happens while getting the MemberOperatorConfig resource, then returns an error.
+func GetConfig(cl client.Client, namespace string) (MemberOperatorConfig, error) {
+	config := configCache.get()
+	if config == nil {
+		err := loadLatest(cl, namespace)
+		if err != nil {
+			return MemberOperatorConfig{cfg: &toolchainv1alpha1.MemberOperatorConfigSpec{}}, err
+		}
+		config = configCache.get()
+	}
+	if config == nil {
+		return MemberOperatorConfig{cfg: &toolchainv1alpha1.MemberOperatorConfigSpec{}}, nil
+	}
+	return MemberOperatorConfig{cfg: &config.Spec}, nil
+}
+
+// Reset resets the cache.
+// Should be used only in tests, but since it has to be used in other packages,
+// then the function has to be exported and placed here.
+func Reset() {
+	configCache = &cache{}
+}

--- a/controllers/memberoperatorconfig/cache_test.go
+++ b/controllers/memberoperatorconfig/cache_test.go
@@ -1,0 +1,144 @@
+package memberoperatorconfig
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCache(t *testing.T) {
+	// given
+	cl := NewFakeClient(t)
+
+	// when
+	defaultConfig, err := GetConfig(cl, MemberOperatorNs)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, defaultConfig.MemberStatus().RefreshPeriod())
+
+	t.Run("return config that is stored in client", func(t *testing.T) {
+		// given
+		config := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("10s"))
+		cl := NewFakeClient(t, config)
+
+		// when
+		actual, err := GetConfig(cl, MemberOperatorNs)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Second, actual.MemberStatus().RefreshPeriod())
+
+		t.Run("returns the same when the cache hasn't been updated", func(t *testing.T) {
+			// given
+			newConfig := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("10s"))
+			cl := NewFakeClient(t, newConfig)
+
+			// when
+			actual, err := GetConfig(cl, MemberOperatorNs)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, 10*time.Second, actual.MemberStatus().RefreshPeriod())
+		})
+
+		t.Run("returns the new config when the cache was updated", func(t *testing.T) {
+			// given
+			newConfig := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("11s"))
+			cl := NewFakeClient(t)
+
+			// when
+			updateConfig(newConfig)
+
+			// then
+			actual, err := GetConfig(cl, MemberOperatorNs)
+			require.NoError(t, err)
+			assert.Equal(t, 11*time.Second, actual.MemberStatus().RefreshPeriod())
+		})
+	})
+}
+
+func TestGetConfigFailed(t *testing.T) {
+	// given
+	t.Run("config not found", func(t *testing.T) {
+		config := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("11s"))
+		cl := NewFakeClient(t, config)
+		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+			return apierrors.NewNotFound(schema.GroupResource{}, "config")
+		}
+
+		// when
+		defaultConfig, err := GetConfig(cl, MemberOperatorNs)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Second, defaultConfig.MemberStatus().RefreshPeriod())
+
+	})
+
+	t.Run("error getting config", func(t *testing.T) {
+		config := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("11s"))
+		cl := NewFakeClient(t, config)
+		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		defaultConfig, err := GetConfig(cl, MemberOperatorNs)
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, 5*time.Second, defaultConfig.MemberStatus().RefreshPeriod())
+
+	})
+}
+
+func TestMultipleExecutionsInParallel(t *testing.T) {
+	// given
+	var latch sync.WaitGroup
+	latch.Add(1)
+	var waitForFinished sync.WaitGroup
+	initconfig := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("1s"))
+	cl := NewFakeClient(t, initconfig)
+
+	for i := 1; i < 1001; i++ {
+		waitForFinished.Add(2)
+		go func() {
+			defer waitForFinished.Done()
+			latch.Wait()
+
+			// when
+			config, err := GetConfig(cl, MemberOperatorNs)
+
+			// then
+			require.NoError(t, err)
+			assert.NotEmpty(t, config.MemberStatus().RefreshPeriod())
+		}()
+		go func(i int) {
+			defer waitForFinished.Done()
+			latch.Wait()
+			config := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod(fmt.Sprintf("%ds", i)))
+			updateConfig(config)
+		}(i)
+	}
+
+	// when
+	latch.Done()
+	waitForFinished.Wait()
+	config, err := GetConfig(NewFakeClient(t), MemberOperatorNs)
+
+	// then
+	require.NoError(t, err)
+	assert.NotEmpty(t, config.MemberStatus().RefreshPeriod())
+}

--- a/controllers/memberoperatorconfig/configuration.go
+++ b/controllers/memberoperatorconfig/configuration.go
@@ -28,20 +28,6 @@ func (a MemberStatusConfig) RefreshPeriod() time.Duration {
 	return d
 }
 
-func getBool(value *bool, defaultValue bool) bool {
-	if value != nil {
-		return *value
-	}
-	return defaultValue
-}
-
-func getInt(value *int, defaultValue int) int {
-	if value != nil {
-		return *value
-	}
-	return defaultValue
-}
-
 func getString(value *string, defaultValue string) string {
 	if value != nil {
 		return *value

--- a/controllers/memberoperatorconfig/configuration.go
+++ b/controllers/memberoperatorconfig/configuration.go
@@ -1,0 +1,50 @@
+package memberoperatorconfig
+
+import (
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+)
+
+type MemberOperatorConfig struct {
+	cfg *toolchainv1alpha1.MemberOperatorConfigSpec
+}
+
+func (c *MemberOperatorConfig) MemberStatus() MemberStatusConfig {
+	return MemberStatusConfig{c.cfg.MemberStatus}
+}
+
+type MemberStatusConfig struct {
+	memberStatus toolchainv1alpha1.MemberStatusConfig
+}
+
+func (a MemberStatusConfig) RefreshPeriod() time.Duration {
+	defaultRefreshPeriod := "5s"
+	refreshPeriod := getString(a.memberStatus.RefreshPeriod, defaultRefreshPeriod)
+	d, err := time.ParseDuration(refreshPeriod)
+	if err != nil {
+		d, _ = time.ParseDuration(defaultRefreshPeriod)
+	}
+	return d
+}
+
+func getBool(value *bool, defaultValue bool) bool {
+	if value != nil {
+		return *value
+	}
+	return defaultValue
+}
+
+func getInt(value *int, defaultValue int) int {
+	if value != nil {
+		return *value
+	}
+	return defaultValue
+}
+
+func getString(value *string, defaultValue string) string {
+	if value != nil {
+		return *value
+	}
+	return defaultValue
+}

--- a/controllers/memberoperatorconfig/configuration_test.go
+++ b/controllers/memberoperatorconfig/configuration_test.go
@@ -1,0 +1,25 @@
+package memberoperatorconfig
+
+import (
+	"testing"
+	"time"
+
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemberStatusConfig(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := newMemberOperatorConfigWithReset(t)
+		memberOperatorCfg := MemberOperatorConfig{cfg: &cfg.Spec}
+
+		assert.Equal(t, 5*time.Second, memberOperatorCfg.MemberStatus().RefreshPeriod())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("10s"))
+		memberOperatorCfg := MemberOperatorConfig{cfg: &cfg.Spec}
+
+		assert.Equal(t, 10*time.Second, memberOperatorCfg.MemberStatus().RefreshPeriod())
+	})
+}

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
@@ -1,0 +1,78 @@
+package memberoperatorconfig
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const configResourceName = "config"
+
+// Requeue every 10 seconds by default to ensure the MemberOperatorConfig on each member remains synchronized with the MemberOperatorConfig
+var defaultReconcile = reconcile.Result{RequeueAfter: 10 * time.Second}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("memberoperatorconfig-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource MemberOperatorConfig
+	return c.Watch(&source.Kind{Type: &toolchainv1alpha1.MemberOperatorConfig{}}, &handler.EnqueueRequestForObject{}, &predicate.GenerationChangedPredicate{})
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
+	return add(mgr, r)
+}
+
+// Reconciler reconciles a MemberOperatorConfig object
+type Reconciler struct {
+	Client client.Client
+	Log    logr.Logger
+}
+
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=memberoperatorconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=memberoperatorconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=memberoperatorconfigs/finalizers,verbs=update
+
+// Reconcile reads that state of the cluster for a MemberOperatorConfig object and makes changes based on the state read
+// and what is in the MemberOperatorConfig.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := r.Log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling MemberOperatorConfig")
+
+	// Fetch the MemberOperatorConfig instance
+	memberconfig := &toolchainv1alpha1.MemberOperatorConfig{}
+	err := r.Client.Get(context.TODO(), request.NamespacedName, memberconfig)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			reqLogger.Error(err, "it looks like the MemberOperatorConfig resource with the name 'config' was removed - the cache will use the latest version of the resource")
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+	updateConfig(memberconfig)
+	return reconcile.Result{}, nil
+}

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
@@ -2,7 +2,6 @@ package memberoperatorconfig
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-logr/logr"
 
@@ -17,11 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
-
-const configResourceName = "config"
-
-// Requeue every 10 seconds by default to ensure the MemberOperatorConfig on each member remains synchronized with the MemberOperatorConfig
-var defaultReconcile = reconcile.Result{RequeueAfter: 10 * time.Second}
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	"github.com/stretchr/testify/assert"
@@ -105,11 +104,4 @@ func newMemberOperatorConfigWithReset(t *testing.T, options ...testconfig.Member
 
 func matchesDefaultConfig(t *testing.T, actual MemberOperatorConfig) {
 	assert.Equal(t, 5*time.Second, actual.MemberStatus().RefreshPeriod())
-}
-
-func newController(cl client.Client, members cluster.GetMemberClustersFunc) Reconciler {
-	return Reconciler{
-		Client: cl,
-		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
-	}
 }

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
@@ -1,0 +1,115 @@
+package memberoperatorconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileWhenMemberOperatorConfigIsAvailable(t *testing.T) {
+	// given
+	config := newMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("10s"))
+	cl := test.NewFakeClient(t, config)
+	controller := Reconciler{
+		Client: cl,
+		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
+	}
+
+	// when
+	_, err := controller.Reconcile(newRequest())
+
+	// then
+	require.NoError(t, err)
+	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, actual.MemberStatus().RefreshPeriod())
+
+	t.Run("update with new version", func(t *testing.T) {
+		// given
+		refreshPeriod := "8s"
+		config.Spec.MemberStatus.RefreshPeriod = &refreshPeriod
+		err := cl.Update(context.TODO(), config)
+		require.NoError(t, err)
+
+		// when
+		_, err = controller.Reconcile(newRequest())
+
+		// then
+		require.NoError(t, err)
+		actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+		require.NoError(t, err)
+		assert.Equal(t, 8*time.Second, actual.MemberStatus().RefreshPeriod())
+	})
+}
+
+func TestReconcileWhenReturnsError(t *testing.T) {
+	// given
+	cl := test.NewFakeClient(t)
+	cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		return fmt.Errorf("some error")
+	}
+	controller := Reconciler{
+		Client: cl,
+		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
+	}
+
+	// when
+	_, err := controller.Reconcile(newRequest())
+
+	// then
+	require.Error(t, err)
+	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	require.NoError(t, err)
+	matchesDefaultConfig(t, actual)
+}
+
+func TestReconcileWhenMemberOperatorConfigIsNotPresent(t *testing.T) {
+	// given
+	controller := Reconciler{
+		Client: test.NewFakeClient(t),
+		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
+	}
+
+	// when
+	_, err := controller.Reconcile(newRequest())
+
+	// then
+	require.NoError(t, err)
+	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	require.NoError(t, err)
+	matchesDefaultConfig(t, actual)
+}
+
+func newRequest() reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: test.NamespacedName(test.MemberOperatorNs, "config"),
+	}
+}
+
+func newMemberOperatorConfigWithReset(t *testing.T, options ...testconfig.MemberOperatorConfigOption) *toolchainv1alpha1.MemberOperatorConfig {
+	t.Cleanup(Reset)
+	return testconfig.NewMemberOperatorConfig(options...)
+}
+
+func matchesDefaultConfig(t *testing.T, actual MemberOperatorConfig) {
+	assert.Equal(t, 5*time.Second, actual.MemberStatus().RefreshPeriod())
+}
+
+func newController(cl client.Client, members cluster.GetMemberClustersFunc) Reconciler {
+	return Reconciler{
+		Client: cl,
+		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
+	}
+}

--- a/controllers/memberstatus/memberstatus_controller_test.go
+++ b/controllers/memberstatus/memberstatus_controller_test.go
@@ -84,7 +84,7 @@ func TestNoMemberStatusFound(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		require.Equal(t, expectedErrMsg, err.Error())
+		require.Equal(t, "unable to get MemberOperatorConfig: "+expectedErrMsg, err.Error())
 		assert.Equal(t, reconcile.Result{}, res)
 	})
 }

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -228,6 +228,32 @@ rules:
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:
+  - memberoperatorconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - memberoperatorconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - memberoperatorconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
   - memberstatuses
   verbs:
   - create

--- a/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain-member-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-member-operator/manifests/toolchain-member-operator.clusterserviceversion.yaml
@@ -360,6 +360,32 @@ spec:
         - apiGroups:
           - toolchain.dev.openshift.com
           resources:
+          - memberoperatorconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - toolchain.dev.openshift.com
+          resources:
+          - memberoperatorconfigs/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - toolchain.dev.openshift.com
+          resources:
+          - memberoperatorconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - toolchain.dev.openshift.com
+          resources:
           - memberstatuses
           verbs:
           - create

--- a/go.mod
+++ b/go.mod
@@ -1,29 +1,22 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210531040930-26d5b5ce93dc
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210601093900-4d23adac3ca3
+	github.com/codeready-toolchain/api v0.0.0-20210614133722-31dc79a71878
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210615160410-5fc6a59ad950
 	github.com/go-logr/logr v0.4.0
 	github.com/gofrs/uuid v3.3.0+incompatible
-	github.com/google/go-cmp v0.5.2
+	github.com/google/go-cmp v0.5.4
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/onsi/ginkgo v1.14.1 // indirect
-	github.com/onsi/gomega v1.10.2 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-sdk v0.19.2
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.7.1 // indirect
 	github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.6.1
-	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 // indirect
-	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
-	golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752 // indirect
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/h2non/gock.v1 v1.0.14
-	honnef.co/go/tools v0.0.1-2020.1.6 // indirect
 	k8s.io/api v0.18.3
 	k8s.io/apiextensions-apiserver v0.18.3
 	k8s.io/apimachinery v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -146,10 +146,10 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210531040930-26d5b5ce93dc h1:pCXIJ83CWKm8DS8vhwHwOrzz6/wCv9U+us2HDUo7EKs=
-github.com/codeready-toolchain/api v0.0.0-20210531040930-26d5b5ce93dc/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210601093900-4d23adac3ca3 h1:D8GPvcJviVLpq9M8vy6xPHfu1GwL7TKugw8pJUTfwlU=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210601093900-4d23adac3ca3/go.mod h1:gJz38DTYBoonUYfbV0qhqRcf2r80TNdi2/cwOBICA30=
+github.com/codeready-toolchain/api v0.0.0-20210614133722-31dc79a71878 h1:i68EEb0tuzXiwpksbkA1G6W06kjYV7CFRILGR3wISN4=
+github.com/codeready-toolchain/api v0.0.0-20210614133722-31dc79a71878/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210615160410-5fc6a59ad950 h1:s6u/XIOmrY2W0Bue6Ft0FTdmk4O1tn7XhtSgVsQa6t4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210615160410-5fc6a59ad950/go.mod h1:bnpg/I9j7Ala/QiJ3YR238Dtddp6BhK4IRmjLCKjmYw=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -424,6 +424,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -548,8 +550,6 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
-github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jsonnet-bundler/jsonnet-bundler v0.3.1/go.mod h1:/by7P/OoohkI3q4CgSFqcoFsVY+IaNbzOVDknEsKDeU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -691,8 +691,6 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
-github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
-github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -703,8 +701,6 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
-github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
@@ -769,8 +765,6 @@ github.com/prometheus/client_golang v1.2.0/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNk
 github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNkDYzz3xecMgSW/F+U=
 github.com/prometheus/client_golang v1.5.1 h1:bdHYieyGlH+6OLEk2YQha8THib30KP0/yD0YH9m6xcA=
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
-github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
-github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -788,8 +782,6 @@ github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
-github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
-github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -803,8 +795,6 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.6/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
-github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
@@ -894,6 +884,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -924,7 +916,6 @@ github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6Ut
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
@@ -991,8 +982,6 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1060,8 +1049,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1123,7 +1110,6 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200120151820-655fe14d7479/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1132,13 +1118,8 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
-golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180805044716-cb6730876b98/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1196,12 +1177,9 @@ golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0 h1:SQvH+DjrwqD1hyyQU+K7JegHz1KEZgEwt17p9d6R2eg=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752 h1:2ntEwh02rqo2jSsrYmp4yKHHjh0CbXP3ZtSUetSB+q8=
-golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1334,8 +1312,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.5 h1:nI5egYTGJakVyOryqLs1cQO5dO0ksin5XXs2pspk75k=
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
-honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=
 k8s.io/api v0.0.0-20190813020757-36bff7324fb7/go.mod h1:3Iy+myeAORNCLgjd/Xu9ebwN7Vh59Bw0vh9jhoX+V58=

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -1336,6 +1336,32 @@ data:
               - apiGroups:
                 - toolchain.dev.openshift.com
                 resources:
+                - memberoperatorconfigs
+                verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+              - apiGroups:
+                - toolchain.dev.openshift.com
+                resources:
+                - memberoperatorconfigs/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - toolchain.dev.openshift.com
+                resources:
+                - memberoperatorconfigs/status
+                verbs:
+                - get
+                - patch
+                - update
+              - apiGroups:
+                - toolchain.dev.openshift.com
+                resources:
                 - memberstatuses
                 verbs:
                 - create

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -25,12 +25,6 @@ const (
 
 // Configuration constants
 const (
-	// varMemberStatusRefreshTime specifies how often the MemberStatus should load and refresh the current member cluster status
-	varMemberStatusRefreshTime = "memberstatus.refresh.time"
-
-	// defaultMemberStatusRefreshTime is the default refresh period for MemberStatus
-	defaultMemberStatusRefreshTime = "5s"
-
 	// varConsoleNamespace is the console route namespace
 	varConsoleNamespace = "console.namespace"
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -160,7 +160,6 @@ func (c *Config) setConfigDefaults() {
 	c.member.SetDefault(clusterHealthCheckPeriod, defaultClusterHealthCheckPeriod)
 	c.member.SetDefault(toolchainClusterTimeout, defaultClusterHealthCheckTimeout)
 	c.member.SetDefault(identityProviderName, defaultIdentityProviderName)
-	c.member.SetDefault(varMemberStatusRefreshTime, defaultMemberStatusRefreshTime)
 	c.member.SetDefault(varConsoleNamespace, defaultConsoleNamespace)
 	c.member.SetDefault(varConsoleRouteName, defaultConsoleRouteName)
 	c.member.SetDefault(varCheNamespace, defaultCheNamespace)
@@ -211,11 +210,6 @@ func (c *Config) GetClusterHealthCheckPeriod() time.Duration {
 // GetToolchainClusterTimeout returns the configured cluster health check timeout
 func (c *Config) GetToolchainClusterTimeout() time.Duration {
 	return c.member.GetDuration(toolchainClusterTimeout)
-}
-
-// GetMemberStatusRefreshTime returns the time how often the MemberStatus should load and refresh the current hosted-toolchain status
-func (c *Config) GetMemberStatusRefreshTime() time.Duration {
-	return c.member.GetDuration(varMemberStatusRefreshTime)
 }
 
 // GetConsoleNamespace returns the console route namespace

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -261,29 +261,6 @@ func TestGetClusterHealthCheckTimeout(t *testing.T) {
 	})
 }
 
-func TestGetMemberStatusRefreshTime(t *testing.T) {
-	key := MemberEnvPrefix + "_" + "MEMBERSTATUS_REFRESH_TIME"
-	resetFunc := test.UnsetEnvVarAndRestore(t, key)
-	defer resetFunc()
-
-	t.Run("default", func(t *testing.T) {
-		resetFunc := test.UnsetEnvVarAndRestore(t, key)
-		defer resetFunc()
-		config := getDefaultConfiguration(t)
-		assert.Equal(t, cast.ToDuration("5s"), config.GetMemberStatusRefreshTime())
-	})
-
-	t.Run("env overwrite", func(t *testing.T) {
-		restore := test.SetEnvVarAndRestore(t, key, "1s")
-		defer restore()
-
-		restore = test.SetEnvVarAndRestore(t, MemberEnvPrefix+"_"+"ANY_CONFIG", "20s")
-		defer restore()
-		config := getDefaultConfiguration(t)
-		assert.Equal(t, cast.ToDuration("1s"), config.GetMemberStatusRefreshTime())
-	})
-}
-
 func TestIsCheRequired(t *testing.T) {
 	key := MemberEnvPrefix + "_" + "CHE_REQUIRED"
 	resetFunc := test.UnsetEnvVarAndRestore(t, key)


### PR DESCRIPTION
Implements a controller for memberoperatorconfig resources plus the cache and config helpers similar to what we have for toolchainconfig.

e2e test PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/324