### PR TITLE
fix: checkout PR head & use composite action

### DIFF
--- a/.github/workflows/publish-operator-for-e2e-tests.yml
+++ b/.github/workflows/publish-operator-for-e2e-tests.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   binary:
-    name: Build & push operator bundle for e2e tests
+    name: Build & push member operator bundle for e2e tests
 
     runs-on: ubuntu-18.04
 
@@ -16,6 +16,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
 
     - name: Install Go
@@ -36,25 +38,12 @@ jobs:
         python-version: '3.x'
 
     - name: Prepare tools
-#      uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
+      #uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
       uses: MatousJobanek/toolchain-cicd/prepare-tools-action@master
 
-    - name: Login to quay
-      shell: bash
-      run: |
-        set -e
-        mkdir -p  ~/.docker || true
-        echo "{
-                      \"auths\": {
-                              \"quay.io\": {
-                                      \"auth\": \"${{ secrets.TEST_QUAY_TOKEN }}\"
-                              }
-                      }
-              }"> ~/.docker/config.json
-
-        podman login quay.io  --authfile=~/.docker/config.json
-
-    - name: Publish current bundle for e2e tests
-      shell: bash
-      run: |
-        make publish-current-bundle-for-e2e QUAY_NAMESPACE=codeready-toolchain-test IMAGE_BUILDER=podman || true
+    - name: Release operator
+      #uses: codeready-toolchain/toolchain-cicd/publish-operator-for-e2e-tests@master
+      uses: MatousJobanek/toolchain-cicd/publish-operator-for-e2e-tests@master
+      with:
+        quay-token: ${{ secrets.TEST_QUAY_TOKEN }}
+        quay-namespace: codeready-toolchain-test


### PR DESCRIPTION
the same fix as in https://github.com/codeready-toolchain/host-operator/pull/467
plus it uses composite from https://github.com/MatousJobanek/toolchain-cicd/blob/master/publish-operator-for-e2e-tests/action.yml