### PR TITLE
fix: don't append path if contains only slash

### DIFF
--- a/pkg/che/che_test.go
+++ b/pkg/che/che_test.go
@@ -584,7 +584,7 @@ func cheRoute(tls bool) *routev1.Route { //nolint: unparam
 		},
 		Spec: routev1.RouteSpec{
 			Host: fmt.Sprintf("codeready-codeready-workspaces-operator.%s", test.MemberClusterName),
-			Path: "",
+			Path: "/",
 		},
 	}
 	if tls {

--- a/pkg/che/tokencache_test.go
+++ b/pkg/che/tokencache_test.go
@@ -359,7 +359,7 @@ func keycloackRoute(tls bool) *routev1.Route { //nolint: unparam
 		},
 		Spec: routev1.RouteSpec{
 			Host: fmt.Sprintf("keycloak-codeready-workspaces-operator.%s", test.MemberClusterName),
-			Path: "",
+			Path: "/",
 		},
 	}
 	if tls {

--- a/pkg/utils/route/route.go
+++ b/pkg/utils/route/route.go
@@ -21,5 +21,11 @@ func GetRouteURL(cl client.Client, namespace, name string) (string, error) {
 	if route.Spec.TLS == nil || *route.Spec.TLS == (routev1.TLSConfig{}) {
 		scheme = "http"
 	}
-	return fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, route.Spec.Path), nil
+
+	path := ""
+	if route.Spec.Path != "/" {
+		path = route.Spec.Path
+	}
+
+	return fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, path), nil
 }

--- a/pkg/utils/route/route.go
+++ b/pkg/utils/route/route.go
@@ -3,6 +3,7 @@ package route
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,10 +23,10 @@ func GetRouteURL(cl client.Client, namespace, name string) (string, error) {
 		scheme = "http"
 	}
 
-	path := ""
-	if route.Spec.Path != "/" {
-		path = route.Spec.Path
+	path := route.Spec.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
 	}
 
-	return fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, path), nil
+	return fmt.Sprintf("%s://%s%s", scheme, route.Spec.Host, path), nil
 }

--- a/pkg/utils/route/route_test.go
+++ b/pkg/utils/route/route_test.go
@@ -1,0 +1,90 @@
+package route
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestGetRouteURL(t *testing.T) {
+	// given
+	require.NoError(t, routev1.Install(scheme.Scheme))
+	ns := "codeready-workspaces-operator"
+	name := "keycloak"
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: routev1.RouteSpec{
+			Host: fmt.Sprintf("keycloak-codeready-workspaces-operator.%s", test.MemberClusterName),
+			Path: "/",
+			TLS: &routev1.TLSConfig{
+				Termination: "edge",
+			},
+		},
+	}
+
+	t.Run("with tls and path as slash", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t, route)
+
+		// when
+		routeURL, err := GetRouteURL(cl, ns, name)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "https://keycloak-codeready-workspaces-operator.member-cluster/", routeURL)
+	})
+
+	t.Run("without tls and without path", func(t *testing.T) {
+		// given
+		r := route.DeepCopy()
+		r.Spec.TLS = nil
+		r.Spec.Path = ""
+		cl := test.NewFakeClient(t, r)
+
+		// when
+		routeURL, err := GetRouteURL(cl, ns, name)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "http://keycloak-codeready-workspaces-operator.member-cluster/", routeURL)
+	})
+
+	t.Run("wit tls and with longer path that doesn't start with slash", func(t *testing.T) {
+		// given
+		r := route.DeepCopy()
+		r.Spec.TLS = nil
+		r.Spec.Path = "cool/path"
+		cl := test.NewFakeClient(t, r)
+
+		// when
+		routeURL, err := GetRouteURL(cl, ns, name)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "http://keycloak-codeready-workspaces-operator.member-cluster/cool/path", routeURL)
+	})
+
+	t.Run("wit tls and with longer path that starts with slash", func(t *testing.T) {
+		// given
+		r := route.DeepCopy()
+		r.Spec.TLS = nil
+		r.Spec.Path = "/cool/path"
+		cl := test.NewFakeClient(t, r)
+
+		// when
+		routeURL, err := GetRouteURL(cl, ns, name)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "http://keycloak-codeready-workspaces-operator.member-cluster/cool/path", routeURL)
+	})
+}


### PR DESCRIPTION
 don't append path in the URL if contains only slash