### PR TITLE
Che client should get config dynamically

### DIFF
--- a/controllers/memberoperatorconfig/cache_test.go
+++ b/controllers/memberoperatorconfig/cache_test.go
@@ -3,10 +3,12 @@ package memberoperatorconfig
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	"github.com/stretchr/testify/assert"
@@ -21,10 +23,11 @@ import (
 
 func TestCache(t *testing.T) {
 	// given
+	os.Setenv("WATCH_NAMESPACE", test.MemberOperatorNs)
 	cl := NewFakeClient(t)
 
 	// when
-	defaultConfig, err := GetConfig(cl, MemberOperatorNs)
+	defaultConfig, err := GetConfig(cl)
 
 	// then
 	require.NoError(t, err)
@@ -36,7 +39,7 @@ func TestCache(t *testing.T) {
 		cl := NewFakeClient(t, config)
 
 		// when
-		actual, err := GetConfig(cl, MemberOperatorNs)
+		actual, err := GetConfig(cl)
 
 		// then
 		require.NoError(t, err)
@@ -45,7 +48,7 @@ func TestCache(t *testing.T) {
 
 		t.Run("returns the same when the cache hasn't been updated", func(t *testing.T) {
 			// when
-			actual, err := GetConfig(cl, MemberOperatorNs)
+			actual, err := GetConfig(cl)
 
 			// then
 			require.NoError(t, err)
@@ -70,7 +73,7 @@ func TestCache(t *testing.T) {
 			updateConfig(newConfig, secretData)
 
 			// then
-			actual, err := GetConfig(cl, MemberOperatorNs)
+			actual, err := GetConfig(cl)
 			require.NoError(t, err)
 			assert.Equal(t, 11*time.Second, actual.MemberStatus().RefreshPeriod())
 			assert.Equal(t, "cheadmin", actual.Che().AdminUserName()) // secret value
@@ -88,7 +91,7 @@ func TestGetConfigFailed(t *testing.T) {
 		}
 
 		// when
-		defaultConfig, err := GetConfig(cl, MemberOperatorNs)
+		defaultConfig, err := GetConfig(cl)
 
 		// then
 		require.NoError(t, err)
@@ -104,7 +107,7 @@ func TestGetConfigFailed(t *testing.T) {
 		}
 
 		// when
-		defaultConfig, err := GetConfig(cl, MemberOperatorNs)
+		defaultConfig, err := GetConfig(cl)
 
 		// then
 		require.Error(t, err)
@@ -120,21 +123,21 @@ func TestLoadLatest(t *testing.T) {
 		cl := NewFakeClient(t, initconfig)
 
 		// when
-		err := loadLatest(cl, MemberOperatorNs)
+		err := loadLatest(cl)
 
 		// then
 		require.NoError(t, err)
-		actual, err := GetConfig(cl, MemberOperatorNs)
+		actual, err := GetConfig(cl)
 		require.NoError(t, err)
 		assert.Equal(t, 1*time.Second, actual.MemberStatus().RefreshPeriod())
 
 		t.Run("returns the same when the config hasn't been updated", func(t *testing.T) {
 			// when
-			err := loadLatest(cl, MemberOperatorNs)
+			err := loadLatest(cl)
 
 			// then
 			require.NoError(t, err)
-			actual, err = GetConfig(cl, MemberOperatorNs)
+			actual, err = GetConfig(cl)
 			require.NoError(t, err)
 			assert.Equal(t, 1*time.Second, actual.MemberStatus().RefreshPeriod())
 		})
@@ -146,11 +149,11 @@ func TestLoadLatest(t *testing.T) {
 			require.NoError(t, err)
 
 			// when
-			err = loadLatest(cl, MemberOperatorNs)
+			err = loadLatest(cl)
 
 			// then
 			require.NoError(t, err)
-			actual, err = GetConfig(cl, MemberOperatorNs)
+			actual, err = GetConfig(cl)
 			require.NoError(t, err)
 			assert.Equal(t, 20*time.Second, actual.MemberStatus().RefreshPeriod())
 		})
@@ -161,7 +164,7 @@ func TestLoadLatest(t *testing.T) {
 		cl := NewFakeClient(t)
 
 		// when
-		err := loadLatest(cl, MemberOperatorNs)
+		err := loadLatest(cl)
 
 		// then
 		require.NoError(t, err)
@@ -176,7 +179,7 @@ func TestLoadLatest(t *testing.T) {
 		}
 
 		// when
-		err := loadLatest(cl, MemberOperatorNs)
+		err := loadLatest(cl)
 
 		// then
 		require.EqualError(t, err, "get error")
@@ -191,7 +194,7 @@ func TestLoadLatest(t *testing.T) {
 		}
 
 		// when
-		err := loadLatest(cl, MemberOperatorNs)
+		err := loadLatest(cl)
 
 		// then
 		require.EqualError(t, err, "list error")
@@ -213,7 +216,7 @@ func TestMultipleExecutionsInParallel(t *testing.T) {
 			latch.Wait()
 
 			// when
-			config, err := GetConfig(cl, MemberOperatorNs)
+			config, err := GetConfig(cl)
 
 			// then
 			require.NoError(t, err)
@@ -230,7 +233,7 @@ func TestMultipleExecutionsInParallel(t *testing.T) {
 	// when
 	latch.Done()
 	waitForFinished.Wait()
-	config, err := GetConfig(NewFakeClient(t), MemberOperatorNs)
+	config, err := GetConfig(NewFakeClient(t))
 
 	// then
 	require.NoError(t, err)

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
@@ -48,5 +48,5 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	reqLogger := log.FromContext(ctx)
 	reqLogger.Info("Reconciling MemberOperatorConfig")
 
-	return reconcile.Result{}, loadLatest(r.Client, request.Namespace)
+	return reconcile.Result{}, loadLatest(r.Client)
 }

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
@@ -29,7 +29,7 @@ func TestReconcileWhenMemberOperatorConfigIsAvailable(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	actual, err := GetConfig(test.NewFakeClient(t))
 	require.NoError(t, err)
 	assert.Equal(t, 10*time.Second, actual.MemberStatus().RefreshPeriod())
 
@@ -45,7 +45,7 @@ func TestReconcileWhenMemberOperatorConfigIsAvailable(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+		actual, err := GetConfig(test.NewFakeClient(t))
 		require.NoError(t, err)
 		assert.Equal(t, 8*time.Second, actual.MemberStatus().RefreshPeriod())
 	})
@@ -67,7 +67,7 @@ func TestReconcileWhenGetConfigReturnsError(t *testing.T) {
 
 	// then
 	require.EqualError(t, err, "get error")
-	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	actual, err := GetConfig(test.NewFakeClient(t))
 	require.NoError(t, err)
 	matchesDefaultConfig(t, actual)
 }
@@ -89,7 +89,7 @@ func TestReconcileWhenListSecretsReturnsError(t *testing.T) {
 
 	// then
 	require.EqualError(t, err, "list error")
-	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	actual, err := GetConfig(test.NewFakeClient(t))
 	require.NoError(t, err)
 	matchesDefaultConfig(t, actual)
 }
@@ -106,7 +106,7 @@ func TestReconcileWhenMemberOperatorConfigIsNotPresent(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	actual, err := GetConfig(test.NewFakeClient(t))
 	require.NoError(t, err)
 	matchesDefaultConfig(t, actual)
 }

--- a/controllers/memberstatus/memberstatus_controller.go
+++ b/controllers/memberstatus/memberstatus_controller.go
@@ -76,7 +76,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	reqLogger.Info("Reconciling MemberStatus")
 
 	// retrieve the latest config and use it for this reconciliation
-	config, err := memberCfg.GetConfig(r.Client, request.Namespace)
+	config, err := memberCfg.GetConfig(r.Client)
 	if err != nil {
 		return reconcile.Result{}, errs.Wrapf(err, "unable to get MemberOperatorConfig")
 	}

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -81,7 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// retrieve the latest config and use it for this reconciliation
-	config, err := memberCfg.GetConfig(r.Client, namespace)
+	config, err := memberCfg.GetConfig(r.Client)
 	if err != nil {
 		return reconcile.Result{}, errs.Wrapf(err, "unable to get MemberOperatorConfig")
 	}

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -46,10 +47,12 @@ const (
 
 func TestReconcile(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	os.Setenv("WATCH_NAMESPACE", test.MemberOperatorNs)
+
 	username := "johnsmith"
 	userID := uuid.NewV4().String()
 
-	config, err := memberCfg.GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	config, err := memberCfg.GetConfig(test.NewFakeClient(t))
 	require.NoError(t, err)
 
 	// given
@@ -1038,7 +1041,7 @@ func TestDisabledUserAccount(t *testing.T) {
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
-	config, err := memberCfg.GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
+	config, err := memberCfg.GetConfig(test.NewFakeClient(t))
 	require.NoError(t, err)
 
 	userAcc := newUserAccount(username, userID, false)
@@ -1545,14 +1548,11 @@ func prepareReconcile(t *testing.T, username string, initObjs ...runtime.Object)
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
 	fakeClient := test.NewFakeClient(t, initObjs...)
-	config, err := memberCfg.GetConfig(fakeClient, test.MemberOperatorNs)
+	config, err := memberCfg.GetConfig(fakeClient)
 	require.NoError(t, err)
 
 	tc := che.NewTokenCache(http.DefaultClient)
-	cheClient := che.NewCheClient(config, http.DefaultClient, fakeClient, tc)
-
-	config, err = memberCfg.GetConfig(fakeClient, test.MemberOperatorNs)
-	require.NoError(t, err)
+	cheClient := che.NewCheClient(http.DefaultClient, fakeClient, tc)
 
 	r := &Reconciler{
 		Client:    fakeClient,

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	crtConfig, err := getCRTConfiguration(cfg, namespace)
+	crtConfig, err := getCRTConfiguration(cfg)
 	if err != nil {
 		setupLog.Error(err, "failed to get toolchain configuration")
 		os.Exit(1)
@@ -126,7 +126,7 @@ func main() {
 	}
 
 	// initialize che client
-	che.InitDefaultCheClient(crtConfig, allNamespacesClient)
+	che.InitDefaultCheClient(allNamespacesClient)
 
 	// Setup all Controllers
 	if err = toolchaincluster.NewReconciler(
@@ -283,7 +283,7 @@ func newAllNamespacesClient(config *rest.Config) (client.Client, cache.Cache, er
 
 // getCRTConfiguration creates the client used for configuration and
 // returns the loaded crt configuration
-func getCRTConfiguration(config *rest.Config, namespace string) (memberoperatorconfig.Configuration, error) {
+func getCRTConfiguration(config *rest.Config) (memberoperatorconfig.Configuration, error) {
 	// create client that will be used for retrieving the member operator config maps
 	cl, err := client.New(config, client.Options{
 		Scheme: scheme,
@@ -292,5 +292,5 @@ func getCRTConfiguration(config *rest.Config, namespace string) (memberoperatorc
 		return memberoperatorconfig.Configuration{}, err
 	}
 
-	return memberoperatorconfig.GetConfig(cl, namespace)
+	return memberoperatorconfig.GetConfig(cl)
 }

--- a/pkg/che/che_test.go
+++ b/pkg/che/che_test.go
@@ -28,9 +28,8 @@ func TestUserExists(t *testing.T) {
 
 	t.Run("missing che route", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -46,9 +45,8 @@ func TestUserExists(t *testing.T) {
 
 	t.Run("unexpected error", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -71,9 +69,8 @@ func TestUserExists(t *testing.T) {
 
 	t.Run("user not found", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -96,9 +93,8 @@ func TestUserExists(t *testing.T) {
 
 	t.Run("user found", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -126,9 +122,8 @@ func TestGetUserIDByUsername(t *testing.T) {
 
 	t.Run("missing che route", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -144,9 +139,8 @@ func TestGetUserIDByUsername(t *testing.T) {
 
 	t.Run("unexpected error", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -169,9 +163,8 @@ func TestGetUserIDByUsername(t *testing.T) {
 
 	t.Run("user ID parse error", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -193,9 +186,8 @@ func TestGetUserIDByUsername(t *testing.T) {
 
 	t.Run("bad body", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -218,9 +210,8 @@ func TestGetUserIDByUsername(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -248,9 +239,8 @@ func TestDeleteUser(t *testing.T) {
 
 	t.Run("missing che route", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -265,9 +255,8 @@ func TestDeleteUser(t *testing.T) {
 
 	t.Run("unexpected error", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -289,9 +278,8 @@ func TestDeleteUser(t *testing.T) {
 
 	t.Run("user not found", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -313,9 +301,8 @@ func TestDeleteUser(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -341,9 +328,8 @@ func TestUserAPICheck(t *testing.T) {
 
 	t.Run("missing che admin credentials", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: testTokenCache(),
@@ -358,9 +344,8 @@ func TestUserAPICheck(t *testing.T) {
 
 	t.Run("missing che route", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -375,9 +360,8 @@ func TestUserAPICheck(t *testing.T) {
 
 	t.Run("error code", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -399,9 +383,8 @@ func TestUserAPICheck(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+		cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: tokenCacheWithValidToken(),
@@ -427,9 +410,8 @@ func TestCheRequest(t *testing.T) {
 
 	t.Run("missing configuration", func(t *testing.T) {
 		// given
-		cl, cfg := prepareClientAndConfig(t, cheRoute(true))
+		cl, _ := prepareClientAndConfig(t, cheRoute(true))
 		cheClient := &Client{
-			config:     cfg,
 			httpClient: http.DefaultClient,
 			k8sClient:  cl,
 			tokenCache: testTokenCache(),
@@ -455,9 +437,8 @@ func TestCheRequest(t *testing.T) {
 
 		t.Run("no che route", func(t *testing.T) {
 			// given
-			cl, cfg := prepareClientAndConfig(t, testSecret)
+			cl, _ := prepareClientAndConfig(t, testSecret)
 			cheClient := &Client{
-				config:     cfg,
 				httpClient: http.DefaultClient,
 				k8sClient:  cl,
 				tokenCache: testTokenCache(),
@@ -473,9 +454,8 @@ func TestCheRequest(t *testing.T) {
 
 		t.Run("no keycloak route", func(t *testing.T) {
 			// given
-			cl, cfg := prepareClientAndConfig(t, testSecret, config, cheRoute(true))
+			cl, _ := prepareClientAndConfig(t, testSecret, config, cheRoute(true))
 			cheClient := &Client{
-				config:     cfg,
 				httpClient: http.DefaultClient,
 				k8sClient:  cl,
 				tokenCache: testTokenCache(),
@@ -491,9 +471,8 @@ func TestCheRequest(t *testing.T) {
 
 		t.Run("nil query params", func(t *testing.T) {
 			// given
-			cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+			cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 			cheClient := &Client{
-				config:     cfg,
 				httpClient: http.DefaultClient,
 				k8sClient:  cl,
 				tokenCache: tokenCacheWithValidToken(),
@@ -516,9 +495,8 @@ func TestCheRequest(t *testing.T) {
 
 		t.Run("che returns error", func(t *testing.T) {
 			// given
-			cl, cfg := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
+			cl, _ := prepareClientAndConfig(t, testSecret, cheRoute(true), keycloackRoute(true))
 			cheClient := &Client{
-				config:     cfg,
 				httpClient: http.DefaultClient,
 				k8sClient:  cl,
 				tokenCache: tokenCacheWithValidToken(),

--- a/pkg/che/tokencache_test.go
+++ b/pkg/che/tokencache_test.go
@@ -3,6 +3,7 @@ package che
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -31,13 +32,14 @@ const (
 
 func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (client.Client, memberCfg.Configuration) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	os.Setenv("WATCH_NAMESPACE", test.MemberOperatorNs)
 
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
 
 	fakeClient := test.NewFakeClient(t, initObjs...)
-	config, err := memberCfg.GetConfig(fakeClient, test.MemberOperatorNs)
+	config, err := memberCfg.GetConfig(fakeClient)
 	require.NoError(t, err)
 
 	return fakeClient, config


### PR DESCRIPTION
There is a problem on staging where the che user API check is failing:
```
  che:
    conditions:
    - lastTransitionTime: "2021-07-19T15:43:47Z"
      lastUpdatedTime: "2021-07-19T15:43:47Z"
      message: 'che user API check failed: the che admin username and/or password
        are not configured'
      reason: CheUserAPICheckFailed
      status: "False"
      type: Ready
```

I believe this is occurring because when we moved to using the ToolchainConfig on the staging cluster we hadn't updated it to include all the latest configuration so the Che secret reference configuration was missing. The ToolchainConfig has since been updated and is now correct but the che user API check is still failing.

The current problem is that the che client was initialized in main.go (`che.InitDefaultCheClient(crtConfig, allNamespacesClient)` and cached the config at that point. Restarting the operator should fix it but the Che client should be getting the config dynamically anyway like it's done in the rest of the code.

This PR does the following:
- updates the Che client to load the configuration dynamically
- updates the configuration code to use the WATCH_NAMESPACE instead of requiring the namespace to be passed in