### PR TITLE
Move autoscaler and webhook

### DIFF
--- a/controllers/memberoperatorconfig/configuration_test.go
+++ b/controllers/memberoperatorconfig/configuration_test.go
@@ -231,6 +231,12 @@ func TestMemberStatus(t *testing.T) {
 
 			assert.Equal(t, 10*time.Second, memberOperatorCfg.MemberStatus().RefreshPeriod())
 		})
+		t.Run("non-default invalid value", func(t *testing.T) {
+			cfg := NewMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("10ABC"))
+			memberOperatorCfg := Configuration{m: &cfg.Spec}
+
+			assert.Equal(t, 5*time.Second, memberOperatorCfg.MemberStatus().RefreshPeriod())
+		})
 	})
 }
 
@@ -248,6 +254,12 @@ func TestToolchainCluster(t *testing.T) {
 
 			assert.Equal(t, 3*time.Second, memberOperatorCfg.ToolchainCluster().HealthCheckPeriod())
 		})
+		t.Run("non-default invalid value", func(t *testing.T) {
+			cfg := NewMemberOperatorConfigWithReset(t, testconfig.ToolchainCluster().HealthCheckPeriod("3ABC"))
+			memberOperatorCfg := Configuration{m: &cfg.Spec}
+
+			assert.Equal(t, 10*time.Second, memberOperatorCfg.ToolchainCluster().HealthCheckPeriod())
+		})
 	})
 	t.Run("health check timeout", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
@@ -261,6 +273,12 @@ func TestToolchainCluster(t *testing.T) {
 			memberOperatorCfg := Configuration{m: &cfg.Spec}
 
 			assert.Equal(t, 11*time.Second, memberOperatorCfg.ToolchainCluster().HealthCheckTimeout())
+		})
+		t.Run("non-default invalid value", func(t *testing.T) {
+			cfg := NewMemberOperatorConfigWithReset(t, testconfig.ToolchainCluster().HealthCheckTimeout("11ABC"))
+			memberOperatorCfg := Configuration{m: &cfg.Spec}
+
+			assert.Equal(t, 3*time.Second, memberOperatorCfg.ToolchainCluster().HealthCheckTimeout())
 		})
 	})
 }

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
@@ -6,10 +6,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -18,11 +26,7 @@ import (
 func TestReconcileWhenMemberOperatorConfigIsAvailable(t *testing.T) {
 	// given
 	config := NewMemberOperatorConfigWithReset(t, testconfig.MemberStatus().RefreshPeriod("10s"))
-	cl := test.NewFakeClient(t, config)
-	controller := Reconciler{
-		Client: cl,
-		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
-	}
+	controller, cl := prepareReconcile(t, config)
 
 	// when
 	_, err := controller.Reconcile(context.TODO(), newRequest())
@@ -96,10 +100,7 @@ func TestReconcileWhenListSecretsReturnsError(t *testing.T) {
 
 func TestReconcileWhenMemberOperatorConfigIsNotPresent(t *testing.T) {
 	// given
-	controller := Reconciler{
-		Client: test.NewFakeClient(t),
-		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
-	}
+	controller, _ := prepareReconcile(t)
 
 	// when
 	_, err := controller.Reconcile(context.TODO(), newRequest())
@@ -109,6 +110,173 @@ func TestReconcileWhenMemberOperatorConfigIsNotPresent(t *testing.T) {
 	actual, err := GetConfig(test.NewFakeClient(t), test.MemberOperatorNs)
 	require.NoError(t, err)
 	matchesDefaultConfig(t, actual)
+}
+
+func TestHandleAutoscalerDeploy(t *testing.T) {
+
+	t.Run("deploy false", func(t *testing.T) {
+		// given
+		config := NewMemberOperatorConfigWithReset(t, testconfig.Autoscaler().Deploy(false))
+		controller, cl := prepareReconcile(t, config)
+		actualConfig, err := GetConfig(cl, test.MemberOperatorNs)
+		require.NoError(t, err)
+
+		// when
+		err = controller.handleAutoscalerDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+
+		// then
+		require.NoError(t, err)
+		actualPrioClass := &schedulingv1.PriorityClass{}
+		err = cl.Get(context.TODO(), test.NamespacedName("", "member-operator-autoscaling-buffer"), actualPrioClass)
+		require.Error(t, err)
+		require.True(t, errors.IsNotFound(err))
+	})
+
+	t.Run("deploy true", func(t *testing.T) {
+		// given
+		config := NewMemberOperatorConfigWithReset(t, testconfig.Autoscaler().Deploy(true))
+		controller, cl := prepareReconcile(t, config)
+
+		actualConfig, err := GetConfig(cl, test.MemberOperatorNs)
+		require.NoError(t, err)
+
+		// when
+		err = controller.handleAutoscalerDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+
+		// then
+		require.NoError(t, err)
+		actualPrioClass := &schedulingv1.PriorityClass{}
+		err = cl.Get(context.TODO(), test.NamespacedName("", "member-operator-autoscaling-buffer"), actualPrioClass)
+		require.NoError(t, err)
+
+		t.Run("removed when set to back false", func(t *testing.T) {
+			modifiedConfig := UpdateMemberOperatorConfigWithReset(t, cl, testconfig.Autoscaler().Deploy(false))
+			err = cl.Update(context.TODO(), modifiedConfig)
+			require.NoError(t, err)
+			updatedConfig, err := loadLatest(cl, test.MemberOperatorNs)
+			require.NoError(t, err)
+			require.False(t, updatedConfig.Autoscaler().Deploy())
+
+			// when
+			err = controller.handleAutoscalerDeploy(controller.Log, updatedConfig, test.MemberOperatorNs)
+
+			// then
+			require.NoError(t, err)
+			actualPrioClass := &schedulingv1.PriorityClass{}
+			err = cl.Get(context.TODO(), test.NamespacedName("", "member-operator-autoscaling-buffer"), actualPrioClass)
+			require.Error(t, err)
+			require.True(t, errors.IsNotFound(err))
+		})
+	})
+
+	t.Run("deploy error", func(t *testing.T) {
+		// given
+		config := NewMemberOperatorConfigWithReset(t, testconfig.Autoscaler().Deploy(true))
+		controller, cl := prepareReconcile(t, config)
+		actualConfig, err := GetConfig(cl, test.MemberOperatorNs)
+		require.NoError(t, err)
+
+		// when
+		cl.(*test.FakeClient).MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			return fmt.Errorf("client error")
+		}
+		err = controller.handleAutoscalerDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+
+		// then
+		require.Contains(t, err.Error(), "cannot deploy autoscaling buffer template: ")
+	})
+
+	t.Run("delete error", func(t *testing.T) {
+		// given
+		config := NewMemberOperatorConfigWithReset(t, testconfig.Autoscaler().Deploy(false))
+		actualPrioClass := &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "member-operator-autoscaling-buffer",
+			},
+		}
+		controller, cl := prepareReconcile(t, config, actualPrioClass)
+		actualConfig, err := GetConfig(cl, test.MemberOperatorNs)
+		require.NoError(t, err)
+
+		// when
+		cl.(*test.FakeClient).MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+			return fmt.Errorf("client error")
+		}
+		err = controller.handleAutoscalerDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+
+		// then
+		require.EqualError(t, err, "cannot delete autoscaling buffer object: client error")
+	})
+}
+
+func TestHandleUsersPodsWebhookDeploy(t *testing.T) {
+	t.Run("deployment not created when webhook deploy is false", func(t *testing.T) {
+		// given
+		config := NewMemberOperatorConfigWithReset(t, testconfig.Webhook().Deploy(false))
+		controller, cl := prepareReconcile(t, config)
+
+		actualConfig, err := GetConfig(cl, test.MemberOperatorNs)
+		require.NoError(t, err)
+
+		// when
+		err = controller.handleUserPodsWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+
+		// then
+		require.NoError(t, err)
+		actualDeployment := &appsv1.Deployment{}
+		err = cl.Get(context.TODO(), test.NamespacedName(test.MemberOperatorNs, "member-operator-webhook"), actualDeployment)
+		require.Error(t, err)
+		require.True(t, errors.IsNotFound(err))
+	})
+
+	t.Run("deployment created when webhook deploy is true", func(t *testing.T) {
+		// given
+		config := NewMemberOperatorConfigWithReset(t, testconfig.Webhook().Deploy(true))
+		controller, cl := prepareReconcile(t, config)
+		actualConfig, err := GetConfig(cl, test.MemberOperatorNs)
+		require.NoError(t, err)
+
+		// when
+		err = controller.handleUserPodsWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+
+		// then
+		require.NoError(t, err)
+		actualDeployment := &appsv1.Deployment{}
+		err = cl.Get(context.TODO(), test.NamespacedName(test.MemberOperatorNs, "member-operator-webhook"), actualDeployment)
+		require.NoError(t, err)
+	})
+
+	t.Run("deployment error", func(t *testing.T) {
+		// given
+		config := NewMemberOperatorConfigWithReset(t, testconfig.Webhook().Deploy(true))
+		controller, cl := prepareReconcile(t, config)
+		actualConfig, err := GetConfig(cl, test.MemberOperatorNs)
+		require.NoError(t, err)
+
+		// when
+		cl.(*test.FakeClient).MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			return fmt.Errorf("client error")
+		}
+		err = controller.handleUserPodsWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+
+		// then
+		require.EqualError(t, err, "cannot deploy webhook template: client error")
+	})
+}
+
+func prepareReconcile(t *testing.T, initObjs ...runtime.Object) (*Reconciler, client.Client) {
+
+	restore := test.SetEnvVarAndRestore(t, "MEMBER_OPERATOR_WEBHOOK_IMAGE", "webhookimage")
+	t.Cleanup(restore)
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	fakeClient := test.NewFakeClient(t, initObjs...)
+	r := &Reconciler{
+		Client: fakeClient,
+		Log:    ctrl.Log.WithName("controllers").WithName("MemberOperatorConfig"),
+	}
+	return r, fakeClient
 }
 
 func newRequest() reconcile.Request {

--- a/main.go
+++ b/main.go
@@ -13,9 +13,7 @@ import (
 	"github.com/codeready-toolchain/member-operator/controllers/useraccount"
 	"github.com/codeready-toolchain/member-operator/controllers/useraccountstatus"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
-	"github.com/codeready-toolchain/member-operator/pkg/autoscaler"
 	"github.com/codeready-toolchain/member-operator/pkg/che"
-	"github.com/codeready-toolchain/member-operator/pkg/webhook/deploy"
 	"github.com/codeready-toolchain/member-operator/version"
 	"github.com/codeready-toolchain/toolchain-common/controllers/toolchaincluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
@@ -195,40 +193,6 @@ func main() {
 		if !mgr.GetCache().WaitForCacheSync(stopChannel) {
 			setupLog.Error(fmt.Errorf("timed out waiting for main cache to sync"), "")
 			os.Exit(1)
-		}
-
-		// By default the users' pods webhook will be deployed, however in some cases (eg. e2e tests) there can be multiple member operators
-		// installed in the same cluster. In those cases only 1 webhook is needed because the MutatingWebhookConfiguration is a cluster-scoped resource and naming can conflict.
-		if crtConfig.Webhook().Deploy() {
-			setupLog.Info("(Re)Deploying users' pods webhook")
-			webhookImage := os.Getenv("MEMBER_OPERATOR_WEBHOOK_IMAGE")
-			if err := deploy.Webhook(mgr.GetClient(), mgr.GetScheme(), namespace, webhookImage); err != nil {
-				setupLog.Error(err, "cannot deploy mutating users' pods webhook")
-				os.Exit(1)
-			}
-			setupLog.Info("(Re)Deployed users' pods webhook")
-		} else {
-			setupLog.Info("Skipping deployment of users' pods webhook")
-		}
-
-		if crtConfig.Autoscaler().Deploy() {
-			setupLog.Info("(Re)Deploying autoscaling buffer")
-			if err := autoscaler.Deploy(mgr.GetClient(), mgr.GetScheme(), namespace, crtConfig.Autoscaler().BufferMemory(), crtConfig.Autoscaler().BufferReplicas()); err != nil {
-				setupLog.Error(err, "cannot deploy autoscaling buffer")
-				os.Exit(1)
-			}
-			setupLog.Info("(Re)Deployed autoscaling buffer")
-		} else {
-			deleted, err := autoscaler.Delete(mgr.GetClient(), mgr.GetScheme(), namespace)
-			if err != nil {
-				setupLog.Error(err, "cannot delete previously deployed autoscaling buffer")
-				os.Exit(1)
-			}
-			if deleted {
-				setupLog.Info("Deleted previously deployed autoscaling buffer")
-			} else {
-				setupLog.Info("Skipping deployment of autoscaling buffer")
-			}
 		}
 
 		setupLog.Info("Starting ToolchainCluster health checks.")

--- a/pkg/webhook/deploy/deployment.go
+++ b/pkg/webhook/deploy/deployment.go
@@ -17,12 +17,12 @@ import (
 func Webhook(cl client.Client, s *runtime.Scheme, namespace, image string) error {
 	caBundle, err := cert.EnsureSecret(cl, namespace, cert.Expiration)
 	if err != nil {
-		return err
+		return errs.Wrap(err, "cannot deploy webhook template")
 	}
 
 	toolchainObjects, err := getTemplateObjects(s, namespace, image, caBundle)
 	if err != nil {
-		return err
+		return errs.Wrap(err, "cannot deploy webhook template")
 	}
 
 	applyClient := applycl.NewApplyClient(cl, s)


### PR DESCRIPTION
- Moves the autoscaler and webhook logic from main.go to the member operator config controller.
- Also updated the cache to use common functions from toolchain-common
- Updated the cache's loadLatest func to also return the configuration so that it's more convenient to use from the controller reconcile function

Related issue: https://issues.redhat.com/browse/CRT-1177