### PR TITLE
remove downloading and installing of golang and oc from dockerfile

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -40,27 +40,6 @@ RUN pip3 install yq
 # Install operator-courier that will be used in CD for nightly builds
 RUN pip3 install operator-courier
 
-WORKDIR /tmp
-
-# download, verify and install golang
-ENV PATH=$PATH:/usr/local/go/bin
-RUN curl -Lo ${GOLANG_VERSION}.linux-amd64.tar.gz https://dl.google.com/go/${GOLANG_VERSION}.linux-amd64.tar.gz \
-    && echo "b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061 ${GOLANG_VERSION}.linux-amd64.tar.gz" > ${GOLANG_VERSION}.linux-amd64.sha256 \
-    && sha256sum -c ${GOLANG_VERSION}.linux-amd64.sha256 \
-    && tar xzf ${GOLANG_VERSION}.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf ${GOLANG_VERSION}.linux-amd64.tar.gz \
-    && rm -f ${GOLANG_VERSION}.linux-amd64.tar.gz \
-    && go version
-
-# download, verify and install openshift client tools (oc and kubectl)
-RUN curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux.tar.gz -o openshift-client-linux.tar.gz \
-    && echo "378fc049719b297fe44e0cc712f230cd1a68d40fb83d45630e5f3fae5b1a017f openshift-client-linux.tar.gz" > openshift-client-linux.sha256 \
-    && sha256sum -c openshift-client-linux.sha256 \
-    && tar xzf openshift-client-linux.tar.gz \
-    && mv oc /usr/bin/oc \
-    && mv kubectl /usr/bin/kubectl \
-    && oc version
-
 RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/
 
 WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}


### PR DESCRIPTION
oc and golang are already available as part of test configuration. Thus removing the downloading and installing of them from dockerfile.