### PR TITLE
chore: configure klog and klog/v2 to output in JSON

### DIFF
--- a/controllers/memberstatus/memberstatus_controller.go
+++ b/controllers/memberstatus/memberstatus_controller.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metrics "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -201,8 +201,7 @@ func (r *Reconciler) loadCurrentResourceUsage(reqLogger logr.Logger, memberStatu
 	if err != nil {
 		return err
 	}
-
-	nodeMetricsList := &v1beta1.NodeMetricsList{}
+	nodeMetricsList := &metrics.NodeMetricsList{}
 	if err := r.Client.List(context.TODO(), nodeMetricsList); err != nil {
 		return err
 	}
@@ -222,7 +221,7 @@ func (r *Reconciler) loadCurrentResourceUsage(reqLogger logr.Logger, memberStatu
 				// let's remove the used allocatable value from the map so we can later check if all values were used
 				delete(allocatableValues, nodeMetric.Name)
 			} else {
-				reqLogger.Info("skipping NodeMetrics resource - there wasn't found corresponding node that would be monitored", "name", nodeMetric.Name)
+				reqLogger.Info("skipping NodeMetrics resource: no corresponding node to monitor", "name", nodeMetric.Name)
 			}
 			continue
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	k8s.io/apiextensions-apiserver v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
+	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.8.0
 	k8s.io/metrics v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
+	klogv1 "k8s.io/klog"
+	klogv2 "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,6 +97,26 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	// also set the client-go logger so we get the same JSON output
+	klogv2.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// see https://github.com/kubernetes/klog#coexisting-with-klogv2
+	// BEGIN : hack to redirect klogv1 calls to klog v2
+	// Tell klog NOT to log into STDERR. Otherwise, we risk
+	// certain kinds of API errors getting logged into a directory not
+	// available in a `FROM scratch` Docker container, causing us to abort
+	var klogv1Flags flag.FlagSet
+	klogv1.InitFlags(&klogv1Flags)
+	if err := klogv1Flags.Set("logtostderr", "false"); err != nil { // By default klog v1 logs to stderr, switch that off
+		setupLog.Error(err, "")
+		os.Exit(1)
+	}
+	if err := klogv1Flags.Set("stderrthreshold", "FATAL"); err != nil { // stderrthreshold defaults to ERROR, so we don't get anything in stderr
+		setupLog.Error(err, "")
+		os.Exit(1)
+	}
+	klogv1.SetOutputBySeverity("INFO", klogWriter{}) // tell klog v1 to use the custom writer
+	// END : hack to redirect klogv1 calls to klog v2
 
 	printVersion()
 
@@ -272,4 +294,33 @@ func getCRTConfiguration(config *rest.Config) (membercfg.Configuration, error) {
 	}
 
 	return membercfg.GetConfiguration(cl)
+}
+
+// OutputCallDepth is the stack depth where we can find the origin of this call
+const OutputCallDepth = 6
+
+// DefaultPrefixLength is the length of the log prefix that we have to strip out
+const DefaultPrefixLength = 53
+
+// klogWriter is used in SetOutputBySeverity call below to redirect
+// any calls to klogv1 to end up in klogv2
+type klogWriter struct{}
+
+func (kw klogWriter) Write(p []byte) (n int, err error) {
+	if len(p) < DefaultPrefixLength {
+		klogv2.InfoDepth(OutputCallDepth, string(p))
+		return len(p), nil
+	}
+	if p[0] == 'I' {
+		klogv2.InfoDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
+	} else if p[0] == 'W' {
+		klogv2.WarningDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
+	} else if p[0] == 'E' {
+		klogv2.ErrorDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
+	} else if p[0] == 'F' {
+		klogv2.FatalDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
+	} else {
+		klogv2.InfoDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
+	}
+	return len(p), nil
 }


### PR DESCRIPTION
since we have dependencies on both klog (v1) and klog/v2,
we need to use the hack suggested in
https://github.com/kubernetes/klog#coexisting-with-klogv2
to configure both implementations with the same settings
as the operator logger.

At least now we can get proper JSON output for
```
pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.NodeMetrics: the server does not allow this method on the requested resource (get nodes.metrics.k8s.io)
```

```
{"level":"error","ts":"2021-10-25T14:58:31.924Z","msg":"pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.NodeMetrics: the server does not allow this method on the requested resource (get nodes.metrics.k8s.io)\n","stacktrace":"k8s.io/klog/v2.(*loggingT).printDepth\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:733\nk8s.io/klog/v2.ErrorDepth\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:1451\nk8s.io/apimachinery/pkg/util/runtime.logError\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:114\nk8s.io/apimachinery/pkg/util/runtime.HandleError\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:108\nk8s.io/client-go/tools/cache.DefaultWatchErrorHandler\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:138\nk8s.io/client-go/tools/cache.(*Reflector).Run.func1\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:222\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156\nk8s.io/client-go/tools/cache.(*Reflector).Run\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:220\nk8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:56\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/Users/xcoulon/code/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:73"}
```

instead of errors like:
```
E1024 20:56:04.391039       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.NodeMetrics: the server does not allow this method on the requested resource (get nodes.metrics.k8s.io)
```

which cannot be pushed by Fluentd into Loki (not valid JSON)

The next step will be to resolve this error ;)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
