### PR TITLE
Add member operator namespace to the tier params

### DIFF
--- a/controllers/nstemplateset/cluster_resources_test.go
+++ b/controllers/nstemplateset/cluster_resources_test.go
@@ -10,6 +10,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	. "github.com/codeready-toolchain/member-operator/test"
+	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -145,6 +146,9 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 	namespaceName := "toolchain-member"
 	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
+
 	t.Run("should create only CRQ and set status to provisioning", func(t *testing.T) {
 		// given
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
@@ -267,6 +271,9 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
 	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 
 	t.Run("fail to list cluster resources", func(t *testing.T) {
 		// given
@@ -447,6 +454,9 @@ func TestDeleteClusterResources(t *testing.T) {
 }
 
 func TestPromoteClusterResources(t *testing.T) {
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
@@ -856,6 +866,9 @@ func TestPromoteClusterResources(t *testing.T) {
 }
 
 func TestUpdateClusterResources(t *testing.T) {
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given

--- a/controllers/nstemplateset/namespaces_test.go
+++ b/controllers/nstemplateset/namespaces_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	. "github.com/codeready-toolchain/member-operator/test"
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"os"
 	"testing"
 
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	. "github.com/codeready-toolchain/member-operator/test"
+	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -317,6 +318,9 @@ func TestGetNamespaceName(t *testing.T) {
 
 func TestEnsureNamespacesOK(t *testing.T) {
 
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
+
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
 	username := "johnsmith"
@@ -437,6 +441,9 @@ func TestEnsureNamespacesFail(t *testing.T) {
 	// given
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 
 	t.Run("fail to create namespace", func(t *testing.T) {
 		// given
@@ -695,6 +702,9 @@ func TestPromoteNamespaces(t *testing.T) {
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
 
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
+
 	t.Run("success", func(t *testing.T) {
 
 		t.Run("upgrade dev to advanced tier", func(t *testing.T) {
@@ -907,6 +917,9 @@ func TestUpdateNamespaces(t *testing.T) {
 	// given
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 
 	t.Run("success", func(t *testing.T) {
 

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -11,6 +11,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	. "github.com/codeready-toolchain/member-operator/test"
+	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	quotav1 "github.com/openshift/api/quota/v1"
 	templatev1 "github.com/openshift/api/template/v1"
@@ -83,6 +84,10 @@ func TestReconcileProvisionOK(t *testing.T) {
 	// given
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
+
 	t.Run("status provisioned when cluster resources are missing", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "code"))
@@ -186,6 +191,9 @@ func TestProvisionTwoUsers(t *testing.T) {
 	// given
 	username := "john"
 	namespaceName := "toolchain-member"
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 
 	t.Run("provision john's ClusterResourceQuota first", func(t *testing.T) {
 		// given
@@ -454,6 +462,9 @@ func TestReconcilePromotion(t *testing.T) {
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
 
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
+
 	t.Run("upgrade from basic to advanced tier", func(t *testing.T) {
 
 		t.Run("create ClusterResourceQuota", func(t *testing.T) {
@@ -633,6 +644,9 @@ func TestReconcileUpdate(t *testing.T) {
 	// given
 	username := "johnsmith"
 	namespaceName := "toolchain-member"
+
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 
 	t.Run("upgrade from abcde11 to abcde12 as part of the advanced tier", func(t *testing.T) {
 

--- a/controllers/nstemplateset/nstemplatetier.go
+++ b/controllers/nstemplateset/nstemplatetier.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
@@ -76,8 +78,15 @@ type tierTemplate struct {
 // process processes the template inside of the tierTemplate object and replaces the USERNAME variable with the given username.
 // Optionally, it also filters the result to return a subset of the template objects.
 func (t *tierTemplate) process(scheme *runtime.Scheme, username string, filters ...template.FilterFunc) ([]runtimeclient.Object, error) {
+	ns, err := configuration.GetWatchNamespace()
+	if err != nil {
+		return nil, err
+	}
 	tmplProcessor := template.NewProcessor(scheme)
-	params := map[string]string{"USERNAME": username}
+	params := map[string]string{
+		"USERNAME":                  username,
+		"MEMBER_OPERATOR_NAMESPACE": ns,
+	}
 	return tmplProcessor.Process(t.template.DeepCopy(), params, filters...)
 }
 

--- a/controllers/nstemplateset/nstemplatetier_test.go
+++ b/controllers/nstemplateset/nstemplatetier_test.go
@@ -67,6 +67,7 @@ parameters:
   required: true
 `
 	_, _, err = decoder.Decode([]byte(tmplContent), nil, &tmpl)
+	require.NoError(t, err)
 	tierTemplate := &tierTemplate{
 		template: tmpl,
 	}


### PR DESCRIPTION
This PR sets a new param `MEMBER_OPERATOR_NAMESPACE` when applying templates. This param will be used by the appstudio tier to setup a role binding for the service account.