### PR TITLE
refactor: decouple UserAccounts from NSTemplateSets

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_useraccounts.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_useraccounts.yaml
@@ -123,7 +123,6 @@ spec:
                 type: string
             required:
             - nsLimit
-            - nsTemplateSet
             - userID
             type: object
           status:

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -663,7 +663,6 @@ func newNSTemplateSet(userAcc *toolchainv1alpha1.UserAccount) *toolchainv1alpha1
 		},
 		Spec: *userAcc.Spec.NSTemplateSet,
 	}
-	setOwnerLabel(nsTmplSet, userAcc.Name)
 	return nsTmplSet
 }
 

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -169,11 +169,13 @@ func (r *Reconciler) migrateNStemplateSetIfNecessary(logger logr.Logger, userAcc
 		return false, err
 	}
 	// ensure that the NSTemplateSet `OwnerReferences` is empty
-	if len(nsTmplSet.OwnerReferences) == 0 {
-		return false, nil
+	if len(nsTmplSet.OwnerReferences) > 0 {
+		logger.Info("removing OwnerReferences in the associated NSTemplateSet")
+		nsTmplSet.OwnerReferences = nil
+		return true, r.Client.Update(context.TODO(), nsTmplSet)
 	}
-	nsTmplSet.OwnerReferences = nil
-	return true, r.Client.Update(context.TODO(), nsTmplSet)
+	// no change on the NSTemplateSet
+	return false, nil
 }
 
 func (r *Reconciler) ensureUserAccountDeletion(logger logr.Logger, config membercfg.Configuration, userAcc *toolchainv1alpha1.UserAccount) error {

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -49,7 +49,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&toolchainv1alpha1.UserAccount{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&source.Kind{Type: &toolchainv1alpha1.NSTemplateSet{}}, mapToOwnerByName).
+		Watches(&source.Kind{Type: &toolchainv1alpha1.NSTemplateSet{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &userv1.User{}}, mapToOwnerByLabel).
 		Watches(&source.Kind{Type: &userv1.Identity{}}, mapToOwnerByLabel).
 		Complete(r)

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -185,7 +185,7 @@ func (r *Reconciler) ensureUserAccountDeletion(logger logr.Logger, config member
 			return nil
 		}
 
-		deleted, err = r.deleteNSTemplateSet(logger, config, userAcc)
+		deleted, err = r.deleteNSTemplateSet(logger, userAcc)
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, userAcc, r.setStatusTerminating, err, "failed to delete the NSTemplateSet")
 		}
@@ -456,7 +456,7 @@ func (r *Reconciler) deleteIdentity(logger logr.Logger, config membercfg.Configu
 
 // deleteNSTemplateSet deletes the NSTemplateSet associated with the given UserAccount.
 // Returns bool and error indicating that whether the resource were deleted.
-func (r *Reconciler) deleteNSTemplateSet(logger logr.Logger, config membercfg.Configuration, userAcc *toolchainv1alpha1.UserAccount) (bool, error) {
+func (r *Reconciler) deleteNSTemplateSet(logger logr.Logger, userAcc *toolchainv1alpha1.UserAccount) (bool, error) {
 	// Get the NSTemplateSet associated with the UserAccount
 	nstmplSet := &toolchainv1alpha1.NSTemplateSet{}
 	err := r.Client.Get(context.TODO(),

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -324,8 +324,7 @@ func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, userAcc *toolchainv
 	logger.Info("NSTemplateSet already exists")
 
 	// update if not same
-	if userAcc.Spec.NSTemplateSet != nil &&
-		!reflect.DeepEqual(nsTmplSet.Spec, *userAcc.Spec.NSTemplateSet) {
+	if !reflect.DeepEqual(nsTmplSet.Spec, *userAcc.Spec.NSTemplateSet) {
 		return r.updateNSTemplateSet(logger, userAcc, nsTmplSet)
 	}
 	logger.Info("NSTemplateSet is up-to-date", "name", name)

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -826,7 +826,7 @@ func TestReconcile(t *testing.T) {
 			memberOperatorSecret := newSecretWithCheAdminCreds()
 			userAcc := newUserAccount(username, userID, withoutNSTemplateSet())
 			util.AddFinalizer(userAcc, toolchainv1alpha1.FinalizerName)
-			r, req, cl, _ := prepareReconcile(t, username, cfg, userAcc, preexistingUser, preexistingIdentity, memberOperatorSecret, cheRoute(true), keycloackRoute(true))
+			r, req, cl, _ := prepareReconcile(t, username, cfg, userAcc, preexistingUser, preexistingIdentity, preexistingNsTmplSet, memberOperatorSecret, cheRoute(true), keycloackRoute(true))
 
 			t.Run("first reconcile deletes identity", func(t *testing.T) {
 				// given

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -196,7 +196,7 @@ func TestReconcile(t *testing.T) {
 
 		t.Run("update", func(t *testing.T) {
 			// given
-			userAcc := newUserAccount(username, userID, withFinalizer(toolchainv1alpha1.FinalizerName))
+			userAcc := newUserAccount(username, userID, withFinalizer())
 			preexistingUserWithNoMapping := &userv1.User{ObjectMeta: metav1.ObjectMeta{
 				Name:   username,
 				UID:    userUID,
@@ -286,7 +286,7 @@ func TestReconcile(t *testing.T) {
 
 		t.Run("update", func(t *testing.T) {
 			// given
-			userAcc := newUserAccount(username, userID, withFinalizer(toolchainv1alpha1.FinalizerName))
+			userAcc := newUserAccount(username, userID, withFinalizer())
 			preexistingIdentityWithNoMapping := &userv1.Identity{ObjectMeta: metav1.ObjectMeta{
 				Name:   ToIdentityName(userAcc.Spec.UserID, config.Auth().Idp()),
 				UID:    types.UID(uuid.NewV4().String()),
@@ -518,7 +518,7 @@ func TestReconcile(t *testing.T) {
 		})
 
 		t.Run("no nstemplateset to update", func(t *testing.T) {
-			userAcc := newUserAccount(username, userID, withoutNSTemplateSet(), withFinalizer(toolchainv1alpha1.FinalizerName))
+			userAcc := newUserAccount(username, userID, withoutNSTemplateSet(), withFinalizer())
 			r, req, cl, _ := prepareReconcile(t, username, userAcc, preexistingUser, preexistingIdentity, preexistingNsTmplSet)
 			cl.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 				return fmt.Errorf("schouldn't be called")
@@ -534,7 +534,7 @@ func TestReconcile(t *testing.T) {
 			AssertThatNSTemplateSet(t, req.Namespace, req.Name, cl).
 				Exists(). // existed before
 				HasNoOwnerReferences().
-				HasNamespaceTemplateRefs(devTemplateRef,codeTemplateRef).
+				HasNamespaceTemplateRefs(devTemplateRef, codeTemplateRef).
 				HasClusterResourcesTemplateRef(clusterResourcesTemplateRef)
 		})
 
@@ -1577,7 +1577,7 @@ func TestDisabledUserAccount(t *testing.T) {
 
 	t.Run("deleting identity for disabled useraccount", func(t *testing.T) {
 		// given
-		userAcc := newUserAccount(username, userID, disabled(), withFinalizer(toolchainv1alpha1.FinalizerName))
+		userAcc := newUserAccount(username, userID, disabled(), withFinalizer())
 		userAcc.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 		r, req, _, _ := prepareReconcile(t, username, userAcc, preexistingNsTmplSet, preexistingUser, preexistingIdentity)
 
@@ -1794,9 +1794,9 @@ func disabled() userAccountOption {
 	}
 }
 
-func withFinalizer(name string) userAccountOption {
+func withFinalizer() userAccountOption {
 	return func(userAcc *toolchainv1alpha1.UserAccount) {
-		userAcc.Finalizers = []string{name}
+		userAcc.Finalizers = []string{toolchainv1alpha1.FinalizerName}
 	}
 }
 

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -1362,7 +1362,7 @@ func TestDisabledUserAccount(t *testing.T) {
 	})
 
 	t.Run("disabled useraccount", func(t *testing.T) {
-		userAcc := newUserAccount(username, userID, disabled(true))
+		userAcc := newUserAccount(username, userID, disabled())
 
 		// given
 		r, req, cl, _ := prepareReconcile(t, username, userAcc, preexistingNsTmplSet)
@@ -1388,7 +1388,7 @@ func TestDisabledUserAccount(t *testing.T) {
 
 	t.Run("disabling useraccount without user", func(t *testing.T) {
 		// given
-		userAcc := newUserAccount(username, userID, disabled(true))
+		userAcc := newUserAccount(username, userID, disabled())
 		r, req, cl, _ := prepareReconcile(t, username, userAcc, preexistingIdentity, preexistingNsTmplSet)
 
 		// when
@@ -1414,7 +1414,7 @@ func TestDisabledUserAccount(t *testing.T) {
 
 	t.Run("disabling useraccount without identity", func(t *testing.T) {
 		// given
-		userAcc := newUserAccount(username, userID, disabled(true))
+		userAcc := newUserAccount(username, userID, disabled())
 		r, req, cl, config := prepareReconcile(t, username, userAcc, preexistingUser, preexistingNsTmplSet)
 
 		// when
@@ -1439,7 +1439,7 @@ func TestDisabledUserAccount(t *testing.T) {
 
 	t.Run("deleting identity for disabled useraccount", func(t *testing.T) {
 		// given
-		userAcc := newUserAccount(username, userID, disabled(true), withFinalizer(toolchainv1alpha1.FinalizerName))
+		userAcc := newUserAccount(username, userID, disabled(), withFinalizer(toolchainv1alpha1.FinalizerName))
 		userAcc.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 		r, req, _, _ := prepareReconcile(t, username, userAcc, preexistingNsTmplSet, preexistingUser, preexistingIdentity)
 
@@ -1651,9 +1651,9 @@ func assertIdentityNotFound(t *testing.T, r *Reconciler, userAcc *toolchainv1alp
 
 type userAccountOption func(*toolchainv1alpha1.UserAccount)
 
-func disabled(disabled bool) userAccountOption {
+func disabled() userAccountOption {
 	return func(userAcc *toolchainv1alpha1.UserAccount) {
-		userAcc.Spec.Disabled = disabled
+		userAcc.Spec.Disabled = true
 	}
 }
 
@@ -1915,7 +1915,7 @@ func gockTokenFail(calls *int) {
 		Reply(400)
 }
 
-func gockFindUserTimes(name string, times int, calls *int) {
+func gockFindUserTimes(name string, times int, calls *int) { //nolint: unparam
 	gock.New(testCheURL).
 		Get("api/user/find").
 		SetMatcher(SpyOnGockCalls(calls)).

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211110171137-ac3d818a6a9a
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112081245-c973cc90dd4f
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584
+	github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210928071424-2ace1784e8d2
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.2
@@ -23,5 +23,9 @@ require (
 	k8s.io/metrics v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
+
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211110171137-ac3d818a6a9a
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112094801-195db272da93
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210928071424-2ace1784e8d2
+	github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.2
 	// using latest commit from 'github.com/openshift/api@release-4.7'
@@ -23,9 +23,5 @@ require (
 	k8s.io/metrics v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,6 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112081245-c973cc90dd4f
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112094801-195db272da93
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/xcoulon/toolchain-common v0.0.0-20211110171137-ac3d818a6a9a h1:dqhArBKnYCkLo56UxiQyEJYprUhD0i6z0h0lEkYvFyQ=
-github.com/xcoulon/toolchain-common v0.0.0-20211110171137-ac3d818a6a9a/go.mod h1:lWYeMUYtvKSctjcRVw5y+5dxVSAvyuuqnxbkNE92zbE=
+github.com/xcoulon/toolchain-common v0.0.0-20211112081245-c973cc90dd4f h1:2m1VXOO+492Niz2/lWJTxWxy/yZKt7fYpgRbOnb+O30=
+github.com/xcoulon/toolchain-common v0.0.0-20211112081245-c973cc90dd4f/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -104,10 +104,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584 h1:TzHWg6C8VJRdB0ALK6PARm4ACKRAguWlV3aNQHoFh0c=
-github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210928071424-2ace1784e8d2 h1:ah3OeK6NfT+QfWH/mz3e5Yy8zcOIGh2CtXlv9PQOoHk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210928071424-2ace1784e8d2/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -524,6 +520,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
+github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/xcoulon/toolchain-common v0.0.0-20211110171137-ac3d818a6a9a h1:dqhArBKnYCkLo56UxiQyEJYprUhD0i6z0h0lEkYvFyQ=
+github.com/xcoulon/toolchain-common v0.0.0-20211110171137-ac3d818a6a9a/go.mod h1:lWYeMUYtvKSctjcRVw5y+5dxVSAvyuuqnxbkNE92zbE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/xcoulon/toolchain-common v0.0.0-20211112081245-c973cc90dd4f h1:2m1VXOO+492Niz2/lWJTxWxy/yZKt7fYpgRbOnb+O30=
-github.com/xcoulon/toolchain-common v0.0.0-20211112081245-c973cc90dd4f/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
+github.com/xcoulon/toolchain-common v0.0.0-20211112094801-195db272da93 h1:W/ML2XJSQ4OTJr4EruKPUekcOL78mqKVQasb6kVMOH0=
+github.com/xcoulon/toolchain-common v0.0.0-20211112094801-195db272da93/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/xcoulon/toolchain-common v0.0.0-20211112094801-195db272da93 h1:W/ML2XJSQ4OTJr4EruKPUekcOL78mqKVQasb6kVMOH0=
-github.com/xcoulon/toolchain-common v0.0.0-20211112094801-195db272da93/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
+github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42 h1:LPlbmNMKwMTTYeCI1PSc8xbU6pAqD2lYy3uAsTabi3I=
+github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,10 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2 h1:MJ6aUUWVuNqku9um4NAVHReKP5y/tq1wXbgBNfphL0c=
+github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb h1:EhSrGxwUJA3+rOl7B7tfqiJN6r3OXqLecLhZGRrTQeA=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -520,10 +524,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
-github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42 h1:LPlbmNMKwMTTYeCI1PSc8xbU6pAqD2lYy3uAsTabi3I=
-github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,6 +39,12 @@ func AssertThatNSTemplateSet(t test.T, namespace, name string, client client.Cli
 	}
 }
 
+func (a *NSTemplateSetAssertion) Exists() *NSTemplateSetAssertion {
+	err := a.loadNSTemplateSet()
+	require.NoError(a.t, err)
+	return a
+}
+
 func (a *NSTemplateSetAssertion) DoesNotExist() *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.Error(a.t, err)
@@ -57,6 +63,13 @@ func (a *NSTemplateSetAssertion) HasConditions(expected ...toolchainv1alpha1.Con
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)
 	test.AssertConditionsMatch(a.t, a.nsTmplSet.Status.Conditions, expected...)
+	return a
+}
+
+func (a *NSTemplateSetAssertion) HasNoOwnerReferences() *NSTemplateSetAssertion {
+	err := a.loadNSTemplateSet()
+	require.NoError(a.t, err)
+	assert.Empty(a.t, a.nsTmplSet.ObjectMeta.OwnerReferences)
 	return a
 }
 


### PR DESCRIPTION
- UserAccountController doesn't set owner reference between
  the UserAccount and the NSTemplateSet
- UserAccountController deletes the NSTemplateSet
  before removing the finalizer on the UserAccount resource, during its
  deletion (until the Space Controller exists and takes care of it)
- If UserAccount.Spec.NSTemplateSet is empty, then UserAccountController
  ignores the NSTemplateSet for all operations

See also:
- https://github.com/codeready-toolchain/api/pull/263
- https://github.com/codeready-toolchain/toolchain-common/pull/216
- https://github.com/codeready-toolchain/toolchain-e2e/pull/407

Fixes https://issues.redhat.com/browse/CRT-1305

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
