### PR TITLE
feat: if appstudio then don't create User nor Identity

### DIFF
--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -96,6 +96,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 		return reconcile.Result{}, err
 	}
+	if userAcc.Spec.NSTemplateSet == nil {
+		logger = logger.WithValues("NSTemplateSet", "empty")
+	} else {
+		logger = logger.WithValues("tierName", userAcc.Spec.NSTemplateSet.TierName)
+	}
 
 	// If the UserAccount has not been deleted, create or update user and Identity resources.
 	// If the UserAccount has been deleted, delete secondary resources identity and user.

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -155,7 +155,7 @@ func (r *Reconciler) ensureUserAndIdentity(logger logr.Logger, userAcc *toolchai
 	var createdOrUpdated bool
 	var user *userv1.User
 	var err error
-	// for AppStudio use-case - create User & Identity resources if user is not used appstudio tier
+	// for AppStudio use-case - create User & Identity resources if user is not using appstudio tier
 	if userAcc.Spec.NSTemplateSet == nil || userAcc.Spec.NSTemplateSet.TierName != "appstudio" {
 		if user, createdOrUpdated, err = r.ensureUser(logger, config, userAcc); err != nil || createdOrUpdated {
 			return createdOrUpdated, err


### PR DESCRIPTION
We cannot create Identity in AppStudio stage cluster because we don't have claim override enabled there. Otherwise, it fails with: 
```
      conditions:
      - lastTransitionTime: "2021-12-13T14:35:13Z"
        message: 'User.user.openshift.io "mjobanek" is invalid: identities[0]: Invalid
          value: "DevSandbox:f:528d76ff-f708-43ed-8cd5-fe16f4fe0ce6:mjobanek": must
          be in the format <providerName>:<providerUserName>'
        reason: UnableToCreateUser
        status: "False"
        type: Ready
```
This PR skips the creation of `User` & `Identity` if the `tierName` equals to `appstudio`. It also deletes the `User` & `Identity` if it's already present.

paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/424