### PR TITLE
fix: delete identity & user only with owner label

### DIFF
--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -501,6 +501,11 @@ func (r *Reconciler) deleteUser(logger logr.Logger, userAcc *toolchainv1alpha1.U
 		}
 		return false, nil
 	}
+	if _, exist := user.Labels[toolchainv1alpha1.OwnerLabelKey]; !exist {
+		logger.Info("the User resource wasn't created by Toolchain Member operator - skipping", "user", userAcc.Name)
+		return false, nil
+	}
+
 	logger.Info("deleting the User resource")
 	// Delete User associated with UserAccount
 	if err := r.Client.Delete(context.TODO(), user); err != nil {
@@ -528,6 +533,11 @@ func (r *Reconciler) deleteIdentity(logger logr.Logger, config membercfg.Configu
 		}
 		return false, nil
 	}
+	if _, exist := identity.Labels[toolchainv1alpha1.OwnerLabelKey]; !exist {
+		logger.Info("the Identity resource wasn't created by Toolchain Member operator - skipping", "identity", identityName)
+		return false, nil
+	}
+
 	logger.Info("deleting the Identity resource")
 	// Delete Identity associated with UserAccount
 	if err := r.Client.Delete(context.TODO(), identity); err != nil {


### PR DESCRIPTION
delete the Identity & User resources only when it contains the "owner" label to unblock @alexeykazakov's broken account in AppStudio stage cluster :-)

is paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/428