### PR TITLE
refactor: map for params when processing a template

### DIFF
--- a/controllers/nstemplateset/cluster_resources.go
+++ b/controllers/nstemplateset/cluster_resources.go
@@ -117,7 +117,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 
 		// get all objects of the resource kind from the template (if the template is specified)
 		if tierTemplate != nil {
-			newObjs, err = tierTemplate.process(r.Scheme, username, retainObjectsOfSameGVK(clusterResourceKind.gvk))
+			newObjs, err = tierTemplate.process(r.Scheme, map[string]string{"USERNAME": username}, retainObjectsOfSameGVK(clusterResourceKind.gvk))
 			if err != nil {
 				return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(gvkLogger, nsTmplSet, err,
 					"failed to process template for the cluster resources with the name '%s'", nsTmplSet.Spec.ClusterResources.TemplateRef)

--- a/controllers/nstemplateset/cluster_resources.go
+++ b/controllers/nstemplateset/cluster_resources.go
@@ -117,7 +117,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 
 		// get all objects of the resource kind from the template (if the template is specified)
 		if tierTemplate != nil {
-			newObjs, err = tierTemplate.process(r.Scheme, map[string]string{"USERNAME": username}, retainObjectsOfSameGVK(clusterResourceKind.gvk))
+			newObjs, err = tierTemplate.process(r.Scheme, map[string]string{Username: username}, retainObjectsOfSameGVK(clusterResourceKind.gvk))
 			if err != nil {
 				return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(gvkLogger, nsTmplSet, err,
 					"failed to process template for the cluster resources with the name '%s'", nsTmplSet.Spec.ClusterResources.TemplateRef)

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -86,7 +86,7 @@ func (r *namespacesManager) ensureNamespace(logger logr.Logger, nsTmplSet *toolc
 // ensureNamespaceResource ensures that the namespace exists.
 func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate) error {
 	logger.Info("creating namespace", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
-	objs, err := tierTemplate.process(r.Scheme, map[string]string{"USERNAME": nsTmplSet.GetName()}, template.RetainNamespaces)
+	objs, err := tierTemplate.process(r.Scheme, map[string]string{Username: nsTmplSet.GetName()}, template.RetainNamespaces)
 	if err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace type '%s'", tierTemplate.typeName)
 	}
@@ -114,7 +114,7 @@ func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSe
 func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate, namespace *corev1.Namespace) error {
 	logger.Info("ensuring namespace resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
 	nsName := namespace.GetName()
-	newObjs, err := tierTemplate.process(r.Scheme, map[string]string{"USERNAME": nsTmplSet.GetName()}, template.RetainAllButNamespaces)
+	newObjs, err := tierTemplate.process(r.Scheme, map[string]string{Username: nsTmplSet.GetName()}, template.RetainAllButNamespaces)
 	if err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace '%s'", nsName)
 	}
@@ -127,7 +127,7 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve current TierTemplate with name '%s'", currentRef)
 		}
-		currentObjs, err := currentTierTemplate.process(r.Scheme, map[string]string{"USERNAME": nsTmplSet.GetName()}, template.RetainAllButNamespaces)
+		currentObjs, err := currentTierTemplate.process(r.Scheme, map[string]string{Username: nsTmplSet.GetName()}, template.RetainAllButNamespaces)
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to process template for TierTemplate with name '%s'", currentRef)
 		}
@@ -292,7 +292,7 @@ func (r *namespacesManager) isUpToDateAndProvisioned(ns *corev1.Namespace, tierT
 		ns.GetLabels()[toolchainv1alpha1.TierLabelKey] == tierTemplate.tierName &&
 		ns.GetLabels()[toolchainv1alpha1.TemplateRefLabelKey] == tierTemplate.templateRef {
 
-		newObjs, err := tierTemplate.process(r.Scheme, map[string]string{"USERNAME": ns.GetLabels()[toolchainv1alpha1.OwnerLabelKey]}, template.RetainAllButNamespaces)
+		newObjs, err := tierTemplate.process(r.Scheme, map[string]string{Username: ns.GetLabels()[toolchainv1alpha1.OwnerLabelKey]}, template.RetainAllButNamespaces)
 		if err != nil {
 			return false, err
 		}

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -11,7 +11,6 @@ import (
 	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 	"github.com/redhat-cop/operator-utils/pkg/util"
@@ -87,8 +86,7 @@ func (r *namespacesManager) ensureNamespace(logger logr.Logger, nsTmplSet *toolc
 // ensureNamespaceResource ensures that the namespace exists.
 func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate) error {
 	logger.Info("creating namespace", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
-
-	objs, err := tierTemplate.process(r.Scheme, nsTmplSet.GetName(), template.RetainNamespaces)
+	objs, err := tierTemplate.process(r.Scheme, map[string]string{"USERNAME": nsTmplSet.GetName()}, template.RetainNamespaces)
 	if err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace type '%s'", tierTemplate.typeName)
 	}
@@ -116,8 +114,7 @@ func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSe
 func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate, namespace *corev1.Namespace) error {
 	logger.Info("ensuring namespace resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
 	nsName := namespace.GetName()
-	username := nsTmplSet.GetName()
-	newObjs, err := tierTemplate.process(r.Scheme, username, template.RetainAllButNamespaces)
+	newObjs, err := tierTemplate.process(r.Scheme, map[string]string{"USERNAME": nsTmplSet.GetName()}, template.RetainAllButNamespaces)
 	if err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusNamespaceProvisionFailed, err, "failed to process template for namespace '%s'", nsName)
 	}
@@ -130,7 +127,7 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve current TierTemplate with name '%s'", currentRef)
 		}
-		currentObjs, err := currentTierTemplate.process(r.Scheme, username, template.RetainAllButNamespaces)
+		currentObjs, err := currentTierTemplate.process(r.Scheme, map[string]string{"USERNAME": nsTmplSet.GetName()}, template.RetainAllButNamespaces)
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to process template for TierTemplate with name '%s'", currentRef)
 		}
@@ -210,10 +207,10 @@ func (r *namespacesManager) getTierTemplatesForAllNamespaces(nsTmplSet *toolchai
 
 // fetchNamespaces returns all current namespaces belonging to the given user
 // i.e., labeled with `"toolchain.dev.openshift.com/owner":<username>`
-func fetchNamespaces(client client.Client, username string) ([]corev1.Namespace, error) {
+func fetchNamespaces(cl runtimeclient.Client, username string) ([]corev1.Namespace, error) {
 	// fetch all namespace with owner=username label
 	userNamespaceList := &corev1.NamespaceList{}
-	if err := client.List(context.TODO(), userNamespaceList, listByOwnerLabel(username)); err != nil {
+	if err := cl.List(context.TODO(), userNamespaceList, listByOwnerLabel(username)); err != nil {
 		return nil, err
 	}
 	names := make([]string, len(userNamespaceList.Items))
@@ -295,7 +292,7 @@ func (r *namespacesManager) isUpToDateAndProvisioned(ns *corev1.Namespace, tierT
 		ns.GetLabels()[toolchainv1alpha1.TierLabelKey] == tierTemplate.tierName &&
 		ns.GetLabels()[toolchainv1alpha1.TemplateRefLabelKey] == tierTemplate.templateRef {
 
-		newObjs, err := tierTemplate.process(r.Scheme, ns.GetLabels()[toolchainv1alpha1.OwnerLabelKey], template.RetainAllButNamespaces)
+		newObjs, err := tierTemplate.process(r.Scheme, map[string]string{"USERNAME": ns.GetLabels()[toolchainv1alpha1.OwnerLabelKey]}, template.RetainAllButNamespaces)
 		if err != nil {
 			return false, err
 		}

--- a/controllers/nstemplateset/nstemplatetier.go
+++ b/controllers/nstemplateset/nstemplatetier.go
@@ -75,7 +75,12 @@ type tierTemplate struct {
 	template    templatev1.Template
 }
 
-// process processes the template inside of the tierTemplate object and replaces the USERNAME variable with the given username.
+const (
+	MemberOperatorNS = "MEMBER_OPERATOR_NAMESPACE"
+	Username         = "USERNAME"
+)
+
+// process processes the template inside of the tierTemplate object with the given parameters.
 // Optionally, it also filters the result to return a subset of the template objects.
 func (t *tierTemplate) process(scheme *runtime.Scheme, params map[string]string, filters ...template.FilterFunc) ([]runtimeclient.Object, error) {
 	ns, err := configuration.GetWatchNamespace()
@@ -83,7 +88,7 @@ func (t *tierTemplate) process(scheme *runtime.Scheme, params map[string]string,
 		return nil, err
 	}
 	tmplProcessor := template.NewProcessor(scheme)
-	params["MEMBER_OPERATOR_NAMESPACE"] = ns // add (or enforce)
+	params[MemberOperatorNS] = ns // add (or enforce)
 	return tmplProcessor.Process(t.template.DeepCopy(), params, filters...)
 }
 

--- a/controllers/nstemplateset/nstemplatetier.go
+++ b/controllers/nstemplateset/nstemplatetier.go
@@ -77,16 +77,13 @@ type tierTemplate struct {
 
 // process processes the template inside of the tierTemplate object and replaces the USERNAME variable with the given username.
 // Optionally, it also filters the result to return a subset of the template objects.
-func (t *tierTemplate) process(scheme *runtime.Scheme, username string, filters ...template.FilterFunc) ([]runtimeclient.Object, error) {
+func (t *tierTemplate) process(scheme *runtime.Scheme, params map[string]string, filters ...template.FilterFunc) ([]runtimeclient.Object, error) {
 	ns, err := configuration.GetWatchNamespace()
 	if err != nil {
 		return nil, err
 	}
 	tmplProcessor := template.NewProcessor(scheme)
-	params := map[string]string{
-		"USERNAME":                  username,
-		"MEMBER_OPERATOR_NAMESPACE": ns,
-	}
+	params["MEMBER_OPERATOR_NAMESPACE"] = ns // add (or enforce)
 	return tmplProcessor.Process(t.template.DeepCopy(), params, filters...)
 }
 

--- a/controllers/nstemplateset/nstemplatetier_test.go
+++ b/controllers/nstemplateset/nstemplatetier_test.go
@@ -76,7 +76,7 @@ parameters:
 	t.Cleanup(restore)
 
 	// when
-	obj, err := tierTemplate.process(s, "johnsmith")
+	obj, err := tierTemplate.process(s, map[string]string{"USERNAME": "johnsmith"})
 
 	// then
 	require.NoError(t, err)

--- a/controllers/nstemplateset/nstemplatetier_test.go
+++ b/controllers/nstemplateset/nstemplatetier_test.go
@@ -76,7 +76,7 @@ parameters:
 	t.Cleanup(restore)
 
 	// when
-	obj, err := tierTemplate.process(s, map[string]string{"USERNAME": "johnsmith"})
+	obj, err := tierTemplate.process(s, map[string]string{Username: "johnsmith"})
 
 	// then
 	require.NoError(t, err)


### PR DESCRIPTION
With spaces, the `USERNAME` param gets confusing or inadequate.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
