### PR TITLE
chore: revert linter changes

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -108,8 +108,7 @@ func (r *Reconciler) ensureIdling(logger logr.Logger, idler *toolchainv1alpha1.I
 		return err
 	}
 	newStatusPods := make([]toolchainv1alpha1.Pod, 0, 10)
-	for i := range podList.Items {
-		pod := podList.Items[i] // avoids the "G601: Implicit memory aliasing in for loop. (gosec)" problem
+	for _, pod := range podList.Items {
 		podLogger := logger.WithValues("pod_name", pod.Name, "pod_phase", pod.Status.Phase)
 		if trackedPod := findPodByName(idler, pod.Name); trackedPod != nil {
 			// Already tracking this pod. Check the timeout.
@@ -122,7 +121,7 @@ func (r *Reconciler) ensureIdling(logger logr.Logger, idler *toolchainv1alpha1.I
 				}
 				if !deletedByController { // Pod not managed by a controller. We can just delete the pod.
 					logger.Info("Deleting pod without controller")
-					if err := r.AllNamespacesClient.Delete(context.TODO(), &pod); err != nil {
+					if err := r.AllNamespacesClient.Delete(context.TODO(), &pod); err != nil { // nolint:gosec
 						return err
 					}
 					podLogger.Info("Pod deleted")

--- a/controllers/nstemplateset/space_roles.go
+++ b/controllers/nstemplateset/space_roles.go
@@ -30,8 +30,7 @@ func (r *spaceRolesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 			"failed to list namespaces for workspace '%s'", nsTmplSet.Name)
 	}
 	logger.Info("ensuring space roles", "namespace_count", len(nss), "role_count", len(nsTmplSet.Spec.SpaceRoles))
-	for i := range nss {
-		ns := &nss[i] // avoids the `G601: Implicit memory aliasing in for loop. (gosec)` problem
+	for _, ns := range nss {
 		// space roles previously applied
 		// read annotation to see what was applied last time, so we can compare with the new SpaceRoles and remove all obsolete resources (based on their kind/names)
 		var lastAppliedSpaceRoles []toolchainv1alpha1.NSTemplateSetSpaceRole
@@ -48,12 +47,12 @@ func (r *spaceRolesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
 			return false, err
 		}
-		lastAppliedSpaceRoleObjs, err := r.getSpaceRolesObjects(ns, lastAppliedSpaceRoles)
+		lastAppliedSpaceRoleObjs, err := r.getSpaceRolesObjects(&ns, lastAppliedSpaceRoles) // nolint:gosec
 		if err != nil {
 			return false, r.wrapErrorWithStatusUpdateForSpaceRolesFailure(logger, nsTmplSet, err, "failed to retrieve last applied space roles")
 		}
 		// space roles to apply now
-		spaceRoleObjs, err := r.getSpaceRolesObjects(ns, nsTmplSet.Spec.SpaceRoles)
+		spaceRoleObjs, err := r.getSpaceRolesObjects(&ns, nsTmplSet.Spec.SpaceRoles) // nolint:gosec
 		if err != nil {
 			return false, r.wrapErrorWithStatusUpdateForSpaceRolesFailure(logger, nsTmplSet, err, "failed to retrieve space roles to apply")
 		}
@@ -82,7 +81,7 @@ func (r *spaceRolesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 			ns.Annotations = map[string]string{}
 		}
 		ns.Annotations[toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey] = string(sr)
-		if err := r.Client.Update(context.TODO(), ns); err != nil {
+		if err := r.Client.Update(context.TODO(), &ns); err != nil { // nolint:gosec
 			return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusProvisionFailed, err,
 				"failed update namespace annotation")
 		}


### PR DESCRIPTION
revert unneeded changes after gosec linter complains
use `// nolint:gosec` comment instead.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
