### PR TITLE
Updated UserAccountController to use IdentityNamingStandard

### DIFF
--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -253,11 +253,11 @@ func (r *Reconciler) ensureUser(logger logr.Logger, config membercfg.Configurati
 	logger.Info("user already exists")
 
 	// ensure mapping
-	expectedIdentities := []string{identity2.NewIdentityNamingStandard(userAcc.Spec.UserID, config.Auth().Idp()).IdentityName()}
+	expectedIdentities := []string{commonidentity.NewIdentityNamingStandard(userAcc.Spec.UserID, config.Auth().Idp()).IdentityName()}
 
 	// If the OriginalSub property has been set also, then an additional identity is required to be created
 	if userAcc.Spec.OriginalSub != "" {
-		expectedIdentities = append(expectedIdentities, identity2.NewIdentityNamingStandard(userAcc.Spec.OriginalSub, config.Auth().Idp()).IdentityName())
+		expectedIdentities = append(expectedIdentities, commonidentity.NewIdentityNamingStandard(userAcc.Spec.OriginalSub, config.Auth().Idp()).IdentityName())
 	}
 
 	stringSlicesEqual := func(a, b []string) bool {
@@ -312,7 +312,7 @@ func (r *Reconciler) ensureIdentity(logger logr.Logger, config membercfg.Configu
 func (r *Reconciler) loadIdentityAndEnsureMapping(logger logr.Logger, config membercfg.Configuration, username string,
 	userAccount *toolchainv1alpha1.UserAccount, user *userv1.User) (*userv1.Identity, bool, error) {
 
-	ins := identity2.NewIdentityNamingStandard(username, config.Auth().Idp())
+	ins := commonidentity.NewIdentityNamingStandard(username, config.Auth().Idp())
 
 	identity := &userv1.Identity{}
 
@@ -323,7 +323,7 @@ func (r *Reconciler) loadIdentityAndEnsureMapping(logger logr.Logger, config mem
 				return nil, false, err
 			}
 			identity = newIdentity(user)
-			identity2.NewIdentityNamingStandard(username, config.Auth().Idp()).ApplyToIdentity(identity)
+			commonidentity.NewIdentityNamingStandard(username, config.Auth().Idp()).ApplyToIdentity(identity)
 
 			setOwnerLabel(identity, userAccount.Name)
 			if err := r.Client.Create(context.TODO(), identity); err != nil {
@@ -718,7 +718,7 @@ func newUser(userAcc *toolchainv1alpha1.UserAccount, config membercfg.Configurat
 		ObjectMeta: metav1.ObjectMeta{
 			Name: userAcc.Name,
 		},
-		Identities: []string{identity2.NewIdentityNamingStandard(userAcc.Spec.UserID, config.Auth().Idp()).IdentityName()},
+		Identities: []string{commonidentity.NewIdentityNamingStandard(userAcc.Spec.UserID, config.Auth().Idp()).IdentityName()},
 	}
 	return user
 }

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -2,10 +2,9 @@ package useraccount
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
+	identity2 "github.com/codeready-toolchain/toolchain-common/pkg/identity"
 	"reflect"
-	"regexp"
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -34,12 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
-
-const (
-	dns1123Value string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-)
-
-var dns1123ValueRegexp = regexp.MustCompile("^" + dns1123Value + "$")
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
@@ -260,21 +253,11 @@ func (r *Reconciler) ensureUser(logger logr.Logger, config membercfg.Configurati
 	logger.Info("user already exists")
 
 	// ensure mapping
-
-	// If the UserID contains invalid characters, then we will base64-encode it here
-	var userID string
-	if isIdentityNameCompliant(userAcc.Spec.UserID) {
-		userID = ToIdentityName(userAcc.Spec.UserID, config.Auth().Idp())
-	} else {
-		userID = ToIdentityName(fmt.Sprintf("b64:%s", base64.RawStdEncoding.EncodeToString([]byte(userAcc.Spec.UserID))), config.Auth().Idp())
-	}
-
-	expectedIdentities := []string{userID}
+	expectedIdentities := []string{identity2.NewIdentityNamingStandard(userAcc.Spec.UserID, config.Auth().Idp()).IdentityName()}
 
 	// If the OriginalSub property has been set also, then an additional identity is required to be created
 	if userAcc.Spec.OriginalSub != "" {
-		expectedIdentities = append(expectedIdentities, ToIdentityName(fmt.Sprintf("b64:%s",
-			base64.RawStdEncoding.EncodeToString([]byte(userAcc.Spec.OriginalSub))), config.Auth().Idp()))
+		expectedIdentities = append(expectedIdentities, identity2.NewIdentityNamingStandard(userAcc.Spec.OriginalSub, config.Auth().Idp()).IdentityName())
 	}
 
 	stringSlicesEqual := func(a, b []string) bool {
@@ -316,7 +299,6 @@ func (r *Reconciler) ensureIdentity(logger logr.Logger, config membercfg.Configu
 
 	// Check if the OriginalSub property is set, and if it is create additional identity/s as required
 	if userAcc.Spec.OriginalSub != "" {
-
 		// Encoded the OriginalSub as an unpadded Base64 value
 		_, createdOrUpdated, err := r.loadIdentityAndEnsureMapping(logger, config, userAcc.Spec.OriginalSub, userAcc, user)
 		if createdOrUpdated || err != nil {
@@ -330,26 +312,22 @@ func (r *Reconciler) ensureIdentity(logger logr.Logger, config membercfg.Configu
 func (r *Reconciler) loadIdentityAndEnsureMapping(logger logr.Logger, config membercfg.Configuration, username string,
 	userAccount *toolchainv1alpha1.UserAccount, user *userv1.User) (*userv1.Identity, bool, error) {
 
-	// If the username contains invalid characters, then we will base64-encode it here
-	var identityName string
-	if isIdentityNameCompliant(username) {
-		identityName = ToIdentityName(username, config.Auth().Idp())
-	} else {
-		identityName = ToIdentityName(fmt.Sprintf("b64:%s", base64.RawStdEncoding.EncodeToString([]byte(username))), config.Auth().Idp())
-	}
+	ins := identity2.NewIdentityNamingStandard(username, config.Auth().Idp())
 
 	identity := &userv1.Identity{}
 
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: identityName}, identity); err != nil {
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: ins.IdentityName()}, identity); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info("creating a new identity")
 			if err := r.setStatusProvisioning(userAccount); err != nil {
 				return nil, false, err
 			}
-			identity = newIdentity(identityName, username, user, config)
+			identity = newIdentity(user)
+			identity2.NewIdentityNamingStandard(username, config.Auth().Idp()).ApplyToIdentity(identity)
+
 			setOwnerLabel(identity, userAccount.Name)
 			if err := r.Client.Create(context.TODO(), identity); err != nil {
-				return nil, false, r.wrapErrorWithStatusUpdate(logger, userAccount, r.setStatusIdentityCreationFailed, err, "failed to create identity '%s'", identityName)
+				return nil, false, r.wrapErrorWithStatusUpdate(logger, userAccount, r.setStatusIdentityCreationFailed, err, "failed to create identity '%s'", ins.IdentityName())
 			}
 			if err := r.setStatusProvisioning(userAccount); err != nil {
 				return nil, false, err
@@ -357,13 +335,13 @@ func (r *Reconciler) loadIdentityAndEnsureMapping(logger logr.Logger, config mem
 			logger.Info("identity created successfully")
 			return identity, true, nil
 		}
-		return nil, false, r.wrapErrorWithStatusUpdate(logger, userAccount, r.setStatusIdentityCreationFailed, err, "failed to get identity '%s'", identityName)
+		return nil, false, r.wrapErrorWithStatusUpdate(logger, userAccount, r.setStatusIdentityCreationFailed, err, "failed to get identity '%s'", ins.IdentityName())
 	}
 	logger.Info("identity already exists")
 
 	// ensure mapping
 	if identity.User.Name != user.Name || identity.User.UID != user.UID {
-		logger.Info("identity is missing a reference to user; updating the reference", "identity", identityName, "user", user.Name)
+		logger.Info("identity is missing a reference to user; updating the reference", "identity", ins.IdentityName(), "user", user.Name)
 		if err := r.setStatusProvisioning(userAccount); err != nil {
 			return nil, false, err
 		}
@@ -372,7 +350,7 @@ func (r *Reconciler) loadIdentityAndEnsureMapping(logger logr.Logger, config mem
 			UID:  user.UID,
 		}
 		if err := r.Client.Update(context.TODO(), identity); err != nil {
-			return nil, false, r.wrapErrorWithStatusUpdate(logger, userAccount, r.setStatusMappingCreationFailed, err, "failed to update identity '%s'", identityName)
+			return nil, false, r.wrapErrorWithStatusUpdate(logger, userAccount, r.setStatusMappingCreationFailed, err, "failed to update identity '%s'", ins.IdentityName())
 		}
 		if err := r.setStatusProvisioning(userAccount); err != nil {
 			return nil, false, err
@@ -736,31 +714,18 @@ func (r *Reconciler) updateStatusConditions(userAcc *toolchainv1alpha1.UserAccou
 }
 
 func newUser(userAcc *toolchainv1alpha1.UserAccount, config membercfg.Configuration) *userv1.User {
-	username := userAcc.Spec.UserID
-	if !isIdentityNameCompliant(username) {
-		username = fmt.Sprintf("b64:%s", base64.RawStdEncoding.EncodeToString([]byte(username)))
-	}
-
 	user := &userv1.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: userAcc.Name,
 		},
-		Identities: []string{ToIdentityName(username, config.Auth().Idp())},
+		Identities: []string{identity2.NewIdentityNamingStandard(userAcc.Spec.UserID, config.Auth().Idp()).IdentityName()},
 	}
 	return user
 }
 
-func newIdentity(identityName, username string, user *userv1.User, config membercfg.Configuration) *userv1.Identity {
-	if !isIdentityNameCompliant(username) {
-		username = fmt.Sprintf("b64:%s", base64.RawStdEncoding.EncodeToString([]byte(username)))
-	}
-
+func newIdentity(user *userv1.User) *userv1.Identity {
 	identity := &userv1.Identity{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: identityName,
-		},
-		ProviderName:     config.Auth().Idp(),
-		ProviderUserName: username,
+		ObjectMeta: metav1.ObjectMeta{},
 		User: corev1.ObjectReference{
 			Name: user.Name,
 			UID:  user.UID,
@@ -817,12 +782,4 @@ func (r *Reconciler) lookupAndDeleteCheUser(logger logr.Logger, config membercfg
 	}
 
 	return nil
-}
-
-// isIdentityNameCompliant returns true if the specified name is RFC-1123 compliant, otherwise it returns false
-func isIdentityNameCompliant(name string) bool {
-	if len(name) > 253 {
-		return false
-	}
-	return dns1123ValueRegexp.MatchString(name)
 }

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -3,7 +3,7 @@ package useraccount
 import (
 	"context"
 	"fmt"
-	identity2 "github.com/codeready-toolchain/toolchain-common/pkg/identity"
+	commonidentity "github.com/codeready-toolchain/toolchain-common/pkg/identity"
 	"reflect"
 	"time"
 

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	identity2 "github.com/codeready-toolchain/toolchain-common/pkg/identity"
 	"net/http"
 	"os"
 	"testing"
@@ -1937,15 +1938,8 @@ func assertIdentityNotFound(t *testing.T, r *Reconciler, userAcc *toolchainv1alp
 }
 
 func assertIdentity(t *testing.T, r *Reconciler, userAcc *toolchainv1alpha1.UserAccount, idp string) *userv1.Identity {
-	var identityName string
-	if isIdentityNameCompliant(userAcc.Spec.UserID) {
-		identityName = ToIdentityName(userAcc.Spec.UserID, idp)
-	} else {
-		identityName = ToIdentityName(fmt.Sprintf("b64:%s", base64.RawStdEncoding.EncodeToString([]byte(userAcc.Spec.UserID))), idp)
-	}
-
 	identity := &userv1.Identity{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: identityName}, identity)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: identity2.NewIdentityNamingStandard(userAcc.Spec.UserID, idp).IdentityName()}, identity)
 	require.NoError(t, err)
 	require.NotNil(t, identity.Labels)
 	assert.Equal(t, userAcc.Name, identity.Labels["toolchain.dev.openshift.com/owner"])

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/member-operator
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220201204931-0f8a253e08e0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.5
 	// using latest commit from 'github.com/openshift/api@release-4.7'

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574 h1:lwAkKKUSpTawVSzFWuadyWlT9StIKjgUZhOS0ncxiYE=
 github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084 h1:9V+OvCQU9h7V3W6bx0hhqO3JQL/hyENwuRPeq24XYf4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220201204931-0f8a253e08e0 h1:fU3TjtPE9EGWDLME7F1Q6lys2ngnRgYY6x+bfVcY0h4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220201204931-0f8a253e08e0/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -513,6 +513,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sbryzak/toolchain-common v0.0.0-20220131220504-656e0665e9c8 h1:LpiQP2RRb2iQpf7utZN/yPxUYM/ARaHuIv2J8gLBw8I=
+github.com/sbryzak/toolchain-common v0.0.0-20220131220504-656e0665e9c8/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
This PR replaces the ad hoc code that sets Identity property values in the UserAccountController and uses the IdentityNamingStandard utility instead.

Fixes https://issues.redhat.com/browse/CRT-1421