### PR TITLE
Fix panic in useraccount controller

### DIFF
--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -388,6 +388,9 @@ func setOwnerAndProviderLabel(object metav1.Object, owner string) {
 func addProviderLabel(object client.Object, cl client.Client) error {
 	if _, exists := object.GetLabels()[toolchainv1alpha1.ProviderLabelKey]; !exists {
 		labels := object.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
 		labels[toolchainv1alpha1.ProviderLabelKey] = toolchainv1alpha1.ProviderLabelValue
 		err := cl.Update(context.TODO(), object)
 		if err != nil {


### PR DESCRIPTION
Fix for the following error reported by Chris Chase on RHODS cluster:
```
{"level":"error","ts":"2022-02-16T01:17:12.679Z","msg":"Observed a panic: \"assignment to entry in nil map\" (assignment to entry in nil map)\ngoroutine 1712 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic(0x196edc0, 0x1d78070)\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:74 +0x95\nk8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:48 +0x86\npanic(0x196edc0, 0x1d78070)\n\t/opt/hostedtoolcache/go/1.16.13/x64/src/runtime/panic.go:965 +0x1b9\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.addProviderLabel(0x1df2dc0, 0xc002b67500, 0x1de2718, 0xc0004fd090, 0x0, 0x0)\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:391 +0xb0\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).loadIdentityAndEnsureMapping(0xc000a99240, 0x1dd7f08, 0xc002b41bf0, 0xc002b67458, 0xc002b49e60, 0xc000f23c88, 0x8, 0xc002b63800, 0xc002b6a420, 0x36, ...)\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:350 +0x939\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).ensureIdentity(0xc000a99240, 0x1dd7f08, 0xc002b41bf0, 0xc002b67458, 0xc002b49e60, 0xc002b63800, 0xc002b6a420, 0xc00074bb00, 0x0, 0x0, ...)\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:302 +0x98\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).ensureUserAndIdentity(0xc000a99240, 0x1dd7f08, 0xc002b41bf0, 0xc002b63800, 0xc002b67458, 0xc002b49e60, 0xd, 0x1df27f8, 0xc002b63800)\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:165 +0x145\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).Reconcile(0xc000a99240, 0x1dcde18, 0xc002b49e00, 0xc000dab0a0, 0x19, 0xc000f23c50, 0xd, 0xc002b49e00, 0xc000e4a000, 0x1a02a60, ...)\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:119 +0x809\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000b66460, 0x1dcdd70, 0xc0002c51c0, 0x19c5140, 0xc00139db20)\n\t/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:298 +0x30d\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000b66460, 0x1dcdd70, 0xc0002c51c0, 0xc000b41600)\n\t/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:253 +0x205\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2(0x1dcdd70, 0xc0002c51c0)\n\t/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:216 +0x4a\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185 +0x37\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000b41750)\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155 +0x5f\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc001e33f50, 0x1d91140, 0xc001e28030, 0xc0002c5101, 0xc000ac4000)\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156 +0x9b\nk8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000b41750, 0x3b9aca00, 0x0, 0xc19301, 0xc000ac4000)\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:133 +0x98\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext(0x1dcdd70, 0xc0002c51c0, 0xc000e93560, 0x3b9aca00, 0x0, 0x1)\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185 +0xa6\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext(0x1dcdd70, 0xc0002c51c0, 0xc000e93560, 0x3b9aca00)\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:99 +0x57\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:213 +0x40d\n","stacktrace":"k8s.io/klog/v2.(*loggingT).printf\n\t/tmp/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:751\nk8s.io/klog/v2.Errorf\n\t/tmp/go/pkg/mod/k8s.io/klog/v2@v2.8.0/klog.go:1463\nk8s.io/apimachinery/pkg/util/runtime.logPanic\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:78\nk8s.io/apimachinery/pkg/util/runtime.HandleCrash\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:48\nruntime.gopanic\n\t/opt/hostedtoolcache/go/1.16.13/x64/src/runtime/panic.go:965\nruntime.mapassign_faststr\n\t/opt/hostedtoolcache/go/1.16.13/x64/src/runtime/map_faststr.go:204\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.addProviderLabel\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:391\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).loadIdentityAndEnsureMapping\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:350\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).ensureIdentity\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:302\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).ensureUserAndIdentity\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:165\ngithub.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).Reconcile\n\t/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:298\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:253\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2\n\t/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:216\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:99"}
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 1712 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:55 +0x109
panic(0x196edc0, 0x1d78070)
	/opt/hostedtoolcache/go/1.16.13/x64/src/runtime/panic.go:965 +0x1b9
github.com/codeready-toolchain/member-operator/controllers/useraccount.addProviderLabel(0x1df2dc0, 0xc002b67500, 0x1de2718, 0xc0004fd090, 0x0, 0x0)
	/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:391 +0xb0
github.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).loadIdentityAndEnsureMapping(0xc000a99240, 0x1dd7f08, 0xc002b41bf0, 0xc002b67458, 0xc002b49e60, 0xc000f23c88, 0x8, 0xc002b63800, 0xc002b6a420, 0x36, ...)
	/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:350 +0x939
github.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).ensureIdentity(0xc000a99240, 0x1dd7f08, 0xc002b41bf0, 0xc002b67458, 0xc002b49e60, 0xc002b63800, 0xc002b6a420, 0xc00074bb00, 0x0, 0x0, ...)
	/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:302 +0x98
github.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).ensureUserAndIdentity(0xc000a99240, 0x1dd7f08, 0xc002b41bf0, 0xc002b63800, 0xc002b67458, 0xc002b49e60, 0xd, 0x1df27f8, 0xc002b63800)
	/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:165 +0x145
github.com/codeready-toolchain/member-operator/controllers/useraccount.(*Reconciler).Reconcile(0xc000a99240, 0x1dcde18, 0xc002b49e00, 0xc000dab0a0, 0x19, 0xc000f23c50, 0xd, 0xc002b49e00, 0xc000e4a000, 0x1a02a60, ...)
	/home/runner/work/member-operator/member-operator/controllers/useraccount/useraccount_controller.go:119 +0x809
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000b66460, 0x1dcdd70, 0xc0002c51c0, 0x19c5140, 0xc00139db20)
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000b66460, 0x1dcdd70, 0xc0002c51c0, 0xc000b41600)
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2(0x1dcdd70, 0xc0002c51c0)
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:216 +0x4a
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
	/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185 +0x37
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000b41750)
	/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc001e33f50, 0x1d91140, 0xc001e28030, 0xc0002c5101, 0xc000ac4000)
	/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000b41750, 0x3b9aca00, 0x0, 0xc19301, 0xc000ac4000)
	/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext(0x1dcdd70, 0xc0002c51c0, 0xc000e93560, 0x3b9aca00, 0x0, 0x1)
	/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185 +0xa6
k8s.io/apimachinery/pkg/util/wait.UntilWithContext(0x1dcdd70, 0xc0002c51c0, 0xc000e93560, 0x3b9aca00)
	/tmp/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:99 +0x57
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:213 +0x40d
```