### PR TITLE
Adjust logic and add unit test

### DIFF
--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -1439,33 +1439,69 @@ func TestReconcile(t *testing.T) {
 
 	// Test existing User and Identity without provider label
 	t.Run("existing User without provider label has the label added", func(t *testing.T) {
-		// given
-		withoutLabel := preexistingUser.DeepCopy()
-		delete(withoutLabel.Labels, toolchainv1alpha1.ProviderLabelKey)
-		r, req, _, _ := prepareReconcile(t, username, userAcc, withoutLabel, preexistingIdentity)
 
-		// when
-		res, err := r.Reconcile(context.TODO(), req)
+		t.Run("User with nil labels", func(t *testing.T) {
+			// given
+			withoutAnyLabel := preexistingUser.DeepCopy()
+			withoutAnyLabel.Labels = nil
+			r, req, _, _ := prepareReconcile(t, username, userAcc, withoutAnyLabel, preexistingIdentity)
 
-		//then
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, res)
-		assertUser(t, r, userAcc)
+			// when
+			res, err := r.Reconcile(context.TODO(), req)
+
+			//then
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, res)
+			assertUser(t, r, userAcc)
+		})
+
+		t.Run("User with another label defined", func(t *testing.T) {
+			// given
+			withoutLabel := preexistingUser.DeepCopy()
+			delete(withoutLabel.Labels, toolchainv1alpha1.ProviderLabelKey)
+			r, req, _, _ := prepareReconcile(t, username, userAcc, withoutLabel, preexistingIdentity)
+
+			// when
+			res, err := r.Reconcile(context.TODO(), req)
+
+			//then
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, res)
+			assertUser(t, r, userAcc)
+		})
 	})
 
 	t.Run("existing Identity without provider label has the label added", func(t *testing.T) {
-		// given
-		withoutLabel := preexistingIdentity.DeepCopy()
-		delete(withoutLabel.Labels, toolchainv1alpha1.ProviderLabelKey)
-		r, req, _, _ := prepareReconcile(t, username, userAcc, withoutLabel, preexistingUser)
 
-		// when
-		res, err := r.Reconcile(context.TODO(), req)
+		t.Run("Identity with nil labels", func(t *testing.T) {
+			// given
+			withoutLabel := preexistingIdentity.DeepCopy()
+			withoutLabel.Labels = nil
+			r, req, _, _ := prepareReconcile(t, username, userAcc, withoutLabel, preexistingUser)
 
-		//then
-		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, res)
-		assertIdentity(t, r, userAcc, config.Auth().Idp())
+			// when
+			res, err := r.Reconcile(context.TODO(), req)
+
+			//then
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, res)
+			assertIdentity(t, r, userAcc, config.Auth().Idp())
+		})
+
+		t.Run("Identity with another label defined", func(t *testing.T) {
+			// given
+			withoutLabel := preexistingIdentity.DeepCopy()
+			delete(withoutLabel.Labels, toolchainv1alpha1.ProviderLabelKey)
+			r, req, _, _ := prepareReconcile(t, username, userAcc, withoutLabel, preexistingUser)
+
+			// when
+			res, err := r.Reconcile(context.TODO(), req)
+
+			//then
+			require.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, res)
+			assertIdentity(t, r, userAcc, config.Auth().Idp())
+		})
 	})
 }
 


### PR DESCRIPTION
Unit tests for https://github.com/codeready-toolchain/member-operator/pull/337

After adding the unit test with a User/Identity that had nil labels the tests were failing because the assertUser function checks the following:
```
assert.Equal(t, userAcc.Name, user.Labels["toolchain.dev.openshift.com/owner"])
assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, user.Labels[toolchainv1alpha1.ProviderLabelKey])
```

So I'm assuming it's always expected that both owner and provider labels should be present? At least that's the assumption I went with to make the unit tests pass. I changed the `addProviderLabel` func to `addOwnerAndProviderLabels` so it adds both. Please verify that that's what we actually want.