### PR TITLE
refactor: returned bool from ApplyToolchainObjects

### DIFF
--- a/controllers/nstemplateset/client_test.go
+++ b/controllers/nstemplateset/client_test.go
@@ -58,6 +58,21 @@ func TestApplyToolchainObjects(t *testing.T) {
 		assertObjects(t, fakeClient, false)
 	})
 
+	t.Run("when creating none because the both already exists", func(t *testing.T) {
+		// given
+		apiClient, fakeClient := prepareAPIClient(t)
+		_, err := client.NewApplyClient(fakeClient, scheme.Scheme).Apply(copyObjects(role, devNs), additionalLabel)
+		require.NoError(t, err)
+
+		// when
+		changed, err := apiClient.ApplyToolchainObjects(logger, copyObjects(role, devNs), additionalLabel)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assertObjects(t, fakeClient, false)
+	})
+
 	t.Run("when only DBaaSTenant is supposed to be applied but the group for DBaaS is not present", func(t *testing.T) {
 		// given
 		apiClient, fakeClient := prepareAPIClient(t)

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -196,11 +196,11 @@ func (r *namespacesManager) ensureDeleted(logger logr.Logger, nsTmplSet *toolcha
 func (r *namespacesManager) getTierTemplatesForAllNamespaces(nsTmplSet *toolchainv1alpha1.NSTemplateSet) ([]*tierTemplate, error) {
 	var tmpls []*tierTemplate
 	for _, ns := range nsTmplSet.Spec.Namespaces {
-		nsTmpl, err := getTierTemplate(r.GetHostCluster, ns.TemplateRef)
+		tmpl, err := getTierTemplate(r.GetHostCluster, ns.TemplateRef)
 		if err != nil {
 			return nil, err
 		}
-		tmpls = append(tmpls, nsTmpl)
+		tmpls = append(tmpls, tmpl)
 	}
 	return tmpls, nil
 }

--- a/controllers/nstemplateset/nstemplateset_controller.go
+++ b/controllers/nstemplateset/nstemplateset_controller.go
@@ -134,6 +134,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		logger.Error(err, "failed to either provision or update cluster resources")
 		return reconcile.Result{}, err
 	} else if createdOrUpdated {
+		logger.Info("created or updated cluster resources")
 		return reconcile.Result{}, nil // wait for cluster resources to be created
 	}
 
@@ -141,6 +142,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		logger.Error(err, "failed to either provision or update user namespaces")
 		return reconcile.Result{}, err
 	} else if createdOrUpdated {
+		logger.Info("created or updated namespace resources")
 		return reconcile.Result{}, nil // something in the watched resources has changed - wait for another reconcile
 	}
 
@@ -148,6 +150,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		logger.Error(err, "failed to either provision or update roles in space")
 		return reconcile.Result{}, err
 	} else if createdOrUpdated {
+		logger.Info("created or updated space-role resources")
 		return reconcile.Result{}, nil // something in the watched resources has changed - wait for another reconcile
 	}
 
@@ -215,9 +218,8 @@ func (r *Reconciler) deleteNSTemplateSet(logger logr.Logger, nsTmplSet *toolchai
 
 // deleteObsoleteObjects takes template objects of the current tier and of the new tier (provided as newObjects param),
 // compares their names and GVKs and deletes those ones that are in the current template but are not found in the new one.
-// return `true, nil` if an object was deleted, `false, nil`/`false, err` otherwise
 func deleteObsoleteObjects(logger logr.Logger, client runtimeclient.Client, currentObjs []runtimeclient.Object, newObjects []runtimeclient.Object) error {
-	logger.Info("looking for obsolete objects", "count", len(currentObjs))
+	logger.Info("looking for obsolete objects", "current_count", len(currentObjs))
 Current:
 	for _, currentObj := range currentObjs {
 		objectLogger := logger.WithValues("objectName", currentObj.GetObjectKind().GroupVersionKind().Kind+"/"+currentObj.GetName())


### PR DESCRIPTION
return `true` when at least one resource is applied,
`false` otherwise.

Notes:
In some tests, the rolebinding resources were replaced by
idlers in order to have changes in the specs, which in turn
trigger a resource update at the client level (ie, the resource
generation changed).
As a consequence, when the only change in the resource is at the labels
level, the client returns `false` and the controller moves on the next
resource, instead of exiting the reconcile loop. This means less reconcile
loops to process a whole NSTemplateSet update (also affects the unit-tests)

Also, rename more `code` namespaces to `stage` in unit tests

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
