### PR TITLE
Handle migration from CRW to Dev Spaces

### DIFF
--- a/controllers/memberstatus/memberstatus_controller.go
+++ b/controllers/memberstatus/memberstatus_controller.go
@@ -295,13 +295,13 @@ func (r *Reconciler) cheHandleStatus(reqLogger logr.Logger, memberStatus *toolch
 	}
 
 	if !r.isCheAdminUserConfigured(config) {
-		err := fmt.Errorf("Che admin user credentials are not configured but Che user deletion is enabled")
+		err := fmt.Errorf("the Che admin user credentials are not configured but Che user deletion is enabled")
 		errCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberStatusCheAdminUserNotConfiguredReason, err.Error())
 		memberStatus.Status.Che.Conditions = []toolchainv1alpha1.Condition{*errCondition}
 		return err
 	}
 
-	// Get che route for testing user API
+	// Ensure it's possible to construct the che URL for using the Che user API
 	if _, err := r.cheDashboardURL(config); err != nil {
 		wrappedErr := errs.Wrapf(err, "Che dashboard URL unavailable but Che user deletion is enabled")
 		errCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberStatusCheRouteUnavailableReason, wrappedErr.Error())
@@ -309,11 +309,13 @@ func (r *Reconciler) cheHandleStatus(reqLogger logr.Logger, memberStatus *toolch
 		return err
 	}
 
-	// User API check
-	if err := r.CheClient.UserAPICheck(); err != nil {
-		errCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberStatusCheUserAPICheckFailedReason, err.Error())
-		memberStatus.Status.Che.Conditions = []toolchainv1alpha1.Condition{*errCondition}
-		return err
+	// User API check (not applicable after migration from Che to Dev Spaces)
+	if config.Che().Namespace() != "crw" && config.Che().RouteName() != "devspaces" {
+		if err := r.CheClient.UserAPICheck(); err != nil {
+			errCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberStatusCheUserAPICheckFailedReason, err.Error())
+			memberStatus.Status.Che.Conditions = []toolchainv1alpha1.Condition{*errCondition}
+			return err
+		}
 	}
 
 	readyCondition := status.NewComponentReadyCondition(toolchainv1alpha1.ToolchainStatusMemberStatusCheReadyReason)

--- a/controllers/memberstatus/memberstatus_controller_test.go
+++ b/controllers/memberstatus/memberstatus_controller_test.go
@@ -606,7 +606,7 @@ func TestOverallStatusCondition(t *testing.T) {
 				HasCondition(ComponentsNotReady("che")).
 				HasMemoryUsage(OfNodeRole("master", 33), OfNodeRole("worker", 25)).
 				HasRoutes("https://console.member-cluster/console/", "http://codeready-codeready-workspaces-operator.member-cluster/che/", routesAvailable()).
-				HasCheConditions(cheAdminUserNotConfigured("Che admin user credentials are not configured but Che user deletion is enabled"))
+				HasCheConditions(cheAdminUserNotConfigured("the Che admin user credentials are not configured but Che user deletion is enabled"))
 		})
 
 		t.Run("no che route", func(t *testing.T) {

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -8,6 +8,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	membercfg "github.com/codeready-toolchain/member-operator/controllers/memberoperatorconfig"
 	"github.com/codeready-toolchain/member-operator/pkg/che"
+	"github.com/codeready-toolchain/member-operator/pkg/utils/user"
 	commoncontroller "github.com/codeready-toolchain/toolchain-common/controllers"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
@@ -427,24 +428,23 @@ func (r *Reconciler) deleteIdentityAndUser(logger logr.Logger, userAcc *toolchai
 // if the user existed and something wrong happened. If the users don't exist,
 // this func returns `false, nil`
 func (r *Reconciler) deleteUser(logger logr.Logger, userAcc *toolchainv1alpha1.UserAccount) (bool, error) {
-	userList := &userv1.UserList{}
-	err := r.Client.List(context.TODO(), userList, listByOwnerLabel(userAcc.Name))
+	userList, err := user.GetUsersByOwnerName(r.Client, userAcc.Name)
 	if err != nil {
 		return false, err
 	}
 
-	if len(userList.Items) == 0 {
+	if len(userList) == 0 {
 		return false, nil
 	}
 
 	logger.Info("deleting the User resources")
 
 	// Delete User associated with UserAccount
-	if err := r.Client.Delete(context.TODO(), &userList.Items[0]); err != nil {
+	if err := r.Client.Delete(context.TODO(), &userList[0]); err != nil {
 		return false, err
 	}
 	// Return here, as deleting the user should cause another reconcile of the UserAccount
-	logger.Info(fmt.Sprintf("deleted User resource [%s]", userList.Items[0].Name))
+	logger.Info(fmt.Sprintf("deleted User resource [%s]", userList[0].Name))
 	return true, nil
 }
 
@@ -615,6 +615,10 @@ func (r *Reconciler) lookupAndDeleteCheUser(logger logr.Logger, config membercfg
 		return nil
 	}
 
+	if config.Che().Namespace() == "crw" && config.Che().RouteName() == "devspaces" {
+		return r.deleteDevSpacesUser(logger, userAcc)
+	}
+
 	userExists, err := r.CheClient.UserExists(userAcc.Name)
 	if err != nil {
 		return err
@@ -638,6 +642,22 @@ func (r *Reconciler) lookupAndDeleteCheUser(logger logr.Logger, config membercfg
 	}
 
 	return nil
+}
+
+func (r *Reconciler) deleteDevSpacesUser(logger logr.Logger, userAcc *toolchainv1alpha1.UserAccount) error {
+	logger.Info("Deleting OpenShift Dev Spaces user")
+
+	// look up user resource to get UID
+	userList, err := user.GetUsersByOwnerName(r.Client, userAcc.Name)
+	if err != nil {
+		return err
+	}
+
+	if len(userList) == 0 {
+		return nil
+	}
+
+	return r.CheClient.DevSpacesDBCleanerDelete(string(userList[0].GetObjectMeta().GetUID()))
 }
 
 // listByOwnerLabel returns runtimeclient.ListOption that filters by label toolchain.dev.openshift.com/owner equal to the given owner name

--- a/pkg/utils/user/user.go
+++ b/pkg/utils/user/user.go
@@ -1,0 +1,22 @@
+package user
+
+import (
+	"context"
+
+	userv1 "github.com/openshift/api/user/v1"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetUsersByOwnerName gets the user resources by matching owner label.
+func GetUsersByOwnerName(cl client.Client, owner string) ([]userv1.User, error) {
+	userList := &userv1.UserList{}
+	labels := map[string]string{toolchainv1alpha1.OwnerLabelKey: owner}
+	err := cl.List(context.TODO(), userList, client.MatchingLabels(labels))
+	if err != nil {
+		return []userv1.User{}, err
+	}
+
+	return userList.Items, nil
+}


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1562

- updates the `lookupAndDeleteCheUser` func to check whether the MemberOperatorConfig's Che Namespace and Route match `crw` and `devspaces` respectively. If the configuration matches then it will enter the DevSpaces deletion flow which will look up the User resource in order to get the UID. It then calls the che-db-cleaner service to delete the user using the UID.
- also updates the member status to check if we are in DevSpaces mode and if so it will skip the legacy Che User API checks  since DevSpaces does not have such APIs anymore
- no updates to e2e tests since this requires DevSpaces installation and our e2e environment does not have it but unit tests have good enough coverage