### PR TITLE
fix(#343): Add permissions to scale Camel K resources

### DIFF
--- a/config/rbac/camel_k_role.yaml
+++ b/config/rbac/camel_k_role.yaml
@@ -1,0 +1,26 @@
+# permissions to scale Camel K resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: camel-k-role
+rules:
+- apiGroups:
+    - camel.apache.org
+  resources:
+    - integrations
+    - kameletbindings
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - camel.apache.org
+  resources:
+    - integrations/scale
+    - integrations/status
+    - kameletbindings/scale
+    - kameletbindings/status
+  verbs:
+    - get
+    - patch
+    - update

--- a/config/rbac/camel_k_role_binding.yaml
+++ b/config/rbac/camel_k_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: camel-k-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: camel-k-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- camel_k_role.yaml
+- camel_k_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
Allow controller manager to scale Camel K Integration and KameletBinding custom resources on the cluster

Signed-off-by: Christoph Deppisch <cdeppisch@redhat.com>