### PR TITLE
enable cross-platform build

### DIFF
--- a/make/docker.mk
+++ b/make/docker.mk
@@ -4,12 +4,13 @@ IMAGE_TAG ?= ${GIT_COMMIT_ID_SHORT}
 IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}:${IMAGE_TAG}
 QUAY_USERNAME ?= ${QUAY_NAMESPACE}
 WEBHOOK_IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}-webhook:${IMAGE_TAG}
+IMAGE_PLATFORM ?= linux/amd64
 
 .PHONY: docker-image
 ## Build the binary image
 docker-image: build
-	$(Q)docker build -f build/Dockerfile -t ${IMAGE} .
-	$(Q)docker build -f build/Dockerfile.webhook -t ${WEBHOOK_IMAGE} .
+	$(Q)docker build --platform ${IMAGE_PLATFORM} -f build/Dockerfile -t ${IMAGE} .
+	$(Q)docker build --platform ${IMAGE_PLATFORM} -f build/Dockerfile.webhook -t ${WEBHOOK_IMAGE} .
 
 .PHONY: docker-push
 ## Push the binary image to quay.io registry
@@ -20,8 +21,8 @@ docker-push: check-namespace docker-image
 .PHONY: podman-image
 ## Build the binary image
 podman-image: build
-	$(Q)podman build -f build/Dockerfile -t ${IMAGE} .
-	$(Q)podman build -f build/Dockerfile.webhook -t ${WEBHOOK_IMAGE} .
+	$(Q)podman build --platform ${IMAGE_PLATFORM} -f build/Dockerfile -t ${IMAGE} .
+	$(Q)podman build --platform ${IMAGE_PLATFORM} -f build/Dockerfile.webhook -t ${WEBHOOK_IMAGE} .
 
 .PHONY: podman-push
 ## Push the binary image to quay.io registry

--- a/make/go.mk
+++ b/make/go.mk
@@ -5,7 +5,7 @@ GO_PACKAGE_PATH ?= github.com/${GO_PACKAGE_ORG_NAME}/${GO_PACKAGE_REPO_NAME}
 
 GO111MODULE?=on
 export GO111MODULE
-goarch=$(shell go env GOARCH)
+goarch ?= $(shell go env GOARCH)
 
 .PHONY: build
 ## Build the operator

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,5 +1,6 @@
 TMP_DIR?=/tmp
 IMAGE_BUILDER?=podman
+IMAGE_PLATFORM?=linux/amd64
 INDEX_IMAGE_NAME?=member-operator-index
 FIRST_RELEASE?=false
 CHANNEL=staging
@@ -23,7 +24,7 @@ push-bundle-and-index-image:
 ifneq (${BUNDLE_TAG},"")
 	$(eval BUNDLE_TAG_PARAM = -bt ${BUNDLE_TAG})
 endif
-	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/cd/push-bundle-and-index-image.sh SCRIPT_PARAMS="-pr ../member-operator/ -qn ${QUAY_NAMESPACE} -ch ${CHANNEL} -td ${TMP_DIR} -ib ${IMAGE_BUILDER} -iin ${INDEX_IMAGE_NAME} -iit ${INDEX_IMAGE_TAG} ${BUNDLE_TAG_PARAM}"
+	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/cd/push-bundle-and-index-image.sh SCRIPT_PARAMS="-pr ../member-operator/ -qn ${QUAY_NAMESPACE} -ch ${CHANNEL} -td ${TMP_DIR} -ib ${IMAGE_BUILDER} -iin ${INDEX_IMAGE_NAME} -iit ${INDEX_IMAGE_TAG} -ip ${IMAGE_PLATFORM} ${BUNDLE_TAG_PARAM}"
 
 .PHONY: generate-rbac
 generate-rbac: build controller-gen


### PR DESCRIPTION
While building docker images on Mac M1 chipset and deploying to AWS dev environment (running on linux/amd64) I need to change the build platform from my default one.

This PR enables configuring the docker build platform option, example command to run from within the toolchain-e2e dir:

make dev-deploy-e2e HOST_REPO_PATH=$(PWD)/../host-operator goarch=amd64 IMAGE_BUILDER=docker

NOTE: doesn't work with podman on Apple M1 apparently, the images starting with FROM scratch are not being built for the architecture specified with --platform option but with the default one (in my case arm64 ). This could be an issue with podman on Mac only, since docker works fine.