### PR TITLE
ASC-116 drop unused fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,3 +101,7 @@ require (
 )
 
 go 1.18
+
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20221205110700-f7cdcd29d698
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20221213094525-fa5cf2aa499b

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20221205081558-245f157cb403 h1:vq+8TMk92aZazyBisg4nDcX3Dqezs8+/0UWByPOETSE=
-github.com/codeready-toolchain/api v0.0.0-20221205081558-245f157cb403/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20221205082814-2dbd788a5e87 h1:raVr665MxCvCQvxHld9Wni8d5mkAx4ZG8BSoKQvIoTk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20221205082814-2dbd788a5e87/go.mod h1:MDqL9rC53vsujATfvQpKwayKmZZ8kBjTU6oAH5VDy20=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -393,6 +389,10 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mfrancisc/api v0.0.0-20221205110700-f7cdcd29d698 h1:ht1kxsGI8U5/7qGXhOCWo84tR6WJQWuwfG84unchRW4=
+github.com/mfrancisc/api v0.0.0-20221205110700-f7cdcd29d698/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
+github.com/mfrancisc/toolchain-common v0.0.0-20221213094525-fa5cf2aa499b h1:F5EQyilgJNHdKKZrqAGrQS03YYTVifCd6qDDvM31yMk=
+github.com/mfrancisc/toolchain-common v0.0.0-20221213094525-fa5cf2aa499b/go.mod h1:MDqL9rC53vsujATfvQpKwayKmZZ8kBjTU6oAH5VDy20=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=


### PR DESCRIPTION
Remove UserAccountCount, AutomaticApproval.ResourceCapacityThreshold fields and related functionality.

This is the last subtask: [ASC-116](https://issues.redhat.com/browse/ASC-116) of this bigger story [ASC-60](https://issues.redhat.com/browse/ASC-60).

Related PRs:
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/283
- api: https://github.com/codeready-toolchain/api/pull/331
- sandbox-sre: https://github.com/codeready-toolchain/sandbox-sre/pull/848
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/718
- reg-service: https://github.com/codeready-toolchain/registration-service/pull/294

Paired with:
-  toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/636