### PR TITLE
handle kustomize build failure

### DIFF
--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -37,7 +37,7 @@ bundle: clean-bundle generate-rbac kustomize ## Generate bundle manifests and me
 	$(eval TMP_MANIFEST_FILE := $(shell mktemp))
 	@echo "generating manifests to temporary file: ${TMP_MANIFEST_FILE}"
 	$(KUSTOMIZE) build config/manifests -o ${TMP_MANIFEST_FILE}
-	@-cat ${TMP_MANIFEST_FILE} | operator-sdk generate bundle --overwrite --version=${NEXT_VERSION} --channels ${CHANNEL} --default-channel ${CHANNEL} --package toolchain-member-operator
+	cat ${TMP_MANIFEST_FILE} | operator-sdk generate bundle --overwrite --version=${NEXT_VERSION} --channels ${CHANNEL} --default-channel ${CHANNEL} --package toolchain-member-operator
 	operator-sdk bundle validate ./bundle
 
 .PHONY: publish-current-bundle

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -34,7 +34,10 @@ generate-rbac: build controller-gen
 .PHONY: bundle
 bundle: clean-bundle generate-rbac kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle --overwrite --version=${NEXT_VERSION} --channels ${CHANNEL} --default-channel ${CHANNEL} --package toolchain-member-operator
+	$(eval TMP_MANIFEST_FILE := $(shell mktemp))
+	@echo "generating manifests to temporary file: ${TMP_MANIFEST_FILE}"
+	$(KUSTOMIZE) build config/manifests -o ${TMP_MANIFEST_FILE}
+	@-cat ${TMP_MANIFEST_FILE} | operator-sdk generate bundle --overwrite --version=${NEXT_VERSION} --channels ${CHANNEL} --default-channel ${CHANNEL} --package toolchain-member-operator
 	operator-sdk bundle validate ./bundle
 
 .PHONY: publish-current-bundle


### PR DESCRIPTION
save `kustomize build` output to temporary file, in order to intercept failures and avoid publishing empty bundles.

See "green job" with failed build example:
https://github.com/codeready-toolchain/member-operator/actions/runs/3749944798/jobs/6369029675#step:9:1296
