### PR TITLE
test: use var within loop

### DIFF
--- a/controllers/nstemplateset/nstemplatetier_test.go
+++ b/controllers/nstemplateset/nstemplatetier_test.go
@@ -271,7 +271,7 @@ func TestGetTierTemplate(t *testing.T) {
 		for _, tierTemplate := range []*toolchainv1alpha1.TierTemplate{basicTierCode, basicTierDev, basicTierStage, basicTierCluster, advancedTierCode, advancedTierDev, advancedTierStage} {
 			for i := 0; i < 1000; i++ {
 				waitForFinished.Add(1)
-				go func() {
+				go func(tierTemplate *toolchainv1alpha1.TierTemplate) {
 					// given
 					defer waitForFinished.Done()
 					latch.Wait()
@@ -286,7 +286,7 @@ func TestGetTierTemplate(t *testing.T) {
 					// then
 					assert.NoError(t, err)
 					assertThatTierTemplateIsSameAs(t, tierTemplate, retrievedTierTemplate)
-				}()
+				}(tierTemplate)
 			}
 		}
 


### PR DESCRIPTION
address the `loop variable tierTemplate captured by func literal` warning

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
