### PR TITLE
feat: add list of provisioned namespaces into NSTemplateSet status

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatesets.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatesets.yaml
@@ -147,21 +147,19 @@ spec:
                 description: ProvisionedNamespaces is a list of Namespaces that were
                   provisioned by the NSTemplateSet.
                 items:
+                  description: SpaceNamespace is a common type to define the information
+                    about a namespace within a Space Used in NSTemplateSet, Space
+                    and Workspace status
                   properties:
                     name:
-                      description: Name of the namespace
+                      description: Name the name of the namespace.
                       type: string
                     type:
-                      description: Type of the namespace
+                      description: Type the type of the namespace. eg. default
                       type: string
-                  required:
-                  - name
-                  - type
                   type: object
                 type: array
-                x-kubernetes-list-map-keys:
-                - name
-                x-kubernetes-list-type: map
+                x-kubernetes-list-type: atomic
             type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true

--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatesets.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatesets.yaml
@@ -143,6 +143,25 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              provisionedNamespaces:
+                description: ProvisionedNamespaces is a list of Namespaces that were
+                  provisioned by the NSTemplateSet.
+                items:
+                  properties:
+                    name:
+                      description: Name of the namespace
+                      type: string
+                    type:
+                      description: Type of the namespace
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -436,3 +436,10 @@ func (r *namespacesManager) containsRoleBindings(list []rbac.RoleBinding, obj ru
 	}
 	return false, nil
 }
+
+func (r *namespacesManager) setProvisionedNamespaceList(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (err error) {
+	logger.Info("setting provisioned namespaces", "username", nsTmplSet.GetName())
+	username := nsTmplSet.GetName()
+	userNamespaces, err := fetchNamespacesByOwner(r.Client, username)
+	return r.statusManager.updateStatusProvisionedNamespaces(nsTmplSet, userNamespaces)
+}

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -441,5 +441,8 @@ func (r *namespacesManager) setProvisionedNamespaceList(logger logr.Logger, nsTm
 	logger.Info("setting provisioned namespaces", "username", nsTmplSet.GetName())
 	username := nsTmplSet.GetName()
 	userNamespaces, err := fetchNamespacesByOwner(r.Client, username)
+	if err != nil {
+		return err
+	}
 	return r.statusManager.updateStatusProvisionedNamespaces(nsTmplSet, userNamespaces)
 }

--- a/controllers/nstemplateset/nstemplateset_controller.go
+++ b/controllers/nstemplateset/nstemplateset_controller.go
@@ -145,6 +145,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, nil // something in the watched resources has changed - wait for another reconcile
 	}
 
+	// update provisioned namespace list
+	if err := r.namespaces.setProvisionedNamespaceList(logger, nsTmplSet); err != nil {
+		logger.Error(err, "failed to set provisioned namespaces list")
+		return reconcile.Result{}, err
+	}
+
 	if createdOrUpdated, err := r.spaceRoles.ensure(logger, nsTmplSet); err != nil {
 		logger.Error(err, "failed to either provision or update roles in space")
 		return reconcile.Result{}, err

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -177,7 +177,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 		require.NoError(t, err)
 		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 			HasFinalizer().
-			HasProvisionedNamespaces([]toolchainv1alpha1.Namespace{
+			HasProvisionedNamespaces([]toolchainv1alpha1.SpaceNamespace{
 				{
 					Name: username + "-dev",
 					Type: "default", // check that default type is added to first NS in alphabetical order

--- a/controllers/nstemplateset/status.go
+++ b/controllers/nstemplateset/status.go
@@ -60,9 +60,9 @@ func (r *statusManager) updateStatusProvisionedNamespaces(nsTmplSet *toolchainv1
 		return nil
 	}
 
-	var provisionedNamespaces []toolchainv1alpha1.Namespace
+	var provisionedNamespaces []toolchainv1alpha1.SpaceNamespace
 	for _, ns := range namespaces {
-		provisionedNamespaces = append(provisionedNamespaces, toolchainv1alpha1.Namespace{
+		provisionedNamespaces = append(provisionedNamespaces, toolchainv1alpha1.SpaceNamespace{
 			Name: ns.Name,
 		})
 	}

--- a/controllers/nstemplateset/status.go
+++ b/controllers/nstemplateset/status.go
@@ -2,6 +2,7 @@ package nstemplateset
 
 import (
 	"context"
+	"sort"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
@@ -50,6 +51,29 @@ func (r *statusManager) updateStatusConditions(nsTmplSet *toolchainv1alpha1.NSTe
 		// Nothing changed
 		return nil
 	}
+	return r.Client.Status().Update(context.TODO(), nsTmplSet)
+}
+
+func (r *statusManager) updateStatusProvisionedNamespaces(nsTmplSet *toolchainv1alpha1.NSTemplateSet, namespaces []corev1.Namespace) error {
+	if len(namespaces) == 0 {
+		// no namespaces to set
+		return nil
+	}
+
+	var provisionedNamespaces []toolchainv1alpha1.Namespace
+	for _, ns := range namespaces {
+		provisionedNamespaces = append(provisionedNamespaces, toolchainv1alpha1.Namespace{
+			Name: ns.Name,
+		})
+	}
+	// todo update logic that sets the type of namespace
+	// for now we just set "default" to the first namespace in alphabetical order
+	sort.Slice(provisionedNamespaces, func(i, j int) bool {
+		return provisionedNamespaces[i].Name < provisionedNamespaces[j].Name
+	})
+	provisionedNamespaces[0].Type = "default"
+
+	nsTmplSet.Status.ProvisionedNamespaces = provisionedNamespaces
 	return r.Client.Status().Update(context.TODO(), nsTmplSet)
 }
 

--- a/controllers/nstemplateset/status_test.go
+++ b/controllers/nstemplateset/status_test.go
@@ -6,17 +6,16 @@ import (
 	"fmt"
 	"testing"
 
-	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	. "github.com/codeready-toolchain/member-operator/test"
-
+	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierros "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -49,6 +48,58 @@ func TestUpdateStatus(t *testing.T) {
 		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 			HasFinalizer().
 			HasConditions(condition)
+	})
+
+	t.Run("update provisioned namespaces", func(t *testing.T) {
+		// given
+		conditions := []toolchainv1alpha1.Condition{{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionTrue,
+		}}
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"), withConditions(conditions...))
+		namespaces := []corev1.Namespace{
+			{ObjectMeta: metav1.ObjectMeta{Name: username + "-dev"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: username + "-stage"}},
+		}
+		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
+
+		// when
+		err := statusManager.updateStatusProvisionedNamespaces(nsTmplSet, namespaces)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasProvisionedNamespaces([]toolchainv1alpha1.Namespace{
+				{
+					Name: username + "-dev",
+					Type: "default", // check that default type is added to first NS in alphabetical order
+				},
+				{
+					Name: username + "-stage",
+					Type: "", // other namespaces do not have type for now...
+				},
+			}...)
+	})
+
+	t.Run("no provisioned namespaces", func(t *testing.T) {
+		// given
+		conditions := []toolchainv1alpha1.Condition{{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: corev1.ConditionTrue,
+		}}
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"), withConditions(conditions...))
+		namespaces := []corev1.Namespace{} // empty list of user namespaces are given for some weired issue
+		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
+
+		// when
+		err := statusManager.updateStatusProvisionedNamespaces(nsTmplSet, namespaces)
+
+		// then
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			HasFinalizer().
+			HasProvisionedNamespaces([]toolchainv1alpha1.Namespace(nil)...) // provisioned namespaces list is nil
 	})
 
 	t.Run("status not updated because not changed", func(t *testing.T) {

--- a/controllers/nstemplateset/status_test.go
+++ b/controllers/nstemplateset/status_test.go
@@ -52,14 +52,10 @@ func TestUpdateStatus(t *testing.T) {
 
 	t.Run("update provisioned namespaces", func(t *testing.T) {
 		// given
-		conditions := []toolchainv1alpha1.Condition{{
-			Type:   toolchainv1alpha1.ConditionReady,
-			Status: corev1.ConditionTrue,
-		}}
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"), withConditions(conditions...))
+		nsTmplSet := newNSTmplSet(namespaceName, username, "basic")
 		namespaces := []corev1.Namespace{
-			{ObjectMeta: metav1.ObjectMeta{Name: username + "-dev"}},
 			{ObjectMeta: metav1.ObjectMeta{Name: username + "-stage"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: username + "-dev"}},
 		}
 		statusManager, fakeClient := prepareStatusManager(t, nsTmplSet)
 

--- a/controllers/nstemplateset/status_test.go
+++ b/controllers/nstemplateset/status_test.go
@@ -70,7 +70,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NoError(t, err)
 		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 			HasFinalizer().
-			HasProvisionedNamespaces([]toolchainv1alpha1.Namespace{
+			HasProvisionedNamespaces([]toolchainv1alpha1.SpaceNamespace{
 				{
 					Name: username + "-dev",
 					Type: "default", // check that default type is added to first NS in alphabetical order
@@ -99,7 +99,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NoError(t, err)
 		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
 			HasFinalizer().
-			HasProvisionedNamespaces([]toolchainv1alpha1.Namespace(nil)...) // provisioned namespaces list is nil
+			HasProvisionedNamespaces([]toolchainv1alpha1.SpaceNamespace(nil)...) // provisioned namespaces list is nil
 	})
 
 	t.Run("status not updated because not changed", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
+	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
@@ -102,4 +102,4 @@ require (
 
 go 1.18
 
-replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230208190910-4c0c1d514378
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230210102142-7059558f1382

--- a/go.mod
+++ b/go.mod
@@ -102,4 +102,4 @@ require (
 
 go 1.18
 
-replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230210102142-7059558f1382
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230210160923-56cca6d4889b

--- a/go.mod
+++ b/go.mod
@@ -101,3 +101,5 @@ require (
 )
 
 go 1.18
+
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230131144710-0c3978aefd57

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20230105105418-0c01b05507c6
+	github.com/codeready-toolchain/api v0.0.0-20230213174945-d3c8d3adc123
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.7
@@ -101,5 +101,3 @@ require (
 )
 
 go 1.18
-
-replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230210160923-56cca6d4889b

--- a/go.mod
+++ b/go.mod
@@ -102,4 +102,4 @@ require (
 
 go 1.18
 
-replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230131144710-0c3978aefd57
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230208190910-4c0c1d514378

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/api v0.0.0-20230210102142-7059558f1382 h1:USgc6HSsjuhO8Y2u66e+i/DFf+RvJo6i1w473ayispQ=
-github.com/mfrancisc/api v0.0.0-20230210102142-7059558f1382/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
+github.com/mfrancisc/api v0.0.0-20230210160923-56cca6d4889b h1:Og1z3xScGC0kT02TmOu/1Tvg2dzxjrki3ExTNxBSMD4=
+github.com/mfrancisc/api v0.0.0-20230210160923-56cca6d4889b/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/api v0.0.0-20230131144710-0c3978aefd57 h1:+9AylMtS3nPqynKzMbGoOyA7CmL3vRWGMiLOPWztpfo=
-github.com/mfrancisc/api v0.0.0-20230131144710-0c3978aefd57/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
+github.com/mfrancisc/api v0.0.0-20230208190910-4c0c1d514378 h1:of7WvLWDUoEq0HBaa5W/x39XGV/IFF0Neg4PI5nJ0Wg=
+github.com/mfrancisc/api v0.0.0-20230208190910-4c0c1d514378/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20230213174945-d3c8d3adc123 h1:LxkT8+VQSka1XHtIZMkf9Goh/wYwbuc5JzINigTMq/0=
+github.com/codeready-toolchain/api v0.0.0-20230213174945-d3c8d3adc123/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6 h1:6QH0TWIP2i6wdzEKn/J2ubDoWd0Ix3dZZvCMJWQrfIs=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6/go.mod h1:MDqL9rC53vsujATfvQpKwayKmZZ8kBjTU6oAH5VDy20=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -391,8 +393,6 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/api v0.0.0-20230210160923-56cca6d4889b h1:Og1z3xScGC0kT02TmOu/1Tvg2dzxjrki3ExTNxBSMD4=
-github.com/mfrancisc/api v0.0.0-20230210160923-56cca6d4889b/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20230105105418-0c01b05507c6 h1:TflQwG0S9m7ZPxA9vTe80YwPaPCVvP4rEz5vReT4nDs=
-github.com/codeready-toolchain/api v0.0.0-20230105105418-0c01b05507c6/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6 h1:6QH0TWIP2i6wdzEKn/J2ubDoWd0Ix3dZZvCMJWQrfIs=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6/go.mod h1:MDqL9rC53vsujATfvQpKwayKmZZ8kBjTU6oAH5VDy20=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -393,6 +391,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mfrancisc/api v0.0.0-20230131144710-0c3978aefd57 h1:+9AylMtS3nPqynKzMbGoOyA7CmL3vRWGMiLOPWztpfo=
+github.com/mfrancisc/api v0.0.0-20230131144710-0c3978aefd57/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.12.0+incompatible h1:SIvoTSbsMEwuM3dzFirLwKc4BH6VXP5CNf+G1FfJVr4=
-github.com/emicklei/go-restful v2.12.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.16.0+incompatible h1:rgqiKNjTnFQA6kkhFe16D8epTksy9HQ1MyrbDXSdYhM=
+github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -391,8 +391,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/api v0.0.0-20230208190910-4c0c1d514378 h1:of7WvLWDUoEq0HBaa5W/x39XGV/IFF0Neg4PI5nJ0Wg=
-github.com/mfrancisc/api v0.0.0-20230208190910-4c0c1d514378/go.mod h1:4BhC+uBP9LbSKzQ1ggRAmKIl9pSj0uxdISj0s/HRwEw=
+github.com/mfrancisc/api v0.0.0-20230210102142-7059558f1382 h1:USgc6HSsjuhO8Y2u66e+i/DFf+RvJo6i1w473ayispQ=
+github.com/mfrancisc/api v0.0.0-20230210102142-7059558f1382/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -59,6 +59,13 @@ func (a *NSTemplateSetAssertion) HasNoConditions() *NSTemplateSetAssertion {
 	return a
 }
 
+func (a *NSTemplateSetAssertion) HasNoProvisionedNamespaces() *NSTemplateSetAssertion {
+	err := a.loadNSTemplateSet()
+	require.NoError(a.t, err)
+	require.Empty(a.t, a.nsTmplSet.Status.ProvisionedNamespaces)
+	return a
+}
+
 func (a *NSTemplateSetAssertion) HasConditions(expected ...toolchainv1alpha1.Condition) *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -66,6 +66,13 @@ func (a *NSTemplateSetAssertion) HasConditions(expected ...toolchainv1alpha1.Con
 	return a
 }
 
+func (a *NSTemplateSetAssertion) HasProvisionedNamespaces(expected ...toolchainv1alpha1.Namespace) *NSTemplateSetAssertion {
+	err := a.loadNSTemplateSet()
+	require.NoError(a.t, err)
+	require.Equal(a.t, expected, a.nsTmplSet.Status.ProvisionedNamespaces)
+	return a
+}
+
 func (a *NSTemplateSetAssertion) HasNoOwnerReferences() *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -66,7 +66,7 @@ func (a *NSTemplateSetAssertion) HasConditions(expected ...toolchainv1alpha1.Con
 	return a
 }
 
-func (a *NSTemplateSetAssertion) HasProvisionedNamespaces(expected ...toolchainv1alpha1.Namespace) *NSTemplateSetAssertion {
+func (a *NSTemplateSetAssertion) HasProvisionedNamespaces(expected ...toolchainv1alpha1.SpaceNamespace) *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)
 	require.Equal(a.t, expected, a.nsTmplSet.Status.ProvisionedNamespaces)


### PR DESCRIPTION
This PR adds the NSTemplateSet.Status.ProvisionedNamespaces field, which will contain all the namespace names provisioned by the NSTemplateSet.
The Namespace.Type field it's still WIP, at the moment only the first namespace in alphabetical order will have this field set to default, further work will be needed once we have better requirements about how many type of namespaces we need to support.

Jira Story: https://issues.redhat.com/browse/ASC-252  
Only first two acceptance criteria are covered by this set of PRs, there will be separate PRs for the update to the Space Controller.

Related PRs:
- api: https://github.com/codeready-toolchain/api/pull/338

Paired with:
- e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/660