### PR TITLE
Create ClusterRole for the proxy workspace lister API

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
 - leader_election_role_binding.yaml
 - camel_k_role.yaml
 - camel_k_role_binding.yaml
+- regsvc_proxy_lister_role.yaml
+- regsvc_proxy_lister_rolebinding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/regsvc_proxy_lister_role.yaml
+++ b/config/rbac/regsvc_proxy_lister_role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workspace-lister
+rules:
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - workspaces
+  verbs:
+  - get
+  - list

--- a/config/rbac/regsvc_proxy_lister_rolebinding.yaml
+++ b/config/rbac/regsvc_proxy_lister_rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: workspace-lister
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workspace-lister
+subjects:
+- kind: Group
+  name: system:authenticated


### PR DESCRIPTION
Creates the ClusterRole that's required for API discovery to work when users use the Proxy Space Lister API.

See https://github.com/codeready-toolchain/api/pull/337 and https://github.com/codeready-toolchain/registration-service/pull/301