### PR TITLE
Set UserID and AccountID in User resource if they are set in UserAccount

### DIFF
--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -386,6 +386,34 @@ func setLabelsAndAnnotations(object metav1.Object, userAcc *toolchainv1alpha1.Us
 			object.SetAnnotations(annotations)
 			changed = true
 		}
+
+		annotations = object.GetAnnotations()
+		set := false
+		userID, ok := userAcc.Annotations[toolchainv1alpha1.SSOUserIDAnnotationKey]
+		if ok {
+			accountID, ok := userAcc.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey]
+			// *IF* both userID and accountID properties are set, then set them on the User resource, otherwise clear
+			// the values if they exist
+			if ok {
+				set = true
+				if annotations == nil {
+					annotations = map[string]string{}
+				}
+				annotations[toolchainv1alpha1.SSOUserIDAnnotationKey] = userID
+				annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey] = accountID
+				object.SetAnnotations(annotations)
+				changed = true
+			}
+		}
+
+		// Delete the UserID and AccountID annotations if they don't exist in the UserAccount
+		if !set && object.GetAnnotations() != nil {
+			annotations = object.GetAnnotations()
+			delete(annotations, toolchainv1alpha1.SSOUserIDAnnotationKey)
+			delete(annotations, toolchainv1alpha1.SSOAccountIDAnnotationKey)
+			object.SetAnnotations(annotations)
+			changed = true
+		}
 	}
 	return changed
 }

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -165,7 +165,7 @@ func TestReconcile(t *testing.T) {
 					require.Equal(t, "987654", user.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey])
 
 					t.Run("test missing AccountID annotation propagates to User", func(t *testing.T) {
-						// Remove the UserID annotation from the UserAccount and reconcile again
+						// Remove the AccountID annotation from the UserAccount and reconcile again
 						delete(userAcc.Annotations, toolchainv1alpha1.SSOAccountIDAnnotationKey)
 						r, req, _, _ = prepareReconcile(t, username, userAcc)
 						//when

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -129,6 +129,8 @@ func TestReconcile(t *testing.T) {
 			user := assertUser(t, r, userAcc)
 			user.UID = preexistingUser.UID // we have to set UID for the obtained user because the fake client doesn't set it
 			checkMapping(t, user, preexistingIdentity)
+			require.Equal(t, "123456", user.Annotations[toolchainv1alpha1.SSOUserIDAnnotationKey])
+			require.Equal(t, "987654", user.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey])
 
 			// Check the identity is not created yet
 			assertIdentityNotFound(t, r, userAcc, config.Auth().Idp())
@@ -1613,7 +1615,9 @@ func newUserAccount(userName, userID string, opts ...userAccountOption) *toolcha
 				toolchainv1alpha1.TierLabelKey: "basic",
 			},
 			Annotations: map[string]string{
-				toolchainv1alpha1.UserEmailAnnotationKey: userName + "@acme.com",
+				toolchainv1alpha1.UserEmailAnnotationKey:    userName + "@acme.com",
+				toolchainv1alpha1.SSOUserIDAnnotationKey:    "123456",
+				toolchainv1alpha1.SSOAccountIDAnnotationKey: "987654",
 			},
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20230213174945-d3c8d3adc123
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6
+	github.com/codeready-toolchain/api v0.0.0-20230216033204-23e19e045d50
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20230217033022-295cba634c6d
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.7
 	// using latest commit from 'github.com/openshift/api branch release-4.11'

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,10 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20230213174945-d3c8d3adc123 h1:LxkT8+VQSka1XHtIZMkf9Goh/wYwbuc5JzINigTMq/0=
-github.com/codeready-toolchain/api v0.0.0-20230213174945-d3c8d3adc123/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6 h1:6QH0TWIP2i6wdzEKn/J2ubDoWd0Ix3dZZvCMJWQrfIs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230112091129-d06f31ddd2f6/go.mod h1:MDqL9rC53vsujATfvQpKwayKmZZ8kBjTU6oAH5VDy20=
+github.com/codeready-toolchain/api v0.0.0-20230216033204-23e19e045d50 h1:ivlSXrtcemmD+rt9yE5X4FcMpmyIFTGkIwj+fZvPzjU=
+github.com/codeready-toolchain/api v0.0.0-20230216033204-23e19e045d50/go.mod h1:eOu09m3Vyr5/gmTKQ0w1z6bOmujX6l6PuaXqCx3whpw=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20230217033022-295cba634c6d h1:TicIFB12s4Ooa9J+MDOIekVMqZ5y0vFfjzWw2F7tfGM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20230217033022-295cba634c6d/go.mod h1:ViXCgmJb02OHoOhvISD5hHh84RfJ49L/+Km4DCtdrCU=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -210,8 +210,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=


### PR DESCRIPTION
Propagate both the UserID and AccountID annotation values from `UserAccount` to `User` during reconciliation, if both values are set.  If the values are not set then delete the annotations on the `User`.

Fixes https://issues.redhat.com/browse/CRT-1718

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/670