### PR TITLE
Web Console plugin service skeleton

### DIFF
--- a/build/Dockerfile.consoleplugin
+++ b/build/Dockerfile.consoleplugin
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV CONSOLE_PLUGIN=/usr/local/bin/member-operator-console-plugin \
+    USER_UID=1001 \
+    USER_NAME=member-operator-console-plugin \
+    LANG=en_US.utf8
+
+ # install plugin binary
+COPY build/_output/bin/member-operator-console-plugin ${CONSOLE_PLUGIN}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/member-operator-console-plugin"]
+
+EXPOSE 8080
+
+USER ${USER_UID}

--- a/cmd/consoleplugin/main.go
+++ b/cmd/consoleplugin/main.go
@@ -1,0 +1,5 @@
+package consoleplugin
+
+func main() {
+
+}

--- a/cmd/consoleplugin/main.go
+++ b/cmd/consoleplugin/main.go
@@ -1,4 +1,4 @@
-package consoleplugin
+package main
 
 func main() {
 

--- a/deploy/consoleplugin/member-operator-console-plugin.yaml
+++ b/deploy/consoleplugin/member-operator-console-plugin.yaml
@@ -1,0 +1,131 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: member-operator-console-plugin
+objects:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        provider: codeready-toolchain
+      name: member-operator-console-plugin
+      namespace: ${NAMESPACE}
+  - kind: Role
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      labels:
+        provider: codeready-toolchain
+      name: member-operator-console-plugin
+      namespace: ${NAMESPACE}
+    rules:
+      - apiGroups:
+          - toolchain.dev.openshift.com
+        resources:
+          - memberoperatorconfigs
+        verbs:
+          - get
+          - list
+          - watch
+  - kind: RoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      labels:
+        provider: codeready-toolchain
+      name: member-operator-console-plugin
+      namespace: ${NAMESPACE}
+    subjects:
+      - kind: ServiceAccount
+        name: member-operator-console-plugin
+    roleRef:
+      kind: Role
+      name: member-operator-console-plugin
+      apiGroup: rbac.authorization.k8s.io
+  - kind: Deployment
+    apiVersion: apps/v1
+    metadata:
+      labels:
+        provider: codeready-toolchain
+      name: member-operator-console-plugin
+      namespace: ${NAMESPACE}
+    spec:
+      replicas: ${{REPLICAS}}
+      selector:
+        matchLabels:
+          name: member-operator-console-plugin
+      template:
+        metadata:
+          labels:
+            name: member-operator-console-plugin
+            run: member-operator-console-plugin
+        spec:
+          serviceAccountName: member-operator-console-plugin
+          containers:
+            - name: member-operator-console-plugin
+              image: ${IMAGE}
+              ports:
+                - containerPort: 8080
+              command:
+                - member-operator-console-plugin
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /api/v1/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              readinessProbe:
+                failureThreshold: 30
+                httpGet:
+                  path: /api/v1/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                periodSeconds: 1
+                successThreshold: 1
+                timeoutSeconds: 1
+              startupProbe:
+                failureThreshold: 180
+                httpGet:
+                  path: /api/v1/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                periodSeconds: 1
+                successThreshold: 1
+                timeoutSeconds: 1
+              env:
+                - name: WATCH_NAMESPACE
+                  value: ${NAMESPACE}
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "10M"
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: member-operator-console-plugin
+      namespace: ${NAMESPACE}
+      labels:
+        provider: codeready-toolchain
+        run: member-operator-console-plugin
+    spec:
+      ports:
+        - name: "8080"
+          protocol: TCP
+          port: 80
+          targetPort: 8080
+      selector:
+        run: member-operator-console-plugin
+      type: ClusterIP
+      sessionAffinity: null
+parameters:
+  - name: NAMESPACE
+    value: 'toolchain-member-operator'
+  - name: IMAGE
+    value: quay.io/openshiftio/codeready-toolchain/member-operator-console-plugin:latest
+  - name: REPLICAS
+    value: '3'

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -4,6 +4,7 @@ IMAGE_TAG ?= ${GIT_COMMIT_ID_SHORT}
 IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}:${IMAGE_TAG}
 QUAY_USERNAME ?= ${QUAY_NAMESPACE}
 WEBHOOK_IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}-webhook:${IMAGE_TAG}
+CONSOLE_PLUGIN_IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}-console-plugin:${IMAGE_TAG}
 IMAGE_PLATFORM ?= linux/amd64
 
 .PHONY: docker-image
@@ -11,24 +12,28 @@ IMAGE_PLATFORM ?= linux/amd64
 docker-image: build
 	$(Q)docker build --platform ${IMAGE_PLATFORM} -f build/Dockerfile -t ${IMAGE} .
 	$(Q)docker build --platform ${IMAGE_PLATFORM} -f build/Dockerfile.webhook -t ${WEBHOOK_IMAGE} .
+	$(Q)docker build --platform ${IMAGE_PLATFORM} -f build/Dockerfile.consoleplugin -t ${CONSOLE_PLUGIN_IMAGE} .
 
 .PHONY: docker-push
 ## Push the binary image to quay.io registry
 docker-push: check-namespace docker-image
 	$(Q)docker push ${IMAGE}
 	$(Q)docker push ${WEBHOOK_IMAGE}
+	$(Q)docker push ${CONSOLE_PLUGIN_IMAGE}
 
 .PHONY: podman-image
 ## Build the binary image
 podman-image: build
 	$(Q)podman build --platform ${IMAGE_PLATFORM} -f build/Dockerfile -t ${IMAGE} .
 	$(Q)podman build --platform ${IMAGE_PLATFORM} -f build/Dockerfile.webhook -t ${WEBHOOK_IMAGE} .
+	$(Q)podman build --platform ${IMAGE_PLATFORM} -f build/Dockerfile.consoleplugin -t ${CONSOLE_PLUGIN_IMAGE} .
 
 .PHONY: podman-push
 ## Push the binary image to quay.io registry
 podman-push: check-namespace podman-image
 	$(Q)podman push ${IMAGE}
 	$(Q)podman push ${WEBHOOK_IMAGE}
+	$(Q)podman push ${CONSOLE_PLUGIN_IMAGE}
 
 .PHONY: check-namespace
 check-namespace:

--- a/make/go.mk
+++ b/make/go.mk
@@ -22,6 +22,11 @@ $(OUT_DIR)/operator:
 		-ldflags "-X ${GO_PACKAGE_PATH}/version.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/version.BuildTime=${BUILD_TIME}" \
 		-o $(OUT_DIR)/bin/member-operator-webhook \
 		cmd/webhook/main.go
+	$(Q)CGO_ENABLED=0 GOARCH=${goarch} GOOS=linux \
+		go build ${V_FLAG} \
+		-ldflags "-X ${GO_PACKAGE_PATH}/version.Commit=${GIT_COMMIT_ID} -X ${GO_PACKAGE_PATH}/version.BuildTime=${BUILD_TIME}" \
+		-o $(OUT_DIR)/bin/member-operator-console-plugin \
+		cmd/consoleplugin/main.go
 
 .PHONY: vendor
 vendor:
@@ -35,4 +40,7 @@ generate-assets: go-bindata
 	@echo "generating autoscaler buffer template data..."
 	@rm ./pkg/autoscaler/template_assets.go 2>/dev/null || true
 	@$(GO_BINDATA) -pkg autoscaler -o ./pkg/autoscaler/template_assets.go -nocompress -prefix deploy/autoscaler deploy/autoscaler
+	@echo "generating console plugin template data..."
+	@rm ./pkg/consoleplugin/deploy/template_assets.go 2>/dev/null || true
+	@$(GO_BINDATA) -pkg deploy -o ./pkg/consoleplugin/deploy/template_assets.go -nocompress -prefix deploy/consoleplugin deploy/consoleplugin
 

--- a/pkg/consoleplugin/deploy/deployment.go
+++ b/pkg/consoleplugin/deploy/deployment.go
@@ -1,0 +1,46 @@
+package deploy
+
+import (
+	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
+	"github.com/codeready-toolchain/toolchain-common/pkg/template"
+
+	tmplv1 "github.com/openshift/api/template/v1"
+	errs "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ConsolePlugin(cl runtimeclient.Client, s *runtime.Scheme, namespace, image string) error {
+	objs, err := getTemplateObjects(s, namespace, image)
+	if err != nil {
+		return errs.Wrap(err, "cannot deploy console plugin template")
+	}
+
+	applyClient := applycl.NewApplyClient(cl)
+	// create all objects that are within the template, and update only when the object has changed.
+	// if the object was either created or updated, then return and wait for another reconcile
+	for _, obj := range objs {
+		if _, err := applyClient.ApplyObject(obj); err != nil {
+			return errs.Wrap(err, "cannot deploy console plugin template")
+		}
+	}
+	return nil
+}
+
+func getTemplateObjects(s *runtime.Scheme, namespace, image string) ([]runtimeclient.Object, error) {
+	deployment, err := Asset("member-operator-console-plugin.yaml")
+	if err != nil {
+		return nil, err
+	}
+	decoder := serializer.NewCodecFactory(s).UniversalDeserializer()
+	deploymentTemplate := &tmplv1.Template{}
+	if _, _, err = decoder.Decode(deployment, nil, deploymentTemplate); err != nil {
+		return nil, err
+	}
+
+	return template.NewProcessor(s).Process(deploymentTemplate, map[string]string{
+		"NAMESPACE": namespace,
+		"IMAGE":     image,
+	})
+}

--- a/pkg/consoleplugin/deploy/deployment_test.go
+++ b/pkg/consoleplugin/deploy/deployment_test.go
@@ -1,0 +1,179 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	rbac "k8s.io/api/rbac/v1"
+
+	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	. "github.com/codeready-toolchain/member-operator/test"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	imgLoc = "quay.io/cool/member-operator-console-plugin:123"
+	saname = "member-operator-console-plugin"
+)
+
+func TestGetTemplateObjects(t *testing.T) {
+	// given
+	s := setScheme(t)
+
+	// when
+	objs, err := getTemplateObjects(s, test.MemberOperatorNs, imgLoc)
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, objs, 5)
+	contains(t, objs, service(test.MemberOperatorNs))
+	contains(t, objs, deployment(test.MemberOperatorNs, saname, imgLoc))
+	contains(t, objs, serviceAccount(test.MemberOperatorNs))
+	contains(t, objs, role())
+	contains(t, objs, roleBinding(test.MemberOperatorNs))
+}
+
+func TestDeploy(t *testing.T) {
+	// given
+	s := setScheme(t)
+	t.Run("when created", func(t *testing.T) {
+		// given
+		fakeClient := test.NewFakeClient(t)
+
+		// when
+		err := ConsolePlugin(fakeClient, s, test.MemberOperatorNs, imgLoc)
+
+		// then
+		require.NoError(t, err)
+		verifyDeployment(t, fakeClient)
+	})
+
+	t.Run("when updated", func(t *testing.T) {
+		// given
+		serviceObj := &v1.Service{}
+		unmarshalObj(t, service(test.MemberOperatorNs), serviceObj)
+		serviceObj.Spec.Ports[0].Port = 8080
+		serviceObj.Spec.Selector = nil
+
+		deploymentObj := &appsv1.Deployment{}
+		unmarshalObj(t, deployment(test.MemberOperatorNs, saname, "quay.io/some/cool:unknown"), deploymentObj)
+		deploymentObj.Spec.Template.Spec.Containers[0].Command = []string{"./some-dummy"}
+		deploymentObj.Spec.Template.Spec.Containers[0].VolumeDevices = nil
+
+		fakeClient := test.NewFakeClient(t, serviceObj, deploymentObj)
+
+		// when
+		err := ConsolePlugin(fakeClient, s, test.MemberOperatorNs, imgLoc)
+
+		// then
+		require.NoError(t, err)
+		verifyDeployment(t, fakeClient)
+	})
+
+	t.Run("when creation fails", func(t *testing.T) {
+		// given
+		fakeClient := test.NewFakeClient(t)
+		fakeClient.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		err := ConsolePlugin(fakeClient, s, test.MemberOperatorNs, imgLoc)
+
+		// then
+		require.Error(t, err)
+	})
+}
+
+func verifyDeployment(t *testing.T, fakeClient *test.FakeClient) {
+	expService := &v1.Service{}
+	unmarshalObj(t, service(test.MemberOperatorNs), expService)
+	actualService := &v1.Service{}
+	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-console-plugin", actualService, func() {
+		assert.Equal(t, expService.Labels, actualService.Labels)
+		assert.Equal(t, expService.Spec, actualService.Spec)
+	})
+
+	expServiceAcc := &v1.ServiceAccount{}
+	unmarshalObj(t, serviceAccount(test.MemberOperatorNs), expServiceAcc)
+	actualServiceAcc := &v1.ServiceAccount{}
+	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-console-plugin", actualServiceAcc, func() {
+		assert.Equal(t, expServiceAcc.Namespace, actualServiceAcc.Namespace)
+	})
+
+	expRole := &rbac.Role{}
+	unmarshalObj(t, role(), expRole)
+	actualRole := &rbac.Role{}
+	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-console-plugin", actualRole, func() {
+		assert.Equal(t, expRole.Rules, actualRole.Rules)
+	})
+
+	expRb := &rbac.RoleBinding{}
+	unmarshalObj(t, roleBinding(test.MemberOperatorNs), expRb)
+	actualRb := &rbac.RoleBinding{}
+	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-console-plugin", actualRb, func() {
+		assert.Equal(t, expRb.Subjects, actualRb.Subjects)
+		assert.Equal(t, expRb.RoleRef, actualRb.RoleRef)
+	})
+
+	expDeployment := &appsv1.Deployment{}
+	unmarshalObj(t, deployment(test.MemberOperatorNs, saname, imgLoc), expDeployment)
+	actualDeployment := &appsv1.Deployment{}
+	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-console-plugin", actualDeployment, func() {
+		assert.Equal(t, expDeployment.Labels, actualDeployment.Labels)
+		assert.Equal(t, expDeployment.Spec, actualDeployment.Spec)
+	})
+}
+
+func setScheme(t *testing.T) *runtime.Scheme {
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	return s
+}
+
+func contains(t *testing.T, objects []runtimeclient.Object, expected string) {
+	strObjects := make([]string, len(objects))
+	for i, obj := range objects {
+		str, err := json.Marshal(obj)
+		require.NoError(t, err)
+		strObjects[i] = string(str)
+	}
+
+	assert.Contains(t, strObjects, expected, "console plugin template doesn't contain expected object")
+}
+
+func unmarshalObj(t *testing.T, content string, target runtime.Object) {
+	err := json.Unmarshal([]byte(content), target)
+	require.NoError(t, err)
+}
+
+func service(namespace string) string {
+	return fmt.Sprintf(`{"apiVersion":"v1","kind":"Service","metadata":{"labels":{"provider":"codeready-toolchain","run":"member-operator-console-plugin"},"name":"member-operator-console-plugin","namespace":"%s"},"spec":{"ports":[{"name":"8080","port":80,"protocol":"TCP","targetPort":8080}],"selector":{"run":"member-operator-console-plugin"},"sessionAffinity":null,"type":"ClusterIP"}}`, namespace)
+}
+
+func deployment(namespace, sa string, image string) string {
+	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"},"spec":{"replicas":3,"selector":{"matchLabels":{"name":"member-operator-console-plugin"}},"template":{"metadata":{"labels":{"name":"member-operator-console-plugin","run":"member-operator-console-plugin"}},"spec":{"containers":[{"command":["member-operator-console-plugin"],"env":[{"name":"WATCH_NAMESPACE","value":"toolchain-member-operator"}],"image":"%s","imagePullPolicy":"IfNotPresent","livenessProbe":{"failureThreshold":3,"httpGet":{"path":"/api/v1/health","port":8080,"scheme":"HTTP"},"initialDelaySeconds":1,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1},"name":"member-operator-console-plugin","ports":[{"containerPort":8080}],"readinessProbe":{"failureThreshold":30,"httpGet":{"path":"/api/v1/health","port":8080,"scheme":"HTTP"},"initialDelaySeconds":1,"periodSeconds":1,"successThreshold":1,"timeoutSeconds":1},"resources":{"requests":{"cpu":"50m","memory":"10M"}},"startupProbe":{"failureThreshold":180,"httpGet":{"path":"/api/v1/health","port":8080,"scheme":"HTTP"},"initialDelaySeconds":1,"periodSeconds":1,"successThreshold":1,"timeoutSeconds":1}}],"serviceAccountName":"%s"}}}}`, namespace, image, sa)
+}
+
+func serviceAccount(namespace string) string {
+	return fmt.Sprintf(`{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"}}`, namespace)
+}
+
+func role() string {
+	return `{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"toolchain-member-operator"},"rules":[{"apiGroups":["toolchain.dev.openshift.com"],"resources":["memberoperatorconfigs"],"verbs":["get","list","watch"]}]}`
+}
+
+func roleBinding(namespace string) string {
+	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"member-operator-console-plugin"},"subjects":[{"kind":"ServiceAccount","name":"member-operator-console-plugin"}]}`, namespace)
+}


### PR DESCRIPTION
This PR introduces an empty service which will be used to return Web Console Plugins, such as pendo.

This PR:
- Adds all needed wiring to make target to build an image for the service
- Adds all service manifests
- Adds a new package and a function to deploy the service

Next steps:
- Add Console Plugin specific configuration to MemberOperatorConfig:
  - Deploy the service: true/false
  - Pendo key
- Implement the health endpoint in the service
- Start deploying the service in the member operator config controller. Similar to https://github.com/codeready-toolchain/member-operator/blob/master/controllers/memberoperatorconfig/memberoperatorconfig_controller.go#L91
- Implement the endpoint which will return the plugin JS.