### PR TITLE
use complete provider label key in plugin manifests

### DIFF
--- a/deploy/consoleplugin/member-operator-console-plugin.yaml
+++ b/deploy/consoleplugin/member-operator-console-plugin.yaml
@@ -7,14 +7,14 @@ objects:
   kind: ServiceAccount
   metadata:
     labels:
-      provider: codeready-toolchain
+      toolchain.dev.openshift.com/provider: codeready-toolchain
     name: member-operator-console-plugin
     namespace: ${NAMESPACE}
 - kind: Role
   apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     labels:
-      provider: codeready-toolchain
+      toolchain.dev.openshift.com/provider: codeready-toolchain
     name: member-operator-console-plugin
     namespace: ${NAMESPACE}
   rules:
@@ -38,7 +38,7 @@ objects:
   apiVersion: rbac.authorization.k8s.io/v1
   metadata:
     labels:
-      provider: codeready-toolchain
+      toolchain.dev.openshift.com/provider: codeready-toolchain
     name: member-operator-console-plugin
     namespace: ${NAMESPACE}
   subjects:
@@ -52,7 +52,7 @@ objects:
   apiVersion: apps/v1
   metadata:
     labels:
-      provider: codeready-toolchain
+      toolchain.dev.openshift.com/provider: codeready-toolchain
     name: member-operator-console-plugin
     namespace: ${NAMESPACE}
   spec:
@@ -128,7 +128,7 @@ objects:
     annotations:
       service.beta.openshift.io/serving-cert-secret-name: member-operator-console-plugin
     labels:
-      provider: codeready-toolchain
+      toolchain.dev.openshift.com/provider: codeready-toolchain
       run: member-operator-console-plugin
   spec:
     ports:

--- a/pkg/consoleplugin/deploy/deployment_test.go
+++ b/pkg/consoleplugin/deploy/deployment_test.go
@@ -159,22 +159,22 @@ func unmarshalObj(t *testing.T, content string, target runtime.Object) {
 
 // contains an empty spec because we do not verify the actual spec value
 func service(namespace string) string {
-	return fmt.Sprintf(`{"apiVersion":"v1","kind":"Service","metadata":{"labels":{"provider":"codeready-toolchain","run":"member-operator-console-plugin"},"name":"member-operator-console-plugin","namespace":"%s"},"spec":{}}`, namespace)
+	return fmt.Sprintf(`{"apiVersion":"v1","kind":"Service","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain","run":"member-operator-console-plugin"},"name":"member-operator-console-plugin","namespace":"%s"},"spec":{}}`, namespace)
 }
 
 // contains an empty spec because we do not verify the actual spec value
 func deployment(namespace string) string {
-	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"},"spec":{}}`, namespace)
+	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"},"spec":{}}`, namespace)
 }
 
 func serviceAccount(namespace string) string {
-	return fmt.Sprintf(`{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"}}`, namespace)
+	return fmt.Sprintf(`{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"}}`, namespace)
 }
 
 func role() string {
-	return `{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"toolchain-member-operator"},"rules":[{"apiGroups":["toolchain.dev.openshift.com"],"resources":["memberoperatorconfigs"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["secrets"],"verbs":["get","list","watch"]}]}`
+	return `{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"toolchain-member-operator"},"rules":[{"apiGroups":["toolchain.dev.openshift.com"],"resources":["memberoperatorconfigs"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["secrets"],"verbs":["get","list","watch"]}]}`
 }
 
 func roleBinding(namespace string) string {
-	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"member-operator-console-plugin"},"subjects":[{"kind":"ServiceAccount","name":"member-operator-console-plugin"}]}`, namespace)
+	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain"},"name":"member-operator-console-plugin","namespace":"%s"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"member-operator-console-plugin"},"subjects":[{"kind":"ServiceAccount","name":"member-operator-console-plugin"}]}`, namespace)
 }


### PR DESCRIPTION
paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/710