### PR TITLE
refactor: use 'runtimeclient'

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/scale"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -28,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -47,9 +48,9 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler reconciles an Idler object
 type Reconciler struct {
-	Client              client.Client
+	Client              runtimeclient.Client
 	Scheme              *runtime.Scheme
-	AllNamespacesClient client.Client
+	AllNamespacesClient runtimeclient.Client
 	ScalesClient        scale.ScalesGetter
 	GetHostCluster      cluster.GetHostClusterFunc
 	Namespace           string

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
@@ -32,7 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	fakescale "k8s.io/client-go/scale/fake"
 	clienttest "k8s.io/client-go/testing"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -1004,7 +1005,7 @@ func createPods(t *testing.T, r *Reconciler, owner metav1.Object, startTime meta
 	return podsToTrack
 }
 
-func prepareReconcile(t *testing.T, name string, getHostClusterFunc func(fakeClient client.Client) cluster.GetHostClusterFunc, initIdlerObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient, *test.FakeClient) {
+func prepareReconcile(t *testing.T, name string, getHostClusterFunc func(fakeClient runtimeclient.Client) cluster.GetHostClusterFunc, initIdlerObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient, *test.FakeClient) {
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
@@ -1090,7 +1091,7 @@ func prepareReconcileWithPodsRunningTooLong(t *testing.T, idler toolchainv1alpha
 	return reconciler, req, cl, allCl
 }
 
-func getHostCluster(fakeClient client.Client) cluster.GetHostClusterFunc {
+func getHostCluster(fakeClient runtimeclient.Client) cluster.GetHostClusterFunc {
 	return memberoperatortest.NewGetHostCluster(fakeClient, true, corev1.ConditionTrue)
 }
 

--- a/controllers/memberoperatorconfig/configuration.go
+++ b/controllers/memberoperatorconfig/configuration.go
@@ -8,7 +8,7 @@ import (
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -26,7 +26,7 @@ type Configuration struct {
 
 // GetConfiguration returns a Configuration using the cache, or if the cache was not initialized
 // then retrieves the latest config using the provided client and updates the cache
-func GetConfiguration(cl client.Client) (Configuration, error) {
+func GetConfiguration(cl runtimeclient.Client) (Configuration, error) {
 	config, secrets, err := commonconfig.GetConfig(cl, &toolchainv1alpha1.MemberOperatorConfig{})
 	if err != nil {
 		// return default config
@@ -43,7 +43,7 @@ func GetCachedConfiguration() Configuration {
 }
 
 // ForceLoadConfiguration updates the cache using the provided client and returns the latest Configuration
-func ForceLoadConfiguration(cl client.Client) (Configuration, error) {
+func ForceLoadConfiguration(cl runtimeclient.Client) (Configuration, error) {
 	config, secrets, err := commonconfig.LoadLatest(cl, &toolchainv1alpha1.MemberOperatorConfig{})
 	if err != nil {
 		// return default config

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
@@ -2,21 +2,20 @@ package memberoperatorconfig
 
 import (
 	"context"
-	consoledeploy "github.com/codeready-toolchain/member-operator/pkg/consoleplugin/deploy"
 	"os"
-
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/autoscaler"
+	consoledeploy "github.com/codeready-toolchain/member-operator/pkg/consoleplugin/deploy"
 	"github.com/codeready-toolchain/member-operator/pkg/webhook/deploy"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -35,7 +34,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler reconciles a MemberOperatorConfig object
 type Reconciler struct {
-	Client client.Client
+	Client runtimeclient.Client
 	Log    logr.Logger
 }
 

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -325,7 +326,7 @@ func TestHandleWebConsolePluginDeploy(t *testing.T) {
 	})
 }
 
-func prepareReconcile(t *testing.T, initObjs ...runtime.Object) (*Reconciler, client.Client) {
+func prepareReconcile(t *testing.T, initObjs ...runtime.Object) (*Reconciler, runtimeclient.Client) {
 	os.Setenv("WATCH_NAMESPACE", test.MemberOperatorNs)
 	restore := test.SetEnvVarAndRestore(t, "MEMBER_OPERATOR_WEBHOOK_IMAGE", "webhookimage")
 	t.Cleanup(restore)

--- a/controllers/memberstatus/creation.go
+++ b/controllers/memberstatus/creation.go
@@ -5,11 +5,11 @@ import (
 	commonclient "github.com/codeready-toolchain/toolchain-common/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateOrUpdateResources creates a memberstatus resource with the given name in the given namespace
-func CreateOrUpdateResources(client client.Client, namespace, memberStatusName string) error {
+func CreateOrUpdateResources(client runtimeclient.Client, namespace, memberStatusName string) error {
 	memberStatus := &toolchainv1alpha1.MemberStatus{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,

--- a/controllers/memberstatus/creation_test.go
+++ b/controllers/memberstatus/creation_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/codeready-toolchain/member-operator/test"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestCreateOrUpdateResources(t *testing.T) {

--- a/controllers/memberstatus/memberstatus_controller.go
+++ b/controllers/memberstatus/memberstatus_controller.go
@@ -12,8 +12,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
@@ -26,7 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	metrics "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -56,10 +56,10 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler reconciles a MemberStatus object
 type Reconciler struct {
-	Client              client.Client
+	Client              runtimeclient.Client
 	Scheme              *runtime.Scheme
 	GetHostCluster      func() (*cluster.CachedToolchainCluster, bool)
-	AllNamespacesClient client.Client
+	AllNamespacesClient runtimeclient.Client
 	CheClient           *che.Client
 }
 

--- a/controllers/memberstatus/memberstatus_controller_test.go
+++ b/controllers/memberstatus/memberstatus_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -715,26 +716,26 @@ func newMemberDeploymentWithConditions(deploymentConditions ...appsv1.Deployment
 	}
 }
 
-func newGetHostClusterReady(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterReady(fakeClient runtimeclient.Client) cluster.GetHostClusterFunc {
 	return NewGetHostClusterWithProbe(fakeClient, true, corev1.ConditionTrue, metav1.Now())
 }
 
-func newGetHostClusterNotReady(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterNotReady(fakeClient runtimeclient.Client) cluster.GetHostClusterFunc {
 	return NewGetHostClusterWithProbe(fakeClient, true, corev1.ConditionFalse, metav1.Now())
 }
 
-func newGetHostClusterProbeNotWorking(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterProbeNotWorking(fakeClient runtimeclient.Client) cluster.GetHostClusterFunc {
 	aMinuteAgo := metav1.Time{
 		Time: time.Now().Add(time.Duration(-60 * time.Second)),
 	}
 	return NewGetHostClusterWithProbe(fakeClient, true, corev1.ConditionTrue, aMinuteAgo)
 }
 
-func newGetHostClusterNotExist(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterNotExist(fakeClient runtimeclient.Client) cluster.GetHostClusterFunc {
 	return NewGetHostClusterWithProbe(fakeClient, false, corev1.ConditionFalse, metav1.Now())
 }
 
-func prepareReconcile(t *testing.T, requestName string, getHostClusterFunc func(fakeClient client.Client) cluster.GetHostClusterFunc, allNamespacesClient *test.FakeClient, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
+func prepareReconcile(t *testing.T, requestName string, getHostClusterFunc func(fakeClient runtimeclient.Client) cluster.GetHostClusterFunc, allNamespacesClient *test.FakeClient, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	os.Setenv("WATCH_NAMESPACE", test.MemberOperatorNs)
 	fakeClient := test.NewFakeClient(t, initObjs...)
@@ -850,7 +851,7 @@ func cheRoute(tls bool) *routev1.Route {
 	return r
 }
 
-func cheTestClient(cl client.Client) *che.Client {
+func cheTestClient(cl runtimeclient.Client) *che.Client {
 	tokenCache := che.NewTokenCacheWithToken(
 		http.DefaultClient,
 		&che.TokenSet{

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -50,7 +51,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler reconciles a UserAccount object
 type Reconciler struct {
-	Client    client.Client
+	Client    runtimeclient.Client
 	Scheme    *runtime.Scheme
 	CheClient *che.Client
 }
@@ -418,7 +419,7 @@ func setLabelsAndAnnotations(object metav1.Object, userAcc *toolchainv1alpha1.Us
 	return changed
 }
 
-func addLabelsAndAnnotations(object client.Object, cl client.Client, userAcc *toolchainv1alpha1.UserAccount, isUserResource bool) error {
+func addLabelsAndAnnotations(object client.Object, cl runtimeclient.Client, userAcc *toolchainv1alpha1.UserAccount, isUserResource bool) error {
 	if setLabelsAndAnnotations(object, userAcc, isUserResource) {
 		return cl.Update(context.TODO(), object)
 	}
@@ -695,7 +696,7 @@ func listByOwnerLabel(owner string) client.ListOption {
 }
 
 // getUsersByOwnerName gets the user resources by matching owner label.
-func getUsersByOwnerName(cl client.Client, owner string) ([]userv1.User, error) {
+func getUsersByOwnerName(cl runtimeclient.Client, owner string) ([]userv1.User, error) {
 	userList := &userv1.UserList{}
 	labels := map[string]string{toolchainv1alpha1.OwnerLabelKey: owner}
 	err := cl.List(context.TODO(), userList, client.MatchingLabels(labels))

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	runtimecluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -302,7 +303,7 @@ func main() {
 // This client should be used only for resources and kinds that are retrieved from other namespaces than the watched one.
 // This will help keeping a reasonable memory usage for this operator since the cache won't store all other namespace scoped
 // resources (secrets, etc.).
-func newAllNamespacesClient(config *rest.Config) (client.Client, cache.Cache, error) {
+func newAllNamespacesClient(config *rest.Config) (runtimeclient.Client, cache.Cache, error) {
 	clusterAllNamespaces, err := runtimecluster.New(config, func(clusterOptions *runtimecluster.Options) {
 		clusterOptions.Scheme = scheme
 	})

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,7 +35,7 @@ func Deploy(cl runtimeclient.Client, s *runtime.Scheme, namespace, requestsMemor
 
 // Delete deletes the autoscaling buffer app if it's deployed. Does nothing if it's not.
 // Returns true if the app was deleted.
-func Delete(cl client.Client, s *runtime.Scheme, namespace string) (bool, error) {
+func Delete(cl runtimeclient.Client, s *runtime.Scheme, namespace string) (bool, error) {
 	objs, err := getTemplateObjects(s, namespace, "0", 0)
 	if err != nil {
 		return false, err

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	. "github.com/codeready-toolchain/member-operator/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestGetTemplateObjects(t *testing.T) {
@@ -90,7 +90,7 @@ func TestDelete(t *testing.T) {
 	s := setScheme(t)
 	prioClass := unmarshalPriorityClass(t, priorityClass())
 	dm := unmarshalDeployment(t, deployment("100Mi", 3))
-	namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: test.MemberOperatorNs}}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: test.MemberOperatorNs}}
 
 	t.Run("when previously deployed", func(t *testing.T) {
 		// given

--- a/pkg/cert/secret.go
+++ b/pkg/cert/secret.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -28,7 +28,7 @@ const (
 	Expiration = 365 * 24 * time.Hour
 )
 
-func EnsureSecret(cl client.Client, namespace, certSecretName, serviceName string, expiration time.Duration) ([]byte, error) {
+func EnsureSecret(cl runtimeclient.Client, namespace, certSecretName, serviceName string, expiration time.Duration) ([]byte, error) {
 	certSecret := &corev1.Secret{}
 	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: certSecretName}, certSecret); err != nil && !errors.IsNotFound(err) {
 		return nil, err

--- a/pkg/cert/secret_test.go
+++ b/pkg/cert/secret_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,7 +51,7 @@ func TestEnsureCertSecret(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.NotEmpty(t, caCert)
-		actualSecret := &v1.Secret{}
+		actualSecret := &corev1.Secret{}
 		AssertObject(t, fakeClient, test.MemberOperatorNs, "service-certs", actualSecret, func() {
 			assert.NotEmpty(t, actualSecret.Data[ServerKey])
 			assert.NotEmpty(t, actualSecret.Data[ServerCert])
@@ -61,7 +61,7 @@ func TestEnsureCertSecret(t *testing.T) {
 
 	t.Run("when secret already exists with wrong values", func(t *testing.T) {
 		// given
-		secret := &v1.Secret{
+		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: test.MemberOperatorNs,
 				Name:      "service-certs",
@@ -79,7 +79,7 @@ func TestEnsureCertSecret(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.NotEqual(t, "ca-cert-data", string(caCert))
-		actualSecret := &v1.Secret{}
+		actualSecret := &corev1.Secret{}
 		AssertObject(t, fakeClient, test.MemberOperatorNs, "service-certs", actualSecret, func() {
 			assert.NotEmpty(t, actualSecret.Data[ServerKey])
 			assert.NotEmpty(t, actualSecret.Data[ServerCert])
@@ -105,7 +105,7 @@ func TestEnsureCertSecret(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.NotEqual(t, secret.Data[CACert], caCert)
-		actualSecret := &v1.Secret{}
+		actualSecret := &corev1.Secret{}
 		AssertObject(t, fakeClient, test.MemberOperatorNs, "service-certs", actualSecret, func() {
 			assert.NotEmpty(t, actualSecret.Data[ServerKey])
 			assert.NotEmpty(t, actualSecret.Data[ServerCert])
@@ -129,7 +129,7 @@ func TestEnsureCertSecret(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, secret.Data[CACert], caCert)
-		actualSecret := &v1.Secret{}
+		actualSecret := &corev1.Secret{}
 		AssertObject(t, fakeClient, test.MemberOperatorNs, "service-certs", actualSecret, func() {
 			assert.Equal(t, secret.Data[ServerKey], actualSecret.Data[ServerKey])
 			assert.Equal(t, secret.Data[ServerCert], actualSecret.Data[ServerCert])
@@ -152,7 +152,7 @@ func TestEnsureCertSecret(t *testing.T) {
 		fakeClient.MockGet = nil
 		require.Error(t, err)
 		assert.Empty(t, caCert)
-		actualSecret := &v1.Secret{}
+		actualSecret := &corev1.Secret{}
 		AssertObjectNotFound(t, fakeClient, test.MemberOperatorNs, "service-certs", actualSecret)
 	})
 
@@ -169,7 +169,7 @@ func TestEnsureCertSecret(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.Empty(t, caCert)
-		actualSecret := &v1.Secret{}
+		actualSecret := &corev1.Secret{}
 		AssertObjectNotFound(t, fakeClient, test.MemberOperatorNs, "service-certs", actualSecret)
 	})
 }

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -17,7 +17,7 @@ import (
 	"github.com/codeready-toolchain/member-operator/pkg/utils/route"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -34,19 +34,19 @@ var DefaultClient *Client
 // Client is a client for interacting with Che services
 type Client struct {
 	httpClient *http.Client
-	k8sClient  client.Client
+	k8sClient  runtimeclient.Client
 	tokenCache *TokenCache
 }
 
 // InitDefaultCheClient initializes the default Che client instance
-func InitDefaultCheClient(cl client.Client) {
+func InitDefaultCheClient(cl runtimeclient.Client) {
 	defaultHTTPClient := newHTTPClient()
 	tc := NewTokenCache(defaultHTTPClient)
 	DefaultClient = NewCheClient(defaultHTTPClient, cl, tc)
 }
 
 // NewCheClient creates a new instance of a Che client
-func NewCheClient(httpCl *http.Client, cl client.Client, tc *TokenCache) *Client {
+func NewCheClient(httpCl *http.Client, cl runtimeclient.Client, tc *TokenCache) *Client {
 	return &Client{
 		httpClient: httpCl,
 		k8sClient:  cl,

--- a/pkg/che/che_test.go
+++ b/pkg/che/che_test.go
@@ -16,7 +16,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -634,8 +634,8 @@ func cheRoute(tls bool) *routev1.Route { //nolint: unparam
 	return r
 }
 
-func newTestSecret() *v1.Secret {
-	return &v1.Secret{
+func newTestSecret() *corev1.Secret {
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: test.MemberOperatorNs,

--- a/pkg/che/tokencache.go
+++ b/pkg/che/tokencache.go
@@ -16,9 +16,9 @@ import (
 	membercfg "github.com/codeready-toolchain/member-operator/controllers/memberoperatorconfig"
 	"github.com/codeready-toolchain/member-operator/pkg/utils/rest"
 	"github.com/codeready-toolchain/member-operator/pkg/utils/route"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/pkg/errors"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const tokenPath = "auth/realms/codeready/protocol/openid-connect/token" //nolint: gosec
@@ -44,7 +44,7 @@ func NewTokenCacheWithToken(cl *http.Client, t *TokenSet) *TokenCache {
 }
 
 // getToken returns the token needed to use Che user APIs, or an error if there was a problem getting the token
-func (tc *TokenCache) getToken(cl client.Client, cfg membercfg.Configuration) (TokenSet, error) {
+func (tc *TokenCache) getToken(cl runtimeclient.Client, cfg membercfg.Configuration) (TokenSet, error) {
 	tc.RLock()
 	// use the cached credentials if they are still valid
 	if !tokenExpired(tc.token) {
@@ -59,7 +59,7 @@ func (tc *TokenCache) getToken(cl client.Client, cfg membercfg.Configuration) (T
 }
 
 // obtainAndCacheNewToken obtains an access token, updates the cache and returns the token. Returns an error if there was a failure at any point
-func (tc *TokenCache) obtainAndCacheNewToken(cl client.Client, cfg membercfg.Configuration) (TokenSet, error) {
+func (tc *TokenCache) obtainAndCacheNewToken(cl runtimeclient.Client, cfg membercfg.Configuration) (TokenSet, error) {
 	defer tc.Unlock()
 	tc.Lock()
 

--- a/pkg/che/tokencache_test.go
+++ b/pkg/che/tokencache_test.go
@@ -10,19 +10,17 @@ import (
 	membercfg "github.com/codeready-toolchain/member-operator/controllers/memberoperatorconfig"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
-	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
-
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -31,7 +29,7 @@ const (
 	testKeycloakURL = "https://keycloak-codeready-workspaces-operator.member-cluster"
 )
 
-func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (client.Client, membercfg.Configuration) {
+func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (runtimeclient.Client, membercfg.Configuration) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	os.Setenv("WATCH_NAMESPACE", test.MemberOperatorNs)
 
@@ -48,7 +46,7 @@ func prepareClientAndConfig(t *testing.T, initObjs ...runtime.Object) (client.Cl
 
 func TestGetToken(t *testing.T) {
 	// given
-	testSecret := &v1.Secret{
+	testSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: test.MemberOperatorNs,

--- a/pkg/consoleplugin/deploy/deployment_test.go
+++ b/pkg/consoleplugin/deploy/deployment_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +57,7 @@ func TestDeploy(t *testing.T) {
 
 	t.Run("when updated", func(t *testing.T) {
 		// given
-		serviceObj := &v1.Service{}
+		serviceObj := &corev1.Service{}
 		unmarshalObj(t, service(test.MemberOperatorNs), serviceObj)
 		serviceObj.Labels = map[string]string{
 			"provider": "foo",
@@ -95,17 +95,17 @@ func TestDeploy(t *testing.T) {
 }
 
 func verifyDeployment(t *testing.T, fakeClient *test.FakeClient) {
-	expService := &v1.Service{}
+	expService := &corev1.Service{}
 	unmarshalObj(t, service(test.MemberOperatorNs), expService)
-	actualService := &v1.Service{}
+	actualService := &corev1.Service{}
 	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-console-plugin", actualService, func() {
 		assert.Equal(t, expService.Labels, actualService.Labels)
 		assert.NotEmpty(t, actualService.Spec)
 	})
 
-	expServiceAcc := &v1.ServiceAccount{}
+	expServiceAcc := &corev1.ServiceAccount{}
 	unmarshalObj(t, serviceAccount(test.MemberOperatorNs), expServiceAcc)
-	actualServiceAcc := &v1.ServiceAccount{}
+	actualServiceAcc := &corev1.ServiceAccount{}
 	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-console-plugin", actualServiceAcc, func() {
 		assert.Equal(t, expServiceAcc.Namespace, actualServiceAcc.Namespace)
 	})

--- a/pkg/utils/route/route.go
+++ b/pkg/utils/route/route.go
@@ -7,11 +7,11 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetRouteURL gets the URL of the route with the given name and namespace using the given client
-func GetRouteURL(cl client.Client, namespace, name string) (string, error) {
+func GetRouteURL(cl runtimeclient.Client, namespace, name string) (string, error) {
 	route := &routev1.Route{}
 	namespacedName := types.NamespacedName{Namespace: namespace, Name: name}
 	err := cl.Get(context.TODO(), namespacedName, route)

--- a/pkg/webhook/deploy/deployment.go
+++ b/pkg/webhook/deploy/deployment.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"encoding/base64"
+
 	"github.com/codeready-toolchain/member-operator/pkg/cert"
 	"github.com/codeready-toolchain/member-operator/pkg/webhook/deploy/userspodswebhook"
 	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"

--- a/pkg/webhook/deploy/deployment_test.go
+++ b/pkg/webhook/deploy/deployment_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,7 +73,7 @@ func TestDeployWebhook(t *testing.T) {
 		prioClass.Labels = map[string]string{}
 		prioClass.Value = 10
 
-		serviceObj := &v1.Service{}
+		serviceObj := &corev1.Service{}
 		unmarshalObj(t, service(test.MemberOperatorNs), serviceObj)
 		serviceObj.Spec.Ports[0].Port = 8080
 		serviceObj.Spec.Selector = nil
@@ -123,17 +123,17 @@ func verifyWebhookDeployment(t *testing.T, fakeClient *test.FakeClient) {
 		assert.Equal(t, expPrioClass.Description, actualPrioClass.Description)
 	})
 
-	expService := &v1.Service{}
+	expService := &corev1.Service{}
 	unmarshalObj(t, service(test.MemberOperatorNs), expService)
-	actualService := &v1.Service{}
+	actualService := &corev1.Service{}
 	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-webhook", actualService, func() {
 		assert.Equal(t, expService.Labels, actualService.Labels)
 		assert.Equal(t, expService.Spec, actualService.Spec)
 	})
 
-	expServiceAcc := &v1.ServiceAccount{}
+	expServiceAcc := &corev1.ServiceAccount{}
 	unmarshalObj(t, serviceAccount(test.MemberOperatorNs), expServiceAcc)
-	actualServiceAcc := &v1.ServiceAccount{}
+	actualServiceAcc := &corev1.ServiceAccount{}
 	AssertObject(t, fakeClient, test.MemberOperatorNs, "member-operator-webhook-sa", actualServiceAcc, func() {
 		assert.Equal(t, expServiceAcc.Namespace, actualServiceAcc.Namespace)
 	})
@@ -161,7 +161,7 @@ func verifyWebhookDeployment(t *testing.T, fakeClient *test.FakeClient) {
 		assert.Equal(t, expDeployment.Spec, actualDeployment.Spec)
 	})
 
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err := fakeClient.Get(context.TODO(), test.NamespacedName(test.MemberOperatorNs, "webhook-certs"), secret)
 	require.NoError(t, err)
 

--- a/pkg/webhook/mutatingwebhook/mutate.go
+++ b/pkg/webhook/mutatingwebhook/mutate.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/admission/v1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,7 +76,7 @@ func HandleMutate(w http.ResponseWriter, r *http.Request) {
 }
 
 func mutate(body []byte) []byte {
-	admReview := v1.AdmissionReview{}
+	admReview := admissionv1.AdmissionReview{}
 	if _, _, err := deserializer.Decode(body, nil, &admReview); err != nil {
 		log.Error(err, "unable to deserialize the admission review object", "body", string(body))
 		admReview.Response = responseWithError(err)
@@ -90,15 +90,15 @@ func mutate(body []byte) []byte {
 	return responseBody
 }
 
-func responseWithError(err error) *v1.AdmissionResponse {
-	return &v1.AdmissionResponse{
+func responseWithError(err error) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
 		Result: &metav1.Status{
 			Message: err.Error(),
 		},
 	}
 }
 
-func createAdmissionReviewResponse(admReview v1.AdmissionReview) *v1.AdmissionResponse {
+func createAdmissionReviewResponse(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	if admReview.Request == nil {
 		err := fmt.Errorf("admission review request is nil")
 		log.Error(err, "cannot read the admission review request", "AdmissionReview", admReview)
@@ -112,8 +112,8 @@ func createAdmissionReviewResponse(admReview v1.AdmissionReview) *v1.AdmissionRe
 		return responseWithError(errors.Wrapf(err, "unable unmarshal pod json object - raw request object: %v", admReview.Request.Object.Raw))
 	}
 
-	patchType := v1.PatchTypeJSONPatch
-	resp := &v1.AdmissionResponse{
+	patchType := admissionv1.PatchTypeJSONPatch
+	resp := &admissionv1.AdmissionResponse{
 		Allowed:   true,
 		UID:       admReview.Request.UID,
 		PatchType: &patchType,

--- a/pkg/webhook/validatingwebhook/validate_checluster_request.go
+++ b/pkg/webhook/validatingwebhook/validate_checluster_request.go
@@ -13,11 +13,11 @@ import (
 	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/types"
-	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type CheClusterRequestValidator struct {
-	Client runtimeClient.Client
+	Client runtimeclient.Client
 }
 
 func (v CheClusterRequestValidator) HandleValidate(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webhook/validatingwebhook/validate_rolebinding_request.go
+++ b/pkg/webhook/validatingwebhook/validate_rolebinding_request.go
@@ -15,11 +15,11 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
-	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type RoleBindingRequestValidator struct {
-	Client runtimeClient.Client
+	Client runtimeclient.Client
 }
 
 func (v RoleBindingRequestValidator) HandleValidate(w http.ResponseWriter, r *http.Request) {

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -5,16 +5,15 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.CachedToolchainCluster
 // that is returned by the function then contains the given client and the given status.
 // If ok == false, then the function returns nil for the cluster.
-func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) cluster.GetHostClusterFunc {
+func NewGetHostCluster(cl runtimeclient.Client, ok bool, status corev1.ConditionStatus) cluster.GetHostClusterFunc {
 	if !ok {
 		return func() (*cluster.CachedToolchainCluster, bool) {
 			return nil, false
@@ -42,7 +41,7 @@ func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) clu
 // NewGetHostClusterWithProbe returns a cluster.GetHostClusterFunc function which returns a cluster.CachedToolchainCluster.
 // The returned cluster.CachedToolchainCluster contains the given client and the given status and lastProbeTime.
 // If ok == false, then the function returns nil for the cluster.
-func NewGetHostClusterWithProbe(cl client.Client, ok bool, status v1.ConditionStatus, lastProbeTime metav1.Time) cluster.GetHostClusterFunc {
+func NewGetHostClusterWithProbe(cl runtimeclient.Client, ok bool, status corev1.ConditionStatus, lastProbeTime metav1.Time) cluster.GetHostClusterFunc {
 	if !ok {
 		return func() (*cluster.CachedToolchainCluster, bool) {
 			return nil, false

--- a/test/cluster_assertion.go
+++ b/test/cluster_assertion.go
@@ -9,22 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ClusterAssertion struct {
-	client client.Client
+	client runtimeclient.Client
 	t      test.T
 }
 
-func AssertThatCluster(t test.T, client client.Client) *ClusterAssertion {
+func AssertThatCluster(t test.T, client runtimeclient.Client) *ClusterAssertion {
 	return &ClusterAssertion{
 		client: client,
 		t:      t,
 	}
 }
 
-func (a *ClusterAssertion) HasResource(name string, obj client.Object, options ...ResourceOption) *ClusterAssertion {
+func (a *ClusterAssertion) HasResource(name string, obj runtimeclient.Object, options ...ResourceOption) *ClusterAssertion {
 	err := a.client.Get(context.TODO(), types.NamespacedName{Name: name}, obj)
 	require.NoError(a.t, err)
 	for _, check := range options {
@@ -33,17 +33,17 @@ func (a *ClusterAssertion) HasResource(name string, obj client.Object, options .
 	return a
 }
 
-func (a *ClusterAssertion) HasNoResource(name string, obj client.Object) *ClusterAssertion {
+func (a *ClusterAssertion) HasNoResource(name string, obj runtimeclient.Object) *ClusterAssertion {
 	err := a.client.Get(context.TODO(), types.NamespacedName{Name: name}, obj)
 	require.Error(a.t, err, "did not expect resource '%s/%s' to exist", obj.GetObjectKind().GroupVersionKind().Kind, name)
 	assert.True(a.t, errors.IsNotFound(err))
 	return a
 }
 
-type ResourceOption func(t test.T, obj client.Object)
+type ResourceOption func(t test.T, obj runtimeclient.Object)
 
 func WithLabel(key, value string) ResourceOption {
-	return func(t test.T, obj client.Object) {
+	return func(t test.T, obj runtimeclient.Object) {
 		v, exists := obj.GetLabels()[key]
 		require.True(t, exists)
 		assert.Equal(t, value, v)
@@ -51,7 +51,7 @@ func WithLabel(key, value string) ResourceOption {
 }
 
 func Containing(value string) ResourceOption {
-	return func(t test.T, obj client.Object) {
+	return func(t test.T, obj runtimeclient.Object) {
 		content, err := json.Marshal(obj)
 		require.NoError(t, err)
 		assert.Contains(t, string(content), value)
@@ -59,7 +59,7 @@ func Containing(value string) ResourceOption {
 }
 
 func HasDeletionTimestamp() ResourceOption {
-	return func(t test.T, obj client.Object) {
+	return func(t test.T, obj runtimeclient.Object) {
 		assert.NotNil(t, obj.GetDeletionTimestamp())
 	}
 }

--- a/test/idler_assertion.go
+++ b/test/idler_assertion.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	batchv1 "k8s.io/api/batch/v1"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
@@ -14,16 +12,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type IdlerAssertion struct {
 	idler          *toolchainv1alpha1.Idler
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              *testing.T
 }
@@ -38,7 +37,7 @@ func (a *IdlerAssertion) loadIdlerAssertion() error {
 	return err
 }
 
-func AssertThatIdler(t *testing.T, name string, client client.Client) *IdlerAssertion {
+func AssertThatIdler(t *testing.T, name string, client runtimeclient.Client) *IdlerAssertion {
 	return &IdlerAssertion{
 		client:         client,
 		namespacedName: types.NamespacedName{Name: name},
@@ -55,7 +54,7 @@ func (a *IdlerAssertion) TracksPods(pods []*corev1.Pod) *IdlerAssertion {
 		startTimeNoMilSec := pod.Status.StartTime.Truncate(time.Second)
 		expected := toolchainv1alpha1.Pod{
 			Name:      pod.Name,
-			StartTime: v1.NewTime(startTimeNoMilSec),
+			StartTime: metav1.NewTime(startTimeNoMilSec),
 		}
 		assert.Contains(a.t, a.idler.Status.Pods, expected)
 	}
@@ -119,11 +118,11 @@ func IdlerNotificationCreationFailed(message string) toolchainv1alpha1.Condition
 }
 
 type IdleablePayloadAssertion struct {
-	client client.Client
+	client runtimeclient.Client
 	t      *testing.T
 }
 
-func AssertThatInIdleableCluster(t *testing.T, client client.Client) *IdleablePayloadAssertion {
+func AssertThatInIdleableCluster(t *testing.T, client runtimeclient.Client) *IdleablePayloadAssertion {
 	return &IdleablePayloadAssertion{
 		client: client,
 		t:      t,

--- a/test/memberstatus_assertion.go
+++ b/test/memberstatus_assertion.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type MemberStatusAssertion struct {
 	memberStatus   *toolchainv1alpha1.MemberStatus
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -28,7 +28,7 @@ func (a *MemberStatusAssertion) loadMemberStatus() error {
 	return err
 }
 
-func AssertThatMemberStatus(t test.T, namespace, name string, client client.Client) *MemberStatusAssertion {
+func AssertThatMemberStatus(t test.T, namespace, name string, client runtimeclient.Client) *MemberStatusAssertion {
 	return &MemberStatusAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),

--- a/test/namespace_assertion.go
+++ b/test/namespace_assertion.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	"github.com/stretchr/testify/assert"
@@ -12,12 +11,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type NamespaceAssertion struct {
 	namespace      *corev1.Namespace
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -29,7 +28,7 @@ func (a *NamespaceAssertion) loadNamespace() error {
 	return err
 }
 
-func AssertThatNamespace(t test.T, name string, client client.Client) *NamespaceAssertion {
+func AssertThatNamespace(t test.T, name string, client runtimeclient.Client) *NamespaceAssertion {
 	return &NamespaceAssertion{
 		client:         client,
 		namespacedName: types.NamespacedName{Name: name},
@@ -88,7 +87,7 @@ func (a *NamespaceAssertion) HasNoLabel(key string) *NamespaceAssertion {
 	return a
 }
 
-func (a *NamespaceAssertion) HasResource(name string, obj client.Object) *NamespaceAssertion {
+func (a *NamespaceAssertion) HasResource(name string, obj runtimeclient.Object) *NamespaceAssertion {
 	err := a.loadNamespace()
 	require.NoError(a.t, err)
 	err = a.client.Get(context.TODO(), types.NamespacedName{Namespace: a.namespace.Name, Name: name}, obj)
@@ -101,7 +100,7 @@ func (a *NamespaceAssertion) HasResource(name string, obj client.Object) *Namesp
 	return a
 }
 
-func (a *NamespaceAssertion) HasNoResource(name string, obj client.Object) *NamespaceAssertion {
+func (a *NamespaceAssertion) HasNoResource(name string, obj runtimeclient.Object) *NamespaceAssertion {
 	err := a.loadNamespace()
 	require.NoError(a.t, err)
 	err = a.client.Get(context.TODO(), types.NamespacedName{Namespace: a.namespace.Name, Name: name}, obj)
@@ -110,7 +109,7 @@ func (a *NamespaceAssertion) HasNoResource(name string, obj client.Object) *Name
 	return a
 }
 
-func (a *NamespaceAssertion) ResourceHasOwnerLabel(name string, obj client.Object, owner string) *NamespaceAssertion {
+func (a *NamespaceAssertion) ResourceHasOwnerLabel(name string, obj runtimeclient.Object, owner string) *NamespaceAssertion {
 	err := a.loadNamespace()
 	require.NoError(a.t, err)
 	err = a.client.Get(context.TODO(), types.NamespacedName{Namespace: a.namespace.Name, Name: name}, obj)

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -12,14 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type NSTemplateSetAssertion struct {
 	nsTmplSet      *toolchainv1alpha1.NSTemplateSet
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -31,7 +31,7 @@ func (a *NSTemplateSetAssertion) loadNSTemplateSet() error {
 	return err
 }
 
-func AssertThatNSTemplateSet(t test.T, namespace, name string, client client.Client) *NSTemplateSetAssertion {
+func AssertThatNSTemplateSet(t test.T, namespace, name string, client runtimeclient.Client) *NSTemplateSetAssertion {
 	return &NSTemplateSetAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),
@@ -48,7 +48,7 @@ func (a *NSTemplateSetAssertion) Exists() *NSTemplateSetAssertion {
 func (a *NSTemplateSetAssertion) DoesNotExist() *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.Error(a.t, err)
-	assert.IsType(a.t, v1.StatusReasonNotFound, errors.ReasonForError(err))
+	assert.IsType(a.t, metav1.StatusReasonNotFound, errors.ReasonForError(err))
 	return a
 }
 

--- a/test/role_assertion.go
+++ b/test/role_assertion.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type RoleAssertion struct {
 	role           *rbacv1.Role
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -27,7 +27,7 @@ func (a *RoleAssertion) loadRole() error {
 	return err
 }
 
-func AssertThatRole(t test.T, namespace, name string, client client.Client) *RoleAssertion {
+func AssertThatRole(t test.T, namespace, name string, client runtimeclient.Client) *RoleAssertion {
 	return &RoleAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),

--- a/test/rolebinding_assertion.go
+++ b/test/rolebinding_assertion.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type RoleBindingAssertion struct {
 	rolebinding    *rbacv1.RoleBinding
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -27,7 +27,7 @@ func (a *RoleBindingAssertion) loadRoleBinding() error {
 	return err
 }
 
-func AssertThatRoleBinding(t test.T, namespace, name string, client client.Client) *RoleBindingAssertion {
+func AssertThatRoleBinding(t test.T, namespace, name string, client runtimeclient.Client) *RoleBindingAssertion {
 	return &RoleBindingAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),


### PR DESCRIPTION
preparing for upcoming changes, using 'runtimeclient' as a package alias everywhere it is used

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
