### PR TITLE
fix: rename USERNAME template parameter with SPACE_NAME 

### DIFF
--- a/controllers/nstemplateset/cluster_resources.go
+++ b/controllers/nstemplateset/cluster_resources.go
@@ -25,10 +25,10 @@ type clusterResourcesManager struct {
 }
 
 // listExistingResourcesIfAvailable returns a list of comparable Objects representing existing resources in the cluster
-type listExistingResources func(cl runtimeclient.Client, username string) ([]runtimeclient.Object, error)
+type listExistingResources func(cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error)
 
 // listExistingResourcesIfAvailable checks if the API group is available in the cluster and returns a list of comparable Objects representing existing resources in the cluster
-type listExistingResourcesIfAvailable func(cl runtimeclient.Client, username string, availableAPIGroups []metav1.APIGroup) ([]runtimeclient.Object, error)
+type listExistingResourcesIfAvailable func(cl runtimeclient.Client, spacename string, availableAPIGroups []metav1.APIGroup) ([]runtimeclient.Object, error)
 
 // toolchainObjectKind represents a resource kind that should be present in templates containing cluster resources.
 // Such a kind should be watched by NSTempalateSet controller which means that every change of the
@@ -45,11 +45,11 @@ func newToolchainObjectKind(gvk schema.GroupVersionKind, emptyObject runtimeclie
 	return toolchainObjectKind{
 		gvk:    gvk,
 		object: emptyObject,
-		listExistingResourcesIfAvailable: func(cl runtimeclient.Client, username string, availableAPIGroups []metav1.APIGroup) (objects []runtimeclient.Object, e error) {
+		listExistingResourcesIfAvailable: func(cl runtimeclient.Client, spacename string, availableAPIGroups []metav1.APIGroup) (objects []runtimeclient.Object, e error) {
 			if !apiGroupIsPresent(availableAPIGroups, gvk) {
 				return []runtimeclient.Object{}, nil
 			}
-			return listExistingResources(cl, username)
+			return listExistingResources(cl, spacename)
 		},
 	}
 }
@@ -59,9 +59,9 @@ var clusterResourceKinds = []toolchainObjectKind{
 	newToolchainObjectKind(
 		quotav1.GroupVersion.WithKind("ClusterResourceQuota"),
 		&quotav1.ClusterResourceQuota{},
-		func(cl runtimeclient.Client, username string) ([]runtimeclient.Object, error) {
+		func(cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error) {
 			itemList := &quotav1.ClusterResourceQuotaList{}
-			if err := cl.List(context.TODO(), itemList, listByOwnerLabel(username)); err != nil {
+			if err := cl.List(context.TODO(), itemList, listByOwnerLabel(spacename)); err != nil {
 				return nil, err
 			}
 			list := make([]runtimeclient.Object, len(itemList.Items))
@@ -74,9 +74,9 @@ var clusterResourceKinds = []toolchainObjectKind{
 	newToolchainObjectKind(
 		rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"),
 		&rbacv1.ClusterRoleBinding{},
-		func(cl runtimeclient.Client, username string) ([]runtimeclient.Object, error) {
+		func(cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error) {
 			itemList := &rbacv1.ClusterRoleBindingList{}
-			if err := cl.List(context.TODO(), itemList, listByOwnerLabel(username)); err != nil {
+			if err := cl.List(context.TODO(), itemList, listByOwnerLabel(spacename)); err != nil {
 				return nil, err
 			}
 			list := make([]runtimeclient.Object, len(itemList.Items))
@@ -89,9 +89,9 @@ var clusterResourceKinds = []toolchainObjectKind{
 	newToolchainObjectKind(
 		toolchainv1alpha1.GroupVersion.WithKind("Idler"),
 		&toolchainv1alpha1.Idler{},
-		func(cl runtimeclient.Client, username string) ([]runtimeclient.Object, error) {
+		func(cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error) {
 			itemList := &toolchainv1alpha1.IdlerList{}
-			if err := cl.List(context.TODO(), itemList, listByOwnerLabel(username)); err != nil {
+			if err := cl.List(context.TODO(), itemList, listByOwnerLabel(spacename)); err != nil {
 				return nil, err
 			}
 			list := make([]runtimeclient.Object, len(itemList.Items))
@@ -105,9 +105,9 @@ var clusterResourceKinds = []toolchainObjectKind{
 // ensure ensures that the cluster resources exist.
 // Returns `true, nil` if something was changed, `false, nil` if nothing changed, `false, err` if an error occurred
 func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
-	userTierLogger := logger.WithValues("username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName)
+	userTierLogger := logger.WithValues("spacename", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName)
 	userTierLogger.Info("ensuring cluster resources")
-	username := nsTmplSet.GetName()
+	spacename := nsTmplSet.GetName()
 	var tierTemplate *tierTemplate
 	var err error
 	if nsTmplSet.Spec.ClusterResources != nil {
@@ -126,8 +126,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 		// get all objects of the resource kind from the template (if the template is specified)
 		if tierTemplate != nil {
 			newObjs, err = tierTemplate.process(r.Scheme, map[string]string{
-				Username:  username,
-				SpaceName: username,
+				SpaceName: spacename,
 			}, retainObjectsOfSameGVK(clusterResourceKind.gvk))
 			if err != nil {
 				return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(gvkLogger, nsTmplSet, err,
@@ -136,7 +135,7 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 		}
 
 		// list all existing objects of the cluster resource kind
-		currentObjects, err := clusterResourceKind.listExistingResourcesIfAvailable(r.Client, username, r.AvailableAPIGroups)
+		currentObjects, err := clusterResourceKind.listExistingResourcesIfAvailable(r.Client, spacename, r.AvailableAPIGroups)
 		if err != nil {
 			return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(gvkLogger, nsTmplSet, err,
 				"failed to list existing cluster resources of GVK '%v'", clusterResourceKind.gvk)

--- a/controllers/nstemplateset/cluster_resources_test.go
+++ b/controllers/nstemplateset/cluster_resources_test.go
@@ -168,9 +168,9 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 	// given
 	logger := zap.New(zap.UseDevMode(true))
 	logf.SetLogger(logger)
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
-	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+	nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
 	t.Cleanup(restore)
@@ -185,17 +185,17 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, createdOrUpdated)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(Provisioning())
 		AssertThatCluster(t, fakeClient).
-			HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-			HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+			HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 	})
 
 	t.Run("should not create ClusterResource objects when the field is nil", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"))
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
 
 		// when
@@ -204,7 +204,7 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.False(t, createdOrUpdated)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev").
 			HasNoConditions()
@@ -212,7 +212,7 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 
 	t.Run("should create only one CRQ when the template contains two CRQs", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
 
 		// when
@@ -221,13 +221,13 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, createdOrUpdated)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(Provisioning())
 		AssertThatCluster(t, fakeClient).
-			HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
 			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-			HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+			HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 		t.Run("should create the second CRQ when the first one is already created but still not ClusterRoleBinding", func(t *testing.T) {
 			// when
@@ -236,13 +236,13 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, createdOrUpdated)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				HasFinalizer().
 				HasConditions(Provisioning())
 			AssertThatCluster(t, fakeClient).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
 				HasResource("for-empty", &quotav1.ClusterResourceQuota{}).
-				HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 			t.Run("should create ClusterRoleBinding when both CRQs are created", func(t *testing.T) {
 				// when
@@ -251,24 +251,24 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.True(t, createdOrUpdated)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasFinalizer().
 					HasConditions(Provisioning())
 				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
 					HasResource("for-empty", &quotav1.ClusterResourceQuota{}).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 			})
 		})
 	})
 
 	t.Run("should not do anything when all cluster resources are already created", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"), withConditions(Provisioned()))
-		crq := newClusterResourceQuota(username, "advanced")
-		crb := newTektonClusterRoleBinding(username, "advanced")
-		idlerDev := newIdler(username, username+"-dev", "advanced")
-		idlerStage := newIdler(username, username+"-stage", "advanced")
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"), withConditions(Provisioned()))
+		crq := newClusterResourceQuota(spacename, "advanced")
+		crb := newTektonClusterRoleBinding(spacename, "advanced")
+		idlerDev := newIdler(spacename, spacename+"-dev", "advanced")
+		idlerStage := newIdler(spacename, spacename+"-stage", "advanced")
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, idlerDev, idlerStage)
 
 		// when
@@ -277,14 +277,14 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.False(t, createdOrUpdated)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(Provisioned())
 		AssertThatCluster(t, fakeClient).
-			HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-			HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
-			HasResource(username+"-dev", &toolchainv1alpha1.Idler{}).
-			HasResource(username+"-stage", &toolchainv1alpha1.Idler{})
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+			HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+			HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
+			HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{})
 	})
 }
 
@@ -293,9 +293,9 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 	// given
 	logger := zap.New(zap.UseDevMode(true))
 	logf.SetLogger(logger)
-	username := "johnsmith"
+	spacename := "johnsmith-space"
 	namespaceName := "toolchain-member"
-	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+	nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
 	t.Cleanup(restore)
@@ -313,14 +313,14 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to list cluster resources")
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(UnableToProvisionClusterResources("unable to list cluster resources"))
 	})
 
 	t.Run("fail to get template containing cluster resources", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "fail", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "fail", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
 
 		// when
@@ -329,7 +329,7 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to retrieve TierTemplate for the cluster resources with the name 'fail-clusterresources-abcde11'")
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(UnableToProvisionClusterResources(
 				"unable to retrieve the TierTemplate 'fail-clusterresources-abcde11' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"fail-clusterresources-abcde11\" not found"))
@@ -348,7 +348,7 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create missing cluster resource of GVK 'quota.openshift.io/v1, Kind=ClusterResourceQuota'")
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(UnableToProvisionClusterResources(
 				"failed to apply cluster resource of type 'quota.openshift.io/v1, Kind=ClusterResourceQuota': unable to create resource of kind: ClusterResourceQuota, version: v1: unable to create resource of kind: ClusterResourceQuota, version: v1: some error"))
@@ -360,11 +360,11 @@ func TestDeleteClusterResources(t *testing.T) {
 	// given
 	logger := zap.New(zap.UseDevMode(true))
 	logf.SetLogger(logger)
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
-	crq := newClusterResourceQuota(username, "advanced")
-	crb := newTektonClusterRoleBinding(username, "advanced")
-	nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "code"), withDeletionTs(), withClusterResources("abcde11"))
+	crq := newClusterResourceQuota(spacename, "advanced")
+	crb := newTektonClusterRoleBinding(spacename, "advanced")
+	nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "code"), withDeletionTs(), withClusterResources("abcde11"))
 
 	t.Run("delete only ClusterResourceQuota", func(t *testing.T) {
 		// given
@@ -377,8 +377,8 @@ func TestDeleteClusterResources(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, deleted)
 		AssertThatCluster(t, cl).
-			HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-			HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+			HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+			HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 		t.Run("delete ClusterRoleBinding since CRQ is already deleted", func(t *testing.T) {
 			// when
@@ -388,17 +388,17 @@ func TestDeleteClusterResources(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, deleted)
 			AssertThatCluster(t, cl).
-				HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-				HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 	})
 
 	t.Run("should delete only one ClusterResourceQuota even when tier contains more ", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-		crq := newClusterResourceQuota(username, "withemptycrq")
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+		crq := newClusterResourceQuota(spacename, "withemptycrq")
 		emptyCrq := newClusterResourceQuota("empty", "withemptycrq")
-		emptyCrq.Labels["toolchain.dev.openshift.com/owner"] = username
+		emptyCrq.Labels["toolchain.dev.openshift.com/owner"] = spacename
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq, crb)
 
 		// when
@@ -409,8 +409,8 @@ func TestDeleteClusterResources(t *testing.T) {
 		assert.True(t, deleted)
 		AssertThatCluster(t, cl).
 			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-			HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-			HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+			HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 		t.Run("delete the for-empty CRQ since it's the last one to be deleted", func(t *testing.T) {
 			// when
@@ -420,20 +420,20 @@ func TestDeleteClusterResources(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, deleted)
 			AssertThatCluster(t, cl).
-				HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}).
+				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
 				HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 	})
 
 	t.Run("delete the second ClusterResourceQuota since the first one has deletion timestamp set", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-		crq := newClusterResourceQuota(username, "withemptycrq")
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+		crq := newClusterResourceQuota(spacename, "withemptycrq")
 		deletionTS := metav1.NewTime(time.Now())
 		crq.SetDeletionTimestamp(&deletionTS)
 		emptyCrq := newClusterResourceQuota("empty", "withemptycrq")
-		emptyCrq.Labels["toolchain.dev.openshift.com/owner"] = username
+		emptyCrq.Labels["toolchain.dev.openshift.com/owner"] = spacename
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq)
 
 		// when
@@ -443,7 +443,7 @@ func TestDeleteClusterResources(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, deleted)
 		AssertThatCluster(t, cl).
-			HasResource("for-"+username, &quotav1.ClusterResourceQuota{}, HasDeletionTimestamp()).
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}, HasDeletionTimestamp()).
 			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{})
 	})
 
@@ -458,7 +458,7 @@ func TestDeleteClusterResources(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, deleted)
 		AssertThatCluster(t, cl).
-			HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{})
+			HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{})
 	})
 
 	t.Run("failed to delete CRQ", func(t *testing.T) {
@@ -475,7 +475,7 @@ func TestDeleteClusterResources(t *testing.T) {
 		require.Error(t, err)
 		assert.False(t, deleted)
 		assert.Equal(t, "failed to delete cluster resource 'for-johnsmith': mock error", err.Error())
-		AssertThatNSTemplateSet(t, namespaceName, username, cl).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 			HasFinalizer(). // finalizer was not added and nothing else was done
 			HasConditions(UnableToTerminate("mock error"))
 	})
@@ -489,18 +489,18 @@ func TestPromoteClusterResources(t *testing.T) {
 	// given
 	logger := zap.New(zap.UseDevMode(true))
 	logf.SetLogger(logger)
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
-	crb := newTektonClusterRoleBinding(username, "advanced")
+	crb := newTektonClusterRoleBinding(spacename, "advanced")
 
 	t.Run("success", func(t *testing.T) {
 
 		t.Run("upgrade from advanced to team tier by changing only the CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "team", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-			codeNs := newNamespace("advanced", username, "code")
-			crq := newClusterResourceQuota(username, "advanced")
-			crb := newTektonClusterRoleBinding(username, "advanced")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "team", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+			codeNs := newNamespace("advanced", spacename, "code")
+			crq := newClusterResourceQuota(spacename, "advanced")
+			crb := newTektonClusterRoleBinding(spacename, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, codeNs)
 
 			// when
@@ -509,15 +509,15 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "team-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "team"),
 					Containing(`"limits.cpu":"4","limits.memory":"15Gi"`)).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 
 			t.Run("upgrade from advanced to team tier by changing only the CRB since CRQ is already changed", func(t *testing.T) {
@@ -527,23 +527,23 @@ func TestPromoteClusterResources(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 					HasFinalizer().
 					HasConditions(Updating())
 				AssertThatCluster(t, cl).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 						WithLabel("toolchain.dev.openshift.com/tier", "team"),
 						Containing(`"limits.cpu":"4","limits.memory":"15Gi"`)).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 						WithLabel("toolchain.dev.openshift.com/tier", "team"))
 			})
 		})
 
 		t.Run("upgrade from base to advanced tier by changing only the tier label - the templateref label doesn't change", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-			codeNs := newNamespace("advanced", username, "code")
-			crq := newClusterResourceQuota(username, "advanced")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+			codeNs := newNamespace("advanced", spacename, "code")
+			crq := newClusterResourceQuota(spacename, "advanced")
 			crq.Labels["toolchain.dev.openshift.com/tier"] = "base"
 			crq.Spec.Quota.Hard["limits.cpu"] = resource.MustParse("100m")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, codeNs)
@@ -554,11 +554,11 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
 					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`))
@@ -566,11 +566,11 @@ func TestPromoteClusterResources(t *testing.T) {
 
 		t.Run("promote from withemptycrq to advanced tier by removing the redundant CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("dev"), withClusterResources("abcde11"))
-			codeNs := newNamespace("advanced", username, "code")
-			crq := newClusterResourceQuota(username, "withemptycrq")
-			crb := newTektonClusterRoleBinding(username, "withemptycrq")
-			emptyCrq := newClusterResourceQuota(username, "withemptycrq")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("dev"), withClusterResources("abcde11"))
+			codeNs := newNamespace("advanced", spacename, "code")
+			crq := newClusterResourceQuota(spacename, "withemptycrq")
+			crb := newTektonClusterRoleBinding(spacename, "withemptycrq")
+			emptyCrq := newClusterResourceQuota(spacename, "withemptycrq")
 			emptyCrq.Name = "for-empty"
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, emptyCrq, crq, crb, codeNs)
 
@@ -580,15 +580,15 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
 				HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "withemptycrq-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "withemptycrq")).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "withemptycrq-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "withemptycrq"))
 
@@ -599,15 +599,15 @@ func TestPromoteClusterResources(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 					HasFinalizer().
 					HasConditions(Updating())
 				AssertThatCluster(t, cl).
 					HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 						WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 						WithLabel("toolchain.dev.openshift.com/templateref", "withemptycrq-clusterresources-abcde11"),
 						WithLabel("toolchain.dev.openshift.com/tier", "withemptycrq"))
 
@@ -616,9 +616,9 @@ func TestPromoteClusterResources(t *testing.T) {
 
 		t.Run("downgrade from advanced to basic tier by removing CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev"))
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev"))
 			// create namespace (and assume it is complete since it has the expected revision number)
-			crq := newClusterResourceQuota(username, "advanced")
+			crq := newClusterResourceQuota(spacename, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
 
 			// when
@@ -627,12 +627,12 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}). // no cluster resources in 'basic` tier
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}). // no cluster resources in 'basic` tier
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 			t.Run("downgrade from advanced to basic tier by removing CRB since CRQ is already removed", func(t *testing.T) {
 				// when
@@ -641,19 +641,19 @@ func TestPromoteClusterResources(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 					HasFinalizer().
 					HasConditions(Updating())
 				AssertThatCluster(t, cl).
-					HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}). // no cluster resources in 'basic` tier
-					HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+					HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}). // no cluster resources in 'basic` tier
+					HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 			})
 		})
 
 		t.Run("delete redundant cluster resources when ClusterResources field is nil in NSTemplateSet", func(t *testing.T) {
 			// given 'advanced' NSTemplate only has a cluster resource
-			nsTmplSet := newNSTmplSet(namespaceName, username, "withemptycrq") // no cluster resources, so the "advancedCRQ" should be deleted even if the tier contains the "advancedCRQ"
-			crq := newClusterResourceQuota(username, "advanced")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq") // no cluster resources, so the "advancedCRQ" should be deleted even if the tier contains the "advancedCRQ"
+			crq := newClusterResourceQuota(spacename, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 			// when
@@ -662,18 +662,18 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}). // resources were deleted
-				HasNoResource("tekton-view-for-"+username, &rbacv1.ClusterRole{}).
-				HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}). // resources were deleted
+				HasNoResource("tekton-view-for-"+spacename, &rbacv1.ClusterRole{}).
+				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 
 		t.Run("upgrade from basic to advanced by creating only CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withClusterResources("abcde11"))
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withClusterResources("abcde11"))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet)
 
 			// when
@@ -682,15 +682,15 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(Provisioning())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
 					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)).
-				HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 			t.Run("upgrade from basic to advanced by creating CRB since CRQ is already created", func(t *testing.T) {
 				// when
@@ -699,14 +699,14 @@ func TestPromoteClusterResources(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 					HasFinalizer().
 					HasConditions(Provisioning())
 				AssertThatCluster(t, cl).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 						WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
 						Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 						WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 			})
 		})
@@ -714,18 +714,18 @@ func TestPromoteClusterResources(t *testing.T) {
 		t.Run("with another user", func(t *testing.T) {
 			// given
 			anotherNsTmplSet := newNSTmplSet(namespaceName, "another-user", "basic")
-			advancedCRQ := newClusterResourceQuota(username, "advanced")
+			advancedCRQ := newClusterResourceQuota(spacename, "advanced")
 			anotherCRQ := newClusterResourceQuota("another-user", "basic")
 			anotherCrb := newTektonClusterRoleBinding("another", "basic")
 
-			idlerDev := newIdler(username, username+"-dev", "advanced")
-			idlerStage := newIdler(username, username+"-stage", "advanced")
+			idlerDev := newIdler(spacename, spacename+"-dev", "advanced")
+			idlerStage := newIdler(spacename, spacename+"-stage", "advanced")
 			anotherIdlerDev := newIdler("another", "another-dev", "advanced")
 			anotherIdlerStage := newIdler("another", "another-stage", "advanced")
 
 			t.Run("no redundant cluster resources to be deleted for the given user", func(t *testing.T) {
 				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withConditions(Provisioned()), withClusterResources("abcde11"))
+				nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withConditions(Provisioned()), withClusterResources("abcde11"))
 				manager, cl := prepareClusterResourcesManager(t, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ, anotherCrb, crb, idlerDev, idlerStage, anotherIdlerDev, anotherIdlerStage)
 
 				// when
@@ -734,23 +734,23 @@ func TestPromoteClusterResources(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.False(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 					HasFinalizer().
 					HasConditions(Provisioned())
 				AssertThatCluster(t, cl).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
 					HasResource("for-another-user", &quotav1.ClusterResourceQuota{}).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
 					HasResource("another-tekton-view", &rbacv1.ClusterRoleBinding{}).
-					HasResource(username+"-dev", &toolchainv1alpha1.Idler{}).
-					HasResource(username+"-stage", &toolchainv1alpha1.Idler{}).
+					HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
+					HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{}).
 					HasResource("another-dev", &toolchainv1alpha1.Idler{}).
 					HasResource("another-stage", &toolchainv1alpha1.Idler{})
 			})
 
 			t.Run("cluster resources should be deleted since it doesn't contain clusterResources template", func(t *testing.T) {
 				// given
-				nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withConditions(Provisioned()))
+				nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withConditions(Provisioned()))
 				manager, cl := prepareClusterResourcesManager(t, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ, anotherCrb, crb)
 
 				// when - let remove everything
@@ -762,12 +762,12 @@ func TestPromoteClusterResources(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 					HasFinalizer().
 					HasConditions(Updating())
 				AssertThatCluster(t, cl).
-					HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-					HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+					HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+					HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
 					HasResource("for-another-user", &quotav1.ClusterResourceQuota{}).
 					HasResource("another-tekton-view", &rbacv1.ClusterRoleBinding{})
 
@@ -776,10 +776,10 @@ func TestPromoteClusterResources(t *testing.T) {
 
 		t.Run("delete only one redundant cluster resource during one call", func(t *testing.T) {
 			// given 'advanced' NSTemplate only has a cluster resource
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
-			advancedCRQ := newClusterResourceQuota(username, "withemptycrq")
-			anotherCRQ := newClusterResourceQuota(username, "withemptycrq")
-			crb := newTektonClusterRoleBinding(username, "withemptycrq")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
+			advancedCRQ := newClusterResourceQuota(spacename, "withemptycrq")
+			anotherCRQ := newClusterResourceQuota(spacename, "withemptycrq")
+			crb := newTektonClusterRoleBinding(spacename, "withemptycrq")
 			anotherCRQ.Name = "for-empty"
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, advancedCRQ, anotherCRQ, crb)
 
@@ -789,7 +789,7 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(Updating()) //
 			quotas := &quotav1.ClusterResourceQuotaList{}
@@ -797,7 +797,7 @@ func TestPromoteClusterResources(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, quotas.Items, 1)
 			AssertThatCluster(t, cl).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 			t.Run("it should delete the second for-empty CRQ since it's the last one", func(t *testing.T) {
 				// when - should delete the second ClusterResourceQuota
@@ -810,7 +810,7 @@ func TestPromoteClusterResources(t *testing.T) {
 				require.NoError(t, err)
 				assert.Len(t, quotas.Items, 0)
 				AssertThatCluster(t, cl).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 				t.Run("it should delete the CRB since both CRQs are already removed", func(t *testing.T) {
 					// when - should delete the second ClusterResourceQuota
@@ -835,9 +835,9 @@ func TestPromoteClusterResources(t *testing.T) {
 
 		t.Run("promotion to another tier fails because it cannot list current resources", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev"), withConditions(Updating()))
-			crq := newClusterResourceQuota(username, "fail")
-			crb := newTektonClusterRoleBinding(username, "fail")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev"), withConditions(Updating()))
+			crq := newClusterResourceQuota(spacename, "fail")
+			crb := newTektonClusterRoleBinding(spacename, "fail")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
 			cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 				return fmt.Errorf("some error")
@@ -848,22 +848,22 @@ func TestPromoteClusterResources(t *testing.T) {
 
 			// then
 			require.Error(t, err)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(UpdateFailed("some error"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "fail-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "fail")).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "fail-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "fail"))
 		})
 
 		t.Run("fail to downgrade from advanced to basic tier", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev"))
-			crq := newClusterResourceQuota(username, "advanced")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev"))
+			crq := newClusterResourceQuota(spacename, "advanced")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
 			cl.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 				return fmt.Errorf("some error")
@@ -875,15 +875,15 @@ func TestPromoteClusterResources(t *testing.T) {
 			// then
 			require.Error(t, err)
 			assert.False(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(UpdateFailed(
 					"failed to delete an existing redundant cluster resource of name 'for-johnsmith' and gvk 'quota.openshift.io/v1, Kind=ClusterResourceQuota': some error"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 		})
@@ -898,17 +898,17 @@ func TestUpdateClusterResources(t *testing.T) {
 	// given
 	logger := zap.New(zap.UseDevMode(true))
 	logf.SetLogger(logger)
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
-	crb := newTektonClusterRoleBinding(username, "advanced")
-	crq := newClusterResourceQuota(username, "advanced")
+	crb := newTektonClusterRoleBinding(spacename, "advanced")
+	crq := newClusterResourceQuota(spacename, "advanced")
 
 	t.Run("success", func(t *testing.T) {
 
 		t.Run("update from abcde11 revision to abcde12 revision as part of the advanced tier by updating CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde12", "dev"), withClusterResources("abcde12"))
-			codeNs := newNamespace("advanced", username, "dev")
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde12", "dev"), withClusterResources("abcde12"))
+			codeNs := newNamespace("advanced", spacename, "dev")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, codeNs)
 
 			// when
@@ -917,11 +917,11 @@ func TestUpdateClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).HasConditions(Updating())
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12")).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"))
 
 			t.Run("update from abcde11 revision to abcde12 revision by deleting CRB since CRQ is already changed", func(t *testing.T) {
@@ -931,18 +931,18 @@ func TestUpdateClusterResources(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).HasConditions(Updating())
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
 				AssertThatCluster(t, cl).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12")).
-					HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+					HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 			})
 		})
 
 		t.Run("update from abcde12 revision to abcde11 revision as part of the advanced tier by updating CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-			crq := newClusterResourceQuota(username, "advanced", withTemplateRefUsingRevision("abcde12"))
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+			crq := newClusterResourceQuota(spacename, "advanced", withTemplateRefUsingRevision("abcde12"))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 			// when
@@ -951,11 +951,11 @@ func TestUpdateClusterResources(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).HasConditions(Updating())
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-				HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 			t.Run("update from abcde12 revision to abcde11 revision as part of the advanced tier by creating CRB", func(t *testing.T) {
 				// when
@@ -964,11 +964,11 @@ func TestUpdateClusterResources(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, username, cl).HasConditions(Updating())
+				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
 				AssertThatCluster(t, cl).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"))
 			})
 		})
@@ -978,7 +978,7 @@ func TestUpdateClusterResources(t *testing.T) {
 
 		t.Run("update to abcde11 fails because it cannot list current resources", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withClusterResources("abcde11"), withConditions(Updating()))
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withClusterResources("abcde11"), withConditions(Updating()))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 			cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 				return fmt.Errorf("some error")
@@ -989,18 +989,18 @@ func TestUpdateClusterResources(t *testing.T) {
 
 			// then
 			require.Error(t, err)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(UpdateFailed("some error"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-				HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 
 		t.Run("update to abcde13 fails because it find the template", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withClusterResources("abcde13"), withConditions(Updating()))
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withClusterResources("abcde13"), withConditions(Updating()))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
 
 			// when
@@ -1009,14 +1009,14 @@ func TestUpdateClusterResources(t *testing.T) {
 			// then
 			require.Error(t, err)
 			assert.False(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, username, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 				HasFinalizer().
 				HasConditions(UpdateFailed(
 					"unable to retrieve the TierTemplate 'advanced-clusterresources-abcde13' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"advanced-clusterresources-abcde13\" not found"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"))
 		})
 	})

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -26,10 +26,10 @@ type namespacesManager struct {
 // return `true, nil` when something changed, `false, nil` or `false, err` otherwise
 func (r *namespacesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (createdOrUpdated bool, err error) {
 	logger.Info("ensuring namespaces", "tier", nsTmplSet.Spec.TierName)
-	username := nsTmplSet.GetName()
-	userNamespaces, err := fetchNamespacesByOwner(r.Client, username)
+	spacename := nsTmplSet.GetName()
+	userNamespaces, err := fetchNamespacesByOwner(r.Client, spacename)
 	if err != nil {
-		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusProvisionFailed, err, "failed to list namespaces with label owner '%s'", username)
+		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusProvisionFailed, err, "failed to list namespaces with label owner '%s'", spacename)
 	}
 
 	tierTemplatesByType, err := r.getTierTemplatesForAllNamespaces(nsTmplSet)
@@ -55,7 +55,7 @@ func (r *namespacesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 		return false, err
 	}
 	if !found {
-		logger.Info("no more namespaces to create", "username", nsTmplSet.GetName())
+		logger.Info("no more namespaces to create", "spacename", nsTmplSet.GetName())
 		return false, nil
 	}
 
@@ -102,7 +102,6 @@ func (r *namespacesManager) ensureNamespace(logger logr.Logger, nsTmplSet *toolc
 // note: checks only if the namespace has labels that match the provided template, it does not check whether any labels could have been removed
 func (r *namespacesManager) namespaceHasExpectedLabelsFromTemplate(tierTemplate *tierTemplate, userNamespace *corev1.Namespace) (bool, error) {
 	objs, err := tierTemplate.process(r.Scheme, map[string]string{
-		Username:  userNamespace.GetLabels()[toolchainv1alpha1.OwnerLabelKey],
 		SpaceName: userNamespace.GetLabels()[toolchainv1alpha1.OwnerLabelKey],
 	}, template.RetainNamespaces)
 	if err != nil {
@@ -148,9 +147,8 @@ func mapContains(actual, contains map[string]string) bool {
 
 // ensureNamespaceResource ensures that the namespace exists.
 func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate) error {
-	logger.Info("creating namespace", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
+	logger.Info("creating namespace", "spacename", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
 	objs, err := tierTemplate.process(r.Scheme, map[string]string{
-		Username:  nsTmplSet.GetName(),
 		SpaceName: nsTmplSet.GetName(),
 	}, template.RetainNamespaces)
 	if err != nil {
@@ -178,10 +176,9 @@ func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSe
 
 // ensureInnerNamespaceResources ensure that the namespace has the expected resources.
 func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate, namespace *corev1.Namespace) error {
-	logger.Info("ensuring namespace resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
+	logger.Info("ensuring namespace resources", "spacename", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
 	nsName := namespace.GetName()
 	newObjs, err := tierTemplate.process(r.Scheme, map[string]string{
-		Username:  nsTmplSet.GetName(),
 		SpaceName: nsTmplSet.GetName(),
 	}, template.RetainAllButNamespaces)
 	if err != nil {
@@ -189,7 +186,7 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 	}
 
 	if currentRef, exists := namespace.Labels[toolchainv1alpha1.TemplateRefLabelKey]; exists && currentRef != "" && currentRef != tierTemplate.templateRef {
-		logger.Info("checking obsolete namespace resources", "username", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
+		logger.Info("checking obsolete namespace resources", "spacename", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName, "type", tierTemplate.typeName)
 		if err := r.setStatusUpdatingIfNotProvisioning(nsTmplSet); err != nil {
 			return err
 		}
@@ -198,7 +195,6 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 			return r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve current TierTemplate with name '%s'", currentRef)
 		}
 		currentObjs, err := currentTierTemplate.process(r.Scheme, map[string]string{
-			Username:  nsTmplSet.GetName(),
 			SpaceName: nsTmplSet.GetName(),
 		}, template.RetainAllButNamespaces)
 		if err != nil {
@@ -234,7 +230,7 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 	return nil // nothing changed, no error occurred
 }
 
-// ensureDeleted ensures that the namespaces that are owned by the user (based on the label) are deleted.
+// ensureDeleted ensures that the namespaces that are owned by the space (based on the label) are deleted.
 // The method deletes only one namespace in one call.
 // It returns true if all the namespaces are gone and returns false if we should re-try:
 //
@@ -247,10 +243,10 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 // If some error happened then it returns false, error
 func (r *namespacesManager) ensureDeleted(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
 	// now, we can delete all "child" namespaces explicitly
-	username := nsTmplSet.Name
-	userNamespaces, err := fetchNamespacesByOwner(r.Client, username)
+	spacename := nsTmplSet.Name
+	userNamespaces, err := fetchNamespacesByOwner(r.Client, spacename)
 	if err != nil {
-		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to list namespace with label owner '%s'", username)
+		return false, r.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to list namespace with label owner '%s'", spacename)
 	}
 
 	if len(userNamespaces) == 0 {
@@ -280,12 +276,12 @@ func (r *namespacesManager) getTierTemplatesForAllNamespaces(nsTmplSet *toolchai
 	return tmpls, nil
 }
 
-// fetchNamespacesByOwner returns all current namespaces belonging to the given user
-// i.e., labeled with `"toolchain.dev.openshift.com/owner":<username>`
-func fetchNamespacesByOwner(cl runtimeclient.Client, username string) ([]corev1.Namespace, error) {
-	// fetch all namespace with owner=username label
+// fetchNamespacesByOwner returns all current namespaces belonging to the given space
+// i.e., labeled with `"toolchain.dev.openshift.com/owner":<spacename>`
+func fetchNamespacesByOwner(cl runtimeclient.Client, spacename string) ([]corev1.Namespace, error) {
+	// fetch all namespace with owner=spacename label
 	userNamespaceList := &corev1.NamespaceList{}
-	if err := cl.List(context.TODO(), userNamespaceList, listByOwnerLabel(username)); err != nil {
+	if err := cl.List(context.TODO(), userNamespaceList, listByOwnerLabel(spacename)); err != nil {
 		return nil, err
 	}
 	// sort namespaces by name
@@ -360,7 +356,7 @@ func (r *namespacesManager) isUpToDateAndProvisioned(logger logr.Logger, ns *cor
 
 		newObjs, err := tierTemplate.process(r.Scheme, map[string]string{
 			Username:  ns.GetLabels()[toolchainv1alpha1.OwnerLabelKey],
-			SpaceName: ns.GetLabels()[toolchainv1alpha1.OwnerLabelKey],
+			SpaceName: ns.GetLabels()[toolchainv1alpha1.OwnerLabelKey], // both username and space name are required here, since rolebindings are still created with the USERNAME param.
 		}, template.RetainAllButNamespaces)
 		if err != nil {
 			return false, err
@@ -443,9 +439,9 @@ func (r *namespacesManager) containsRoleBindings(list []rbac.RoleBinding, obj ru
 }
 
 func (r *namespacesManager) setProvisionedNamespaceList(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (err error) {
-	logger.Info("setting provisioned namespaces", "username", nsTmplSet.GetName())
-	username := nsTmplSet.GetName()
-	userNamespaces, err := fetchNamespacesByOwner(r.Client, username)
+	logger.Info("setting provisioned namespaces", "spacename", nsTmplSet.GetName())
+	spacename := nsTmplSet.GetName()
+	userNamespaces, err := fetchNamespacesByOwner(r.Client, spacename)
 	if err != nil {
 		return err
 	}

--- a/controllers/nstemplateset/nstemplateset_controller.go
+++ b/controllers/nstemplateset/nstemplateset_controller.go
@@ -185,7 +185,7 @@ func (r *Reconciler) deleteNSTemplateSet(logger logr.Logger, nsTmplSet *toolchai
 		return reconcile.Result{}, r.status.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.status.setStatusTerminatingFailed, err,
 			"failed to set status to 'ready=false/reason=terminating' on NSTemplateSet")
 	}
-	username := nsTmplSet.GetName()
+	spacename := nsTmplSet.GetName()
 
 	// delete all namespace one by one
 	allDeleted, err := r.namespaces.ensureDeleted(logger, nsTmplSet)
@@ -215,7 +215,7 @@ func (r *Reconciler) deleteNSTemplateSet(logger logr.Logger, nsTmplSet *toolchai
 	util.RemoveFinalizer(nsTmplSet, toolchainv1alpha1.FinalizerName)
 	if err := r.Client.Update(context.TODO(), nsTmplSet); err != nil {
 		return reconcile.Result{}, r.status.wrapErrorWithStatusUpdate(logger, nsTmplSet, r.status.setStatusTerminatingFailed, err,
-			"failed to remove finalizer on NSTemplateSet '%s'", username)
+			"failed to remove finalizer on NSTemplateSet '%s'", spacename)
 	}
 	return reconcile.Result{}, nil
 }
@@ -244,8 +244,8 @@ Current:
 	return nil
 }
 
-// listByOwnerLabel returns runtimeclient.ListOption that filters by label toolchain.dev.openshift.com/owner equal to the given username
-func listByOwnerLabel(username string) runtimeclient.ListOption {
-	labels := map[string]string{toolchainv1alpha1.OwnerLabelKey: username}
+// listByOwnerLabel returns runtimeclient.ListOption that filters by label toolchain.dev.openshift.com/owner equal to the given spacename
+func listByOwnerLabel(spacename string) runtimeclient.ListOption {
+	labels := map[string]string{toolchainv1alpha1.OwnerLabelKey: spacename}
 	return runtimeclient.MatchingLabels(labels)
 }

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -34,14 +34,14 @@ func TestReconcileAddFinalizer(t *testing.T) {
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
 
 	t.Run("add a finalizer when missing", func(t *testing.T) {
 		t.Run("success", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withoutFinalizer())
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withoutFinalizer())
+			r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet)
 
 			// when
 			res, err := r.Reconcile(context.TODO(), req)
@@ -49,14 +49,14 @@ func TestReconcileAddFinalizer(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				HasFinalizer()
 		})
 
 		t.Run("failure", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withoutFinalizer())
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withoutFinalizer())
+			r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet)
 			fakeClient.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 				fmt.Printf("updating object of type '%T'\n", obj)
 				return fmt.Errorf("mock error")
@@ -69,7 +69,7 @@ func TestReconcileAddFinalizer(t *testing.T) {
 			require.Error(t, err)
 
 			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				DoesNotHaveFinalizer()
 		})
 	})
@@ -80,7 +80,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
 
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
@@ -88,13 +88,13 @@ func TestReconcileProvisionOK(t *testing.T) {
 
 	t.Run("status provisioned when cluster resources and space roles are missing", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev", "stage"))
 		// create namespaces (and assume they are complete since they have the expected revision number)
-		devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		rb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		rb2 := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rb, rb2)
+		devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		rb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		rb2 := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rb, rb2)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
@@ -102,18 +102,18 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Provisioned())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
-			HasLabel("toolchain.dev.openshift.com/owner", username).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
+			HasLabel("toolchain.dev.openshift.com/owner", spacename).
 			HasLabel("toolchain.dev.openshift.com/type", "dev").
 			HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11").
 			HasLabel("toolchain.dev.openshift.com/tier", "basic").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
-			HasLabel("toolchain.dev.openshift.com/owner", username).
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
+			HasLabel("toolchain.dev.openshift.com/owner", spacename).
 			HasLabel("toolchain.dev.openshift.com/type", "stage").
 			HasLabel("toolchain.dev.openshift.com/templateref", "basic-stage-abcde11").
 			HasLabel("toolchain.dev.openshift.com/tier", "basic").
@@ -123,21 +123,21 @@ func TestReconcileProvisionOK(t *testing.T) {
 	t.Run("status provisioned with cluster resources", func(t *testing.T) {
 		// given
 		// create cluster resources
-		crq := newClusterResourceQuota(username, "advanced")
-		crb := newTektonClusterRoleBinding(username, "advanced")
-		idlerDev := newIdler(username, username+"-dev", "advanced")
-		idlerStage := newIdler(username, username+"-stage", "advanced")
+		crq := newClusterResourceQuota(spacename, "advanced")
+		crb := newTektonClusterRoleBinding(spacename, "advanced")
+		idlerDev := newIdler(spacename, spacename+"-dev", "advanced")
+		idlerStage := newIdler(spacename, spacename+"-stage", "advanced")
 		// create namespaces (and assume they are complete since they have the expected revision number)
-		devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage"), withClusterResources("abcde11"))
-		devRole := newRole(devNS.Name, "exec-pods", username)
-		devRb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		devRb2 := newRoleBinding(devNS.Name, "crtadmin-view", username)
-		stageRole := newRole(stageNS.Name, "exec-pods", username)
-		stageRb := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-		stageRb2 := newRoleBinding(stageNS.Name, "crtadmin-view", username)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet,
+		devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage"), withClusterResources("abcde11"))
+		devRole := newRole(devNS.Name, "exec-pods", spacename)
+		devRb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		devRb2 := newRoleBinding(devNS.Name, "crtadmin-view", spacename)
+		stageRole := newRole(stageNS.Name, "exec-pods", spacename)
+		stageRb := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+		stageRb2 := newRoleBinding(stageNS.Name, "crtadmin-view", spacename)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet,
 			crq, crb, idlerDev, idlerStage,
 			devNS, stageNS,
 			devRole, devRb, devRb2,
@@ -149,12 +149,12 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Provisioned())
 		AssertThatCluster(t, fakeClient).
-			HasResource("for-"+username, &quotav1.ClusterResourceQuota{})
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{})
 	})
 
 	t.Run("status should contain provisioned namespaces", func(t *testing.T) {
@@ -163,27 +163,27 @@ func TestReconcileProvisionOK(t *testing.T) {
 			Type:   toolchainv1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
 		}
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "stage", "dev"), withConditions(condition))
-		devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		rb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		rb2 := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rb, rb2)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "stage", "dev"), withConditions(condition))
+		devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		rb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		rb2 := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rb, rb2)
 
 		// when
 		_, err := r.Reconcile(context.TODO(), req)
 
 		// then
 		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasProvisionedNamespaces([]toolchainv1alpha1.SpaceNamespace{
 				{
-					Name: username + "-dev",
+					Name: spacename + "-dev",
 					Type: "default", // check that default type is added to first NS in alphabetical order
 				},
 				{
-					Name: username + "-stage",
+					Name: spacename + "-stage",
 					Type: "", // other namespaces do not have type for now...
 				},
 			}...).
@@ -192,8 +192,8 @@ func TestReconcileProvisionOK(t *testing.T) {
 
 	t.Run("should not create ClusterResource objects when the field is nil but provision namespace", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage"))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
@@ -201,13 +201,13 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Provisioning())
-		AssertThatNamespace(t, username+"-dev", r.Client).
+		AssertThatNamespace(t, spacename+"-dev", r.Client).
 			HasNoOwnerReference().
-			HasLabel("toolchain.dev.openshift.com/owner", username).
+			HasLabel("toolchain.dev.openshift.com/owner", spacename).
 			HasLabel("toolchain.dev.openshift.com/type", "dev").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
 			HasNoLabel("toolchain.dev.openshift.com/templateref").
@@ -216,18 +216,18 @@ func TestReconcileProvisionOK(t *testing.T) {
 
 	t.Run("should recreate rolebinding when missing", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev", "stage"))
 		// create namespaces (and assume they are complete since they have the expected revision number)
-		devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS)
+		devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
@@ -236,51 +236,51 @@ func TestReconcileProvisionOK(t *testing.T) {
 		res, err = r.Reconcile(context.TODO(), req)
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
 
 		// another reconcile creates the missing rolebinding in stage namespace
 		res, err = r.Reconcile(context.TODO(), req)
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Provisioned())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
 	})
 
 	t.Run("should recreate role when missing", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage")) // no cluster resources here
-		devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		rb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		rb2 := newRoleBinding(devNS.Name, "crtadmin-view", username)
-		rb3 := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-		rb4 := newRoleBinding(stageNS.Name, "crtadmin-view", username)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rb, rb2, rb3, rb4)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage")) // no cluster resources here
+		devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		rb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		rb2 := newRoleBinding(devNS.Name, "crtadmin-view", spacename)
+		rb3 := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+		rb4 := newRoleBinding(stageNS.Name, "crtadmin-view", spacename)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rb, rb2, rb3, rb4)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{})
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{})
 
@@ -290,15 +290,15 @@ func TestReconcileProvisionOK(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				HasFinalizer().
 				HasSpecNamespaces("dev", "stage").
 				HasConditions(Updating())
-			AssertThatNamespace(t, username+"-dev", fakeClient).
+			AssertThatNamespace(t, spacename+"-dev", fakeClient).
 				HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 				HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 				HasResource("exec-pods", &rbacv1.Role{}) // created
-			AssertThatNamespace(t, username+"-stage", fakeClient).
+			AssertThatNamespace(t, spacename+"-stage", fakeClient).
 				HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 				HasResource("crtadmin-view", &rbacv1.RoleBinding{})
 
@@ -308,15 +308,15 @@ func TestReconcileProvisionOK(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.Equal(t, reconcile.Result{}, res)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasFinalizer().
 					HasSpecNamespaces("dev", "stage").
 					HasConditions(Provisioned()) // done with updating
-				AssertThatNamespace(t, username+"-dev", fakeClient).
+				AssertThatNamespace(t, spacename+"-dev", fakeClient).
 					HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 					HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 					HasResource("exec-pods", &rbacv1.Role{})
-				AssertThatNamespace(t, username+"-stage", fakeClient).
+				AssertThatNamespace(t, spacename+"-stage", fakeClient).
 					HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 					HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 					HasResource("exec-pods", &rbacv1.Role{}) // created
@@ -326,78 +326,78 @@ func TestReconcileProvisionOK(t *testing.T) {
 
 	t.Run("should recreate all spacerole-related rolebindings at once when missing", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic",
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic",
 			withNamespaces("abcde11", "dev", "stage"),
 			withSpaceRoles(map[string][]string{
-				"basic-admin-abcde11": {username},
+				"basic-admin-abcde11": {spacename},
 			}))
 		// create namespaces (and assume they are complete since they have the expected revision number)
-		devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"), withLastAppliedSpaceRoles(nsTmplSet))
-		stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"), withLastAppliedSpaceRoles(nsTmplSet))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet,
+		devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"), withLastAppliedSpaceRoles(nsTmplSet))
+		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"), withLastAppliedSpaceRoles(nsTmplSet))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet,
 			devNS,
-			newRole(devNS.Name, "exec-pods", username),
-			newRoleBinding(devNS.Name, "crtadmin-pods", username),
-			newRoleBinding(devNS.Name, "crtadmin-view", username),
-			newRole(devNS.Name, "space-admin", username), // `space-admin` role exists, but `${USERNAME}-space-admin` rolebinding is missing
+			newRole(devNS.Name, "exec-pods", spacename),
+			newRoleBinding(devNS.Name, "crtadmin-pods", spacename),
+			newRoleBinding(devNS.Name, "crtadmin-view", spacename),
+			newRole(devNS.Name, "space-admin", spacename), // `space-admin` role exists, but `${SPACE_NAME}-space-admin` rolebinding is missing
 			stageNS,
-			newRole(stageNS.Name, "exec-pods", username),
-			newRoleBinding(stageNS.Name, "crtadmin-pods", username),
-			newRoleBinding(stageNS.Name, "crtadmin-view", username),
-			newRole(stageNS.Name, "space-admin", username))
+			newRole(stageNS.Name, "exec-pods", spacename),
+			newRoleBinding(stageNS.Name, "crtadmin-pods", spacename),
+			newRoleBinding(stageNS.Name, "crtadmin-view", spacename),
+			newRole(stageNS.Name, "space-admin", spacename))
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Provisioned()) // status was NOT changed for this particular use-case
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("exec-pods", &rbacv1.Role{}).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 			HasResource("space-admin", &rbacv1.Role{}).
-			HasResource(username+"-space-admin", &rbacv1.RoleBinding{}) // created
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+			HasResource(spacename+"-space-admin", &rbacv1.RoleBinding{}) // created
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 			HasResource("exec-pods", &rbacv1.Role{}).
 			HasResource("space-admin", &rbacv1.Role{}).
-			HasResource(username+"-space-admin", &rbacv1.RoleBinding{}) // also created
+			HasResource(spacename+"-space-admin", &rbacv1.RoleBinding{}) // also created
 	})
 
 	t.Run("should add owner label to role when missing", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage"))
-		devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		rb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		rb2 := newRoleBinding(devNS.Name, "crtadmin-view", username)
-		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-		rb2Code := newRoleBinding(stageNS.Name, "crtadmin-view", username)
-		ro := newRole(devNS.Name, "exec-pods", username)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage"))
+		devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		rb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		rb2 := newRoleBinding(devNS.Name, "crtadmin-view", spacename)
+		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+		rb2Code := newRoleBinding(stageNS.Name, "crtadmin-view", spacename)
+		ro := newRole(devNS.Name, "exec-pods", spacename)
 		delete(ro.ObjectMeta.Labels, toolchainv1alpha1.OwnerLabelKey)
-		roCode := newRole(stageNS.Name, "exec-pods", username)
+		roCode := newRole(stageNS.Name, "exec-pods", spacename)
 		delete(roCode.ObjectMeta.Labels, toolchainv1alpha1.OwnerLabelKey)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rb, rb2, ro, roCode, rbCode, rb2Code)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rb, rb2, ro, roCode, rbCode, rb2Code)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
-			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 			HasResource("exec-pods", &rbacv1.Role{})
@@ -407,43 +407,43 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
-			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
-			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, username)
+			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, spacename)
 	})
 
 	t.Run("should add owner label to rolebinding when missing", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"))
-		devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		rbDev := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev", "stage"))
+		devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		rbDev := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
 		delete(rbDev.ObjectMeta.Labels, toolchainv1alpha1.OwnerLabelKey)
 		delete(rbCode.ObjectMeta.Labels, toolchainv1alpha1.OwnerLabelKey)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rbDev, rbCode)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rbDev, rbCode)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
-			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
+			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
 
 		//second reconcile adds owner label to rolebinding in stage namespace
@@ -451,37 +451,37 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
-			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
-			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, username)
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
+			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
+			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, spacename)
 	})
 
 	t.Run("should correct the value of owner in label of rolebinding when incorrect", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"))
-		devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev", "stage"))
+		devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
 		rbDev := newRoleBinding(devNS.Name, "crtadmin-pods", "wrong-owner")
 		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", "wrong-owner")
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rbDev, rbCode)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rbDev, rbCode)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
-			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
+			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
 
 		//second reconcile adds owner label to rolebinding in stage namespace
@@ -489,43 +489,43 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
-			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
-			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, username)
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
+			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
+			ResourceHasOwnerLabel("crtadmin-pods", &rbacv1.RoleBinding{}, spacename)
 	})
 
 	t.Run("should correct the value of owner in label of role when incorrect", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage"))
-		devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		rb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		rb2 := newRoleBinding(devNS.Name, "crtadmin-view", username)
-		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-		rb2Code := newRoleBinding(stageNS.Name, "crtadmin-view", username)
-		ro := newRole(devNS.Name, "exec-pods", "wrong-username")
-		roCode := newRole(stageNS.Name, "exec-pods", "wrong-username")
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rb, rb2, ro, roCode, rbCode, rb2Code)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage"))
+		devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		rb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		rb2 := newRoleBinding(devNS.Name, "crtadmin-view", spacename)
+		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+		rb2Code := newRoleBinding(stageNS.Name, "crtadmin-view", spacename)
+		ro := newRole(devNS.Name, "exec-pods", "wrong-spacename")
+		roCode := newRole(stageNS.Name, "exec-pods", "wrong-spacename")
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rb, rb2, ro, roCode, rbCode, rb2Code)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
-			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 			HasResource("exec-pods", &rbacv1.Role{})
@@ -535,23 +535,23 @@ func TestReconcileProvisionOK(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Updating())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
-			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, username)
-		AssertThatNamespace(t, username+"-stage", fakeClient).
+			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, spacename)
+		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{}).
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
-			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, username)
+			ResourceHasOwnerLabel("exec-pods", &rbacv1.Role{}, spacename)
 	})
 
 	t.Run("no NSTemplateSet available", func(t *testing.T) {
 		// given
-		r, req, _ := prepareReconcile(t, namespaceName, username)
+		r, req, _ := prepareReconcile(t, namespaceName, spacename)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
@@ -566,7 +566,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
-	username := "john"
+	spacename := "john"
 	namespaceName := "toolchain-member"
 
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
@@ -574,8 +574,8 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 	t.Run("provision john's ClusterResourceQuota first", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
@@ -583,15 +583,15 @@ func TestProvisionTwoUsers(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev").
 			HasConditions(Provisioning())
-		AssertThatNamespace(t, username+"-dev", fakeClient).
+		AssertThatNamespace(t, spacename+"-dev", fakeClient).
 			DoesNotExist()
 		AssertThatCluster(t, fakeClient).
-			HasResource("for-"+username, &quotav1.ClusterResourceQuota{}). // created
-			HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}). // created
+			HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 		t.Run("provision john's clusterRoleBinding", func(t *testing.T) {
 			// when
@@ -600,15 +600,15 @@ func TestProvisionTwoUsers(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			assert.Equal(t, reconcile.Result{}, res)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				HasFinalizer().
 				HasSpecNamespaces("dev").
 				HasConditions(Provisioning())
-			AssertThatNamespace(t, username+"-dev", fakeClient).
+			AssertThatNamespace(t, spacename+"-dev", fakeClient).
 				DoesNotExist()
 			AssertThatCluster(t, fakeClient).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}) // created
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}) // created
 
 			t.Run("provision john's dev and stage Idlers", func(t *testing.T) {
 				// when
@@ -617,16 +617,16 @@ func TestProvisionTwoUsers(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.Equal(t, reconcile.Result{}, res)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasFinalizer().
 					HasSpecNamespaces("dev").
 					HasConditions(Provisioning())
-				AssertThatNamespace(t, username+"-dev", fakeClient).
+				AssertThatNamespace(t, spacename+"-dev", fakeClient).
 					DoesNotExist()
 				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
-					HasResource(username+"-dev", &toolchainv1alpha1.Idler{}) // created
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+					HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}) // created
 
 				// when
 				res, err = r.Reconcile(context.TODO(), req)
@@ -634,14 +634,14 @@ func TestProvisionTwoUsers(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				assert.Equal(t, reconcile.Result{}, res)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasConditions(Provisioning())
 				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
-					HasResource(username+"-dev", &toolchainv1alpha1.Idler{}).
-					HasResource(username+"-stage", &toolchainv1alpha1.Idler{}) // created
-				AssertThatNamespace(t, username+"-dev", fakeClient).DoesNotExist()
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+					HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
+					HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{}) // created
+				AssertThatNamespace(t, spacename+"-dev", fakeClient).DoesNotExist()
 
 				t.Run("provision john's dev namespace", func(t *testing.T) {
 					// when
@@ -650,17 +650,17 @@ func TestProvisionTwoUsers(t *testing.T) {
 					// then
 					require.NoError(t, err)
 					assert.Equal(t, reconcile.Result{}, res)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+					AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 						HasFinalizer().
 						HasSpecNamespaces("dev").
 						HasConditions(Provisioning())
 					AssertThatCluster(t, fakeClient).
-						HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-						HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
-						HasResource(username+"-dev", &toolchainv1alpha1.Idler{}).
-						HasResource(username+"-stage", &toolchainv1alpha1.Idler{})
-					AssertThatNamespace(t, username+"-dev", fakeClient).
-						HasLabel("toolchain.dev.openshift.com/owner", username).
+						HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+						HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+						HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
+						HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{})
+					AssertThatNamespace(t, spacename+"-dev", fakeClient).
+						HasLabel("toolchain.dev.openshift.com/owner", spacename).
 						HasLabel("toolchain.dev.openshift.com/type", "dev").
 						HasNoLabel("toolchain.dev.openshift.com/templateref"). // no label until all the namespace inner resources have been created
 						HasNoLabel("toolchain.dev.openshift.com/tier").
@@ -676,20 +676,20 @@ func TestProvisionTwoUsers(t *testing.T) {
 						// then
 						require.NoError(t, err)
 						assert.Equal(t, reconcile.Result{}, res)
-						AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+						AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 							HasFinalizer().
 							HasSpecNamespaces("dev").
 							HasConditions(Provisioning())
-						AssertThatNamespace(t, username+"-dev", fakeClient).
-							HasLabel("toolchain.dev.openshift.com/owner", username).
+						AssertThatNamespace(t, spacename+"-dev", fakeClient).
+							HasLabel("toolchain.dev.openshift.com/owner", spacename).
 							HasLabel("toolchain.dev.openshift.com/type", "dev").
 							HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde11").
 							HasLabel("toolchain.dev.openshift.com/tier", "advanced").
 							HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
 							HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
 						AssertThatCluster(t, fakeClient).
-							HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
-							HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+							HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+							HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 						t.Run("provision ClusterResourceQuota for the joe user (using cached TierTemplate)", func(t *testing.T) {
 							// given
@@ -780,7 +780,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 											HasNoLabel("toolchain.dev.openshift.com/tier").
 											HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
 										AssertThatCluster(t, fakeClient).
-											HasResource("for-"+username, &quotav1.ClusterResourceQuota{}).
+											HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
 											HasResource(joeUsername+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 										t.Run("provision inner resources of joe's dev namespace (using cached TierTemplate)", func(t *testing.T) {
@@ -823,7 +823,7 @@ func TestReconcilePromotion(t *testing.T) {
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
 
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
@@ -833,17 +833,17 @@ func TestReconcilePromotion(t *testing.T) {
 
 		t.Run("create ClusterResourceQuota", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 			// create namespace (and assume it is complete since it has the expected revision number)
-			devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"))
-			stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"))
-			devRo := newRole(devNS.Name, "exec-pods", username)
-			stageRo := newRole(stageNS.Name, "exec-pods", username)
-			devRb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-			devRb2 := newRoleBinding(devNS.Name, "crtadmin-view", username)
-			stageRb := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-			stageRb2 := newRoleBinding(stageNS.Name, "crtadmin-view", username)
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, devRo, stageRo, devRb, devRb2, stageRb, stageRb2)
+			devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+			stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+			devRo := newRole(devNS.Name, "exec-pods", spacename)
+			stageRo := newRole(stageNS.Name, "exec-pods", spacename)
+			devRb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+			devRb2 := newRoleBinding(devNS.Name, "crtadmin-view", spacename)
+			stageRb := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+			stageRb2 := newRoleBinding(stageNS.Name, "crtadmin-view", spacename)
+			r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, devRo, stageRo, devRb, devRb2, stageRb, stageRb2)
 
 			err := fakeClient.Update(context.TODO(), nsTmplSet)
 			require.NoError(t, err)
@@ -853,19 +853,19 @@ func TestReconcilePromotion(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, fakeClient).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced")). // upgraded
-				HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
 			for _, nsType := range []string{"stage", "dev"} {
-				AssertThatNamespace(t, username+"-"+nsType, r.Client).
+				AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
+					HasLabel("toolchain.dev.openshift.com/owner", spacename).
 					HasLabel("toolchain.dev.openshift.com/templateref", "basic-"+nsType+"-abcde11"). // not upgraded yet
 					HasLabel("toolchain.dev.openshift.com/tier", "basic").
 					HasLabel("toolchain.dev.openshift.com/type", nsType).
@@ -879,19 +879,19 @@ func TestReconcilePromotion(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasFinalizer().
 					HasConditions(Updating())
 				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 						WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-					HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 				for _, nsType := range []string{"stage", "dev"} {
-					AssertThatNamespace(t, username+"-"+nsType, r.Client).
+					AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 						HasNoOwnerReference().
 						HasLabel("toolchain.dev.openshift.com/templateref", "basic-"+nsType+"-abcde11"). // not upgraded yet
-						HasLabel("toolchain.dev.openshift.com/owner", username).
+						HasLabel("toolchain.dev.openshift.com/owner", spacename).
 						HasLabel("toolchain.dev.openshift.com/tier", "basic"). // not upgraded yet
 						HasLabel("toolchain.dev.openshift.com/type", nsType).
 						HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
@@ -904,7 +904,7 @@ func TestReconcilePromotion(t *testing.T) {
 					// then
 					require.NoError(t, err)
 					AssertThatCluster(t, fakeClient).
-						HasResource(username+"-dev", &toolchainv1alpha1.Idler{},
+						HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{},
 							WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 							WithLabel("toolchain.dev.openshift.com/tier", "advanced")) // created
 
@@ -912,12 +912,12 @@ func TestReconcilePromotion(t *testing.T) {
 					_, err = r.Reconcile(context.TODO(), req)
 					// then
 					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+					AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 						HasFinalizer().
 						HasConditions(Updating())
 					AssertThatCluster(t, fakeClient).
-						HasResource(username+"-dev", &toolchainv1alpha1.Idler{}). // still exists (no need to check again the labels)
-						HasResource(username+"-stage", &toolchainv1alpha1.Idler{},
+						HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}). // still exists (no need to check again the labels)
+						HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{},
 							WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 							WithLabel("toolchain.dev.openshift.com/tier", "advanced")) // created
 
@@ -928,18 +928,18 @@ func TestReconcilePromotion(t *testing.T) {
 
 						// then
 						require.NoError(t, err)
-						AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+						AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 							HasFinalizer().
 							HasConditions(Updating())
 						AssertThatCluster(t, fakeClient).
-							HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+							HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 								WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 								WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 						AssertThatNamespace(t, stageNS.Name, r.Client).
 							DoesNotExist() // namespace was deleted
 						AssertThatNamespace(t, devNS.Name, r.Client).
 							HasNoOwnerReference().
-							HasLabel("toolchain.dev.openshift.com/owner", username).
+							HasLabel("toolchain.dev.openshift.com/owner", spacename).
 							HasLabel("toolchain.dev.openshift.com/templateref", "basic-dev-abcde11").
 							HasLabel("toolchain.dev.openshift.com/type", "dev").
 							HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
@@ -952,18 +952,18 @@ func TestReconcilePromotion(t *testing.T) {
 							// then
 							require.NoError(t, err)
 							// NSTemplateSet provisioning is complete
-							AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+							AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 								HasFinalizer().
 								HasConditions(Updating())
 							AssertThatCluster(t, fakeClient).
-								HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+								HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 									WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 									WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 							AssertThatNamespace(t, stageNS.Name, r.Client).
 								DoesNotExist()
-							AssertThatNamespace(t, username+"-dev", r.Client).
+							AssertThatNamespace(t, spacename+"-dev", r.Client).
 								HasNoOwnerReference().
-								HasLabel("toolchain.dev.openshift.com/owner", username).
+								HasLabel("toolchain.dev.openshift.com/owner", spacename).
 								HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde11").
 								HasLabel("toolchain.dev.openshift.com/tier", "advanced").
 								HasLabel("toolchain.dev.openshift.com/type", "dev").
@@ -982,16 +982,16 @@ func TestReconcilePromotion(t *testing.T) {
 								// then
 								require.NoError(t, err)
 								// NSTemplateSet provisioning is complete
-								AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+								AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 									HasFinalizer().
 									HasConditions(Provisioned())
 								AssertThatCluster(t, fakeClient).
-									HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+									HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 										WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
-								AssertThatNamespace(t, username+"-dev", r.Client).
+								AssertThatNamespace(t, spacename+"-dev", r.Client).
 									HasNoOwnerReference().
 									HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde11").
-									HasLabel("toolchain.dev.openshift.com/owner", username).
+									HasLabel("toolchain.dev.openshift.com/owner", spacename).
 									HasLabel("toolchain.dev.openshift.com/tier", "advanced"). // not updgraded yet
 									HasLabel("toolchain.dev.openshift.com/type", "dev").
 									HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
@@ -1009,7 +1009,7 @@ func TestReconcileUpdate(t *testing.T) {
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
 
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
@@ -1019,21 +1019,21 @@ func TestReconcileUpdate(t *testing.T) {
 
 		t.Run("update ClusterResourceQuota", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde12", "dev"), withClusterResources("abcde12"))
+			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde12", "dev"), withClusterResources("abcde12"))
 
-			devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-			devRo := newRole(devNS.Name, "exec-pods", username)
-			devRb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-			devRbacRb := newRoleBinding(devNS.Name, "crtadmin-view", username)
+			devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+			devRo := newRole(devNS.Name, "exec-pods", spacename)
+			devRb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+			devRbacRb := newRoleBinding(devNS.Name, "crtadmin-view", spacename)
 
-			stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
-			stageRo := newRole(stageNS.Name, "exec-pods", username)
-			stageRb := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-			stageRbacRb := newRoleBinding(stageNS.Name, "crtadmin-view", username)
+			stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+			stageRo := newRole(stageNS.Name, "exec-pods", spacename)
+			stageRb := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+			stageRbacRb := newRoleBinding(stageNS.Name, "crtadmin-view", spacename)
 
-			crb := newTektonClusterRoleBinding(username, "advanced")
-			crq := newClusterResourceQuota(username, "advanced")
-			r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet,
+			crb := newTektonClusterRoleBinding(spacename, "advanced")
+			crq := newClusterResourceQuota(spacename, "advanced")
+			r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet,
 				devNS, devRo, devRb, devRbacRb, stageNS, stageRo, stageRb, stageRbacRb, crq, crb)
 
 			err := fakeClient.Update(context.TODO(), nsTmplSet)
@@ -1044,21 +1044,21 @@ func TestReconcileUpdate(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, fakeClient).
-				HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced")). // upgraded
-				HasResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
 					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
 
 			for _, nsType := range []string{"stage", "dev"} {
-				AssertThatNamespace(t, username+"-"+nsType, r.Client).
+				AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 					HasNoOwnerReference().
-					HasLabel("toolchain.dev.openshift.com/owner", username).
+					HasLabel("toolchain.dev.openshift.com/owner", spacename).
 					HasLabel("toolchain.dev.openshift.com/templateref", "advanced-"+nsType+"-abcde11"). // not upgraded yet
 					HasLabel("toolchain.dev.openshift.com/tier", "advanced").
 					HasLabel("toolchain.dev.openshift.com/type", nsType).
@@ -1074,18 +1074,18 @@ func TestReconcileUpdate(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasFinalizer().
 					HasConditions(Updating())
 				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 														WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12"),
 														WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-					HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{}) // deleted
+					HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}) // deleted
 				for _, nsType := range []string{"stage", "dev"} {
-					AssertThatNamespace(t, username+"-"+nsType, r.Client).
+					AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 						HasNoOwnerReference().
-						HasLabel("toolchain.dev.openshift.com/owner", username).
+						HasLabel("toolchain.dev.openshift.com/owner", spacename).
 						HasLabel("toolchain.dev.openshift.com/templateref", "advanced-"+nsType+"-abcde11"). // not upgraded yet
 						HasLabel("toolchain.dev.openshift.com/tier", "advanced").
 						HasLabel("toolchain.dev.openshift.com/type", nsType).
@@ -1102,19 +1102,19 @@ func TestReconcileUpdate(t *testing.T) {
 
 					// then
 					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+					AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 						HasFinalizer().
 						HasConditions(Updating())
 					AssertThatCluster(t, fakeClient).
-						HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+						HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 							WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12"),
 							WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-						HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+						HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 					AssertThatNamespace(t, stageNS.Name, r.Client).
 						DoesNotExist() // namespace was deleted
 					AssertThatNamespace(t, devNS.Name, r.Client).
 						HasNoOwnerReference().
-						HasLabel("toolchain.dev.openshift.com/owner", username).
+						HasLabel("toolchain.dev.openshift.com/owner", spacename).
 						HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde11"). // not upgraded yet
 						HasLabel("toolchain.dev.openshift.com/type", "dev").
 						HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
@@ -1130,19 +1130,19 @@ func TestReconcileUpdate(t *testing.T) {
 						// then
 						require.NoError(t, err)
 						// NSTemplateSet provisioning is complete
-						AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+						AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 							HasFinalizer().
 							HasConditions(Updating())
 						AssertThatCluster(t, fakeClient).
-							HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+							HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 								WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12"),
 								WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-							HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+							HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 						AssertThatNamespace(t, stageNS.Name, r.Client).
 							DoesNotExist()
 						AssertThatNamespace(t, devNS.Name, r.Client).
 							HasNoOwnerReference().
-							HasLabel("toolchain.dev.openshift.com/owner", username).
+							HasLabel("toolchain.dev.openshift.com/owner", spacename).
 							HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde12"). // upgraded
 							HasLabel("toolchain.dev.openshift.com/type", "dev").
 							HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
@@ -1161,19 +1161,19 @@ func TestReconcileUpdate(t *testing.T) {
 							// then
 							require.NoError(t, err)
 							// NSTemplateSet provisioning is complete
-							AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+							AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 								HasFinalizer().
 								HasConditions(Provisioned())
 							AssertThatCluster(t, fakeClient).
-								HasResource("for-"+username, &quotav1.ClusterResourceQuota{},
+								HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
 									WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12"),
 									WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-								HasNoResource(username+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+								HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 							AssertThatNamespace(t, stageNS.Name, r.Client).
 								DoesNotExist()
 							AssertThatNamespace(t, devNS.Name, r.Client).
 								HasNoOwnerReference().
-								HasLabel("toolchain.dev.openshift.com/owner", username).
+								HasLabel("toolchain.dev.openshift.com/owner", spacename).
 								HasLabel("toolchain.dev.openshift.com/templateref", "advanced-dev-abcde12"). // upgraded
 								HasLabel("toolchain.dev.openshift.com/type", "dev").
 								HasLabel("toolchain.dev.openshift.com/provider", "codeready-toolchain").
@@ -1193,12 +1193,12 @@ func TestReconcileProvisionFail(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	// given
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
 
 	t.Run("fail to get nstmplset", func(t *testing.T) {
 		// given
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename)
 		fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			return errors.New("unable to get NSTemplate")
 		}
@@ -1214,8 +1214,8 @@ func TestReconcileProvisionFail(t *testing.T) {
 
 	t.Run("fail to update status", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"))
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev", "stage"))
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet)
 		fakeClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 			return errors.New("unable to update status")
 		}
@@ -1227,7 +1227,7 @@ func TestReconcileProvisionFail(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to update status")
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasNoConditions() // since we're unable to update the status
 	})
@@ -1235,7 +1235,7 @@ func TestReconcileProvisionFail(t *testing.T) {
 	t.Run("no namespace", func(t *testing.T) {
 		// given
 		r, _ := prepareController(t)
-		req := newReconcileRequest("", username)
+		req := newReconcileRequest("", spacename)
 
 		// when
 		res, err := r.Reconcile(context.TODO(), req)
@@ -1250,12 +1250,12 @@ func TestReconcileProvisionFail(t *testing.T) {
 		// given
 		restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
 		t.Cleanup(restore)
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withNamespaces("abcde11", "dev", "stage"))
-		devNS := newNamespace("basic", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("basic", username, "stage", withTemplateRefUsingRevision("abcde11"))
-		rb := newRoleBinding(devNS.Name, "crtadmin-pods", username)
-		rb2 := newRoleBinding(stageNS.Name, "crtadmin-pods", username)
-		r, req, fakeClient := prepareReconcile(t, namespaceName, username, nsTmplSet, devNS, stageNS, rb, rb2)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev", "stage"))
+		devNS := newNamespace("basic", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
+		rb := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
+		rb2 := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
+		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rb, rb2)
 		fakeClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 			if nsTmpl, ok := obj.(*toolchainv1alpha1.NSTemplateSet); ok {
 				if len(nsTmpl.Status.ProvisionedNamespaces) > 0 {
@@ -1271,7 +1271,7 @@ func TestReconcileProvisionFail(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to update provisioned namespaces list")
 		assert.Equal(t, reconcile.Result{}, res)
-		AssertThatNSTemplateSet(t, namespaceName, username, fakeClient).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasNoConditions().
 			HasNoProvisionedNamespaces() // since we're unable to update the provisioned namespaces in status
@@ -1279,17 +1279,17 @@ func TestReconcileProvisionFail(t *testing.T) {
 }
 
 func TestDeleteNSTemplateSet(t *testing.T) {
-	username := "johnsmith"
+	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
 
 	t.Run("with cluster resources and 2 user namespaces to delete", func(t *testing.T) {
 		// given an NSTemplateSet resource and 2 active user namespaces ("dev" and "stage")
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage"), withDeletionTs(), withClusterResources("abcde11"))
-		crq := newClusterResourceQuota(username, "advanced")
-		devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage"), withDeletionTs(), withClusterResources("abcde11"))
+		crq := newClusterResourceQuota(spacename, "advanced")
+		devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
 		r, _ := prepareController(t, nsTmplSet, crq, devNS, stageNS)
-		req := newReconcileRequest(namespaceName, username)
+		req := newReconcileRequest(namespaceName, spacename)
 
 		t.Run("reconcile after nstemplateset deletion triggers deletion of the first namespace", func(t *testing.T) {
 			// when a first reconcile loop was triggered (because a cluster resource quota was deleted)
@@ -1298,10 +1298,10 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			// get the first namespace and check its deletion timestamp
-			firstNSName := fmt.Sprintf("%s-dev", username)
+			firstNSName := fmt.Sprintf("%s-dev", spacename)
 			AssertThatNamespace(t, firstNSName, r.Client).DoesNotExist()
 			// get the NSTemplateSet resource again and check its status
-			AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+			AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 				HasFinalizer(). // the finalizer should NOT have been removed yet
 				HasConditions(Terminating())
 
@@ -1312,10 +1312,10 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				// get the second namespace and check its deletion timestamp
-				secondtNSName := fmt.Sprintf("%s-dev", username)
+				secondtNSName := fmt.Sprintf("%s-dev", spacename)
 				AssertThatNamespace(t, secondtNSName, r.Client).DoesNotExist()
 				// get the NSTemplateSet resource again and check its finalizers and status
-				AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+				AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 					HasFinalizer(). // the finalizer should not have been removed either
 					HasConditions(Terminating())
 
@@ -1325,11 +1325,11 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 
 					// then
 					require.NoError(t, err)
-					AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+					AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 						HasFinalizer(). // the finalizer should NOT have been removed yet
 						HasConditions(Terminating())
 					AssertThatCluster(t, r.Client).
-						HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{}) // resource was deleted
+						HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}) // resource was deleted
 
 					t.Run("reconcile after cluster resource quota deletion triggers removal of the finalizer and thus successful deletion", func(t *testing.T) {
 						// given - when host cluster is not ready, then it should use the cache
@@ -1341,9 +1341,9 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 						// then
 						require.NoError(t, err)
 						// get the NSTemplateSet resource again and check its finalizers and status
-						AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+						AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 							DoesNotExist()
-						AssertThatCluster(t, r.Client).HasNoResource("for-"+username, &quotav1.ClusterResourceQuota{})
+						AssertThatCluster(t, r.Client).HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{})
 					})
 				})
 			})
@@ -1351,10 +1351,10 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 	})
 
 	t.Run("failed to delete cluster resources", func(t *testing.T) {
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withDeletionTs(), withClusterResources("abcde11"))
-		crq := newClusterResourceQuota(username, "advanced")
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withDeletionTs(), withClusterResources("abcde11"))
+		crq := newClusterResourceQuota(spacename, "advanced")
 		r, fakeClient := prepareController(t, nsTmplSet, crq)
-		req := newReconcileRequest(namespaceName, username)
+		req := newReconcileRequest(namespaceName, spacename)
 
 		// only add deletion timestamp, but not delete
 		fakeClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
@@ -1374,27 +1374,27 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 
 	t.Run("delete when there is no finalizer", func(t *testing.T) {
 		// given an NSTemplateSet resource which is being deleted and whose finalizer was already removed
-		nsTmplSet := newNSTmplSet(namespaceName, username, "basic", withoutFinalizer(), withDeletionTs(), withClusterResources("abcde11"), withNamespaces("abcde11", "dev", "stage"))
-		r, req, _ := prepareReconcile(t, namespaceName, username, nsTmplSet)
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withoutFinalizer(), withDeletionTs(), withClusterResources("abcde11"), withNamespaces("abcde11", "dev", "stage"))
+		r, req, _ := prepareReconcile(t, namespaceName, spacename, nsTmplSet)
 
 		// when a reconcile loop is triggered
 		_, err := r.Reconcile(context.TODO(), req)
 
 		// then
 		require.NoError(t, err)
-		AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 			DoesNotHaveFinalizer() // finalizer was not added and nothing else was done
 	})
 
 	t.Run("NSTemplateSet not deleted until namespace is deleted", func(t *testing.T) {
 		// given an NSTemplateSet resource and 1 active user namespaces ("dev")
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage"), withDeletionTs(), withClusterResources("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage"), withDeletionTs(), withClusterResources("abcde11"))
 		nsTmplSet.SetDeletionTimestamp(&metav1.Time{Time: time.Now().Add(-61 * time.Second)})
-		devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
+		devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
 
 		r, fakeClient := prepareController(t, nsTmplSet, devNS, stageNS)
-		req := newReconcileRequest(namespaceName, username)
+		req := newReconcileRequest(namespaceName, spacename)
 
 		// only add deletion timestamp, but not delete
 		fakeClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
@@ -1416,12 +1416,12 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 
 	t.Run("NSTemplateSet not deleted until namespace is deleted", func(t *testing.T) {
 		// given an NSTemplateSet resource and 1 active user namespaces ("dev")
-		nsTmplSet := newNSTmplSet(namespaceName, username, "advanced", withNamespaces("abcde11", "dev", "stage"), withDeletionTs(), withClusterResources("abcde11"))
-		devNS := newNamespace("advanced", username, "dev", withTemplateRefUsingRevision("abcde11"))
-		stageNS := newNamespace("advanced", username, "stage", withTemplateRefUsingRevision("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "stage"), withDeletionTs(), withClusterResources("abcde11"))
+		devNS := newNamespace("advanced", spacename, "dev", withTemplateRefUsingRevision("abcde11"))
+		stageNS := newNamespace("advanced", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
 
 		r, fakeClient := prepareController(t, nsTmplSet, devNS, stageNS)
-		req := newReconcileRequest(namespaceName, username)
+		req := newReconcileRequest(namespaceName, spacename)
 
 		// only add deletion timestamp, but not delete
 		fakeClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
@@ -1451,14 +1451,14 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		require.True(t, result.Requeue)
 		require.Equal(t, time.Second, result.RequeueAfter)
 
-		firstNSName := fmt.Sprintf("%s-dev", username)
-		secondNSName := fmt.Sprintf("%s-stage", username)
+		firstNSName := fmt.Sprintf("%s-dev", spacename)
+		secondNSName := fmt.Sprintf("%s-stage", spacename)
 		// get the first namespace and check that it has deletion timestamp
 		AssertThatNamespace(t, firstNSName, r.Client).HasDeletionTimestamp()
 		//second NS is not affected
 		AssertThatNamespace(t, secondNSName, r.Client).HasNoDeletionTimestamp()
 		// get the NSTemplateSet resource again, check it is not deleted and its status
-		AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 			HasFinalizer().
 			HasConditions(Terminating())
 
@@ -1471,7 +1471,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		AssertThatNamespace(t, firstNSName, r.Client).HasDeletionTimestamp()
 		AssertThatNamespace(t, secondNSName, r.Client).HasNoDeletionTimestamp()
 		// get the NSTemplateSet resource again, check it is not deleted and its status
-		AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 			HasFinalizer().
 			HasConditions(Terminating())
 
@@ -1495,7 +1495,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		AssertThatNamespace(t, firstNSName, r.Client).DoesNotExist()
 
 		// Check that nsTemplateSet still has finalizer
-		AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 			HasFinalizer().HasConditions(Terminating())
 
 		// deletion of secondNS would trigger another reconcile
@@ -1505,7 +1505,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 
 		AssertThatNamespace(t, secondNSName, r.Client).DoesNotExist()
 		// Check that nsTemplateSet is gone as well
-		AssertThatNSTemplateSet(t, namespaceName, username, r.Client).
+		AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 			DoesNotExist()
 
 	})
@@ -1708,7 +1708,7 @@ func newRole(namespace, name, owner string) *rbacv1.Role { //nolint: unparam
 	}
 }
 
-func newTektonClusterRoleBinding(username, tier string) *rbacv1.ClusterRoleBinding {
+func newTektonClusterRoleBinding(spacename, tier string) *rbacv1.ClusterRoleBinding {
 	crb := &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",
@@ -1719,26 +1719,26 @@ func newTektonClusterRoleBinding(username, tier string) *rbacv1.ClusterRoleBindi
 				"toolchain.dev.openshift.com/provider":    "codeready-toolchain",
 				"toolchain.dev.openshift.com/tier":        tier,
 				"toolchain.dev.openshift.com/templateref": NewTierTemplateName(tier, "clusterresources", "abcde11"),
-				"toolchain.dev.openshift.com/owner":       username,
+				"toolchain.dev.openshift.com/owner":       spacename,
 				"toolchain.dev.openshift.com/type":        "clusterresources",
 			},
-			Name:       username + "-tekton-view",
+			Name:       spacename + "-tekton-view",
 			Generation: int64(1),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "tekton-view-for-" + username,
+			Name:     "tekton-view-for-" + spacename,
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind: "User",
-			Name: username,
+			Name: spacename,
 		}},
 	}
 	return crb
 }
 
-func newClusterResourceQuota(username, tier string, options ...objectMetaOption) *quotav1.ClusterResourceQuota {
+func newClusterResourceQuota(spacename, tier string, options ...objectMetaOption) *quotav1.ClusterResourceQuota {
 	crq := &quotav1.ClusterResourceQuota{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterResourceQuota",
@@ -1749,11 +1749,11 @@ func newClusterResourceQuota(username, tier string, options ...objectMetaOption)
 				"toolchain.dev.openshift.com/provider":    "codeready-toolchain",
 				"toolchain.dev.openshift.com/tier":        tier,
 				"toolchain.dev.openshift.com/templateref": NewTierTemplateName(tier, "clusterresources", "abcde11"),
-				"toolchain.dev.openshift.com/owner":       username,
+				"toolchain.dev.openshift.com/owner":       spacename,
 				"toolchain.dev.openshift.com/type":        "clusterresources",
 			},
 			Annotations: map[string]string{},
-			Name:        "for-" + username,
+			Name:        "for-" + spacename,
 			Generation:  int64(1),
 		},
 		Spec: quotav1.ClusterResourceQuotaSpec{
@@ -1765,7 +1765,7 @@ func newClusterResourceQuota(username, tier string, options ...objectMetaOption)
 			},
 			Selector: quotav1.ClusterResourceQuotaSelector{
 				AnnotationSelector: map[string]string{
-					"openshift.io/requester": username,
+					"openshift.io/requester": spacename,
 				},
 			},
 		},
@@ -1776,7 +1776,7 @@ func newClusterResourceQuota(username, tier string, options ...objectMetaOption)
 	return crq
 }
 
-func newIdler(username, name, tierName string) *toolchainv1alpha1.Idler { // nolint
+func newIdler(spacename, name, tierName string) *toolchainv1alpha1.Idler { // nolint
 	idler := &toolchainv1alpha1.Idler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Idler",
@@ -1787,7 +1787,7 @@ func newIdler(username, name, tierName string) *toolchainv1alpha1.Idler { // nol
 				"toolchain.dev.openshift.com/provider":    "codeready-toolchain",
 				"toolchain.dev.openshift.com/tier":        tierName,
 				"toolchain.dev.openshift.com/templateref": NewTierTemplateName(tierName, "clusterresources", "abcde11"),
-				"toolchain.dev.openshift.com/owner":       username,
+				"toolchain.dev.openshift.com/owner":       spacename,
 				"toolchain.dev.openshift.com/type":        "clusterresources",
 			},
 			Name:       name,
@@ -1836,16 +1836,16 @@ func prepareTemplateTiers(decoder runtime.Decoder) ([]runtime.Object, error) {
 	tmpls := map[string]map[string]map[string]string{
 		"advanced": {
 			"clusterresources": {
-				"abcde11": test.CreateTemplate(test.WithObjects(advancedCrq, clusterTektonRb, idlerDev, idlerStage), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(advancedCrq), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(advancedCrq, clusterTektonRb, idlerDev, idlerStage), test.WithParams(spacename, username)),
+				"abcde12": test.CreateTemplate(test.WithObjects(advancedCrq), test.WithParams(spacename)),
 			},
 			"dev": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(spacename)),
 			},
 			"stage": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(spacename)),
 			},
 			"admin": { // space roles
 				"abcde11": test.CreateTemplate(test.WithObjects(spaceAdmin, spaceAdminRb), test.WithParams(namespace, username)),
@@ -1854,13 +1854,13 @@ func prepareTemplateTiers(decoder runtime.Decoder) ([]runtime.Object, error) {
 		"basic": {
 			// no clusterresources
 			"dev": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(username)),
-				"abcde13": test.CreateTemplate(test.WithObjects(nsWithArgoLabel, crtAdminRb), test.WithParams(username)), // ns label change
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(spacename)),
+				"abcde13": test.CreateTemplate(test.WithObjects(nsWithArgoLabel, crtAdminRb), test.WithParams(spacename)), // ns label change
 			},
 			"stage": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb), test.WithParams(spacename)),
 			},
 			"admin": { // space roles
 				"abcde11": test.CreateTemplate(test.WithObjects(spaceAdmin, spaceAdminRb), test.WithParams(namespace, username)),
@@ -1868,16 +1868,16 @@ func prepareTemplateTiers(decoder runtime.Decoder) ([]runtime.Object, error) {
 		},
 		"team": {
 			"clusterresources": {
-				"abcde11": test.CreateTemplate(test.WithObjects(teamCrq, clusterTektonRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(teamCrq, clusterTektonRb), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(teamCrq, clusterTektonRb), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(teamCrq, clusterTektonRb), test.WithParams(spacename)),
 			},
 			"dev": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(spacename)),
 			},
 			"stage": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(spacename)),
 			},
 			"admin": { // space roles
 				"abcde11": test.CreateTemplate(test.WithObjects(spaceAdmin, spaceAdminRb), test.WithParams(namespace, username)),
@@ -1885,16 +1885,16 @@ func prepareTemplateTiers(decoder runtime.Decoder) ([]runtime.Object, error) {
 		},
 		"withemptycrq": {
 			"clusterresources": {
-				"abcde11": test.CreateTemplate(test.WithObjects(advancedCrq, emptyCrq, clusterTektonRb), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(advancedCrq, emptyCrq, clusterTektonRb), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(advancedCrq, emptyCrq, clusterTektonRb), test.WithParams(spacename, username)),
+				"abcde12": test.CreateTemplate(test.WithObjects(advancedCrq, emptyCrq, clusterTektonRb), test.WithParams(spacename, username)),
 			},
 			"dev": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(spacename)),
 			},
 			"stage": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(username)),
-				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(spacename)),
+				"abcde12": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole), test.WithParams(spacename)),
 			},
 			"admin": { // space roles
 				"abcde11": test.CreateTemplate(test.WithObjects(spaceAdmin, spaceAdminRb), test.WithParams(namespace, username)),
@@ -1902,10 +1902,10 @@ func prepareTemplateTiers(decoder runtime.Decoder) ([]runtime.Object, error) {
 		},
 		"appstudio": {
 			"clusterresources": {
-				"abcde11": test.CreateTemplate(test.WithObjects(advancedCrq, clusterTektonRb, idlerDev, idlerStage), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(advancedCrq, clusterTektonRb, idlerDev, idlerStage), test.WithParams(spacename, username)),
 			},
 			"appstudio": {
-				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(username)),
+				"abcde11": test.CreateTemplate(test.WithObjects(ns, crtAdminRb, execPodsRole, crtAdminViewRb), test.WithParams(spacename)),
 			},
 			"admin": { // space roles
 				"abcde11": test.CreateTemplate(test.WithObjects(spaceAdmin, spaceAdminRb), test.WithParams(namespace, username)),
@@ -1955,14 +1955,14 @@ var (
 - apiVersion: v1
   kind: Namespace
   metadata:
-    name: ${USERNAME}-NSTYPE
+    name: ${SPACE_NAME}-NSTYPE
 `
 
 	nsWithArgoLabel test.TemplateObject = `
 - apiVersion: v1
   kind: Namespace
   metadata:
-    name: ${USERNAME}-NSTYPE
+    name: ${SPACE_NAME}-NSTYPE
     labels:
       argocd.argoproj.io/managed-by: gitops-service-argocd
 `
@@ -1972,7 +1972,7 @@ var (
   kind: Role
   metadata:
     name: exec-pods
-    namespace: ${USERNAME}-NSTYPE
+    namespace: ${SPACE_NAME}-NSTYPE
   rules:
   - apiGroups:
     - ""
@@ -1991,7 +1991,7 @@ var (
   kind: RoleBinding
   metadata:
     name: crtadmin-pods
-    namespace: ${USERNAME}-NSTYPE
+    namespace: ${SPACE_NAME}-NSTYPE
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
@@ -2006,7 +2006,7 @@ var (
   kind: RoleBinding
   metadata:
     name: crtadmin-view
-    namespace: ${USERNAME}-dev
+    namespace: ${SPACE_NAME}-dev
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
@@ -2020,6 +2020,9 @@ var (
 	namespace test.TemplateParam = `
 - name: NAMESPACE
   required: true`
+	spacename test.TemplateParam = `
+- name: SPACE_NAME
+  value: johnsmith`
 	username test.TemplateParam = `
 - name: USERNAME
   value: johnsmith`
@@ -2028,7 +2031,7 @@ var (
 - apiVersion: quota.openshift.io/v1
   kind: ClusterResourceQuota
   metadata:
-    name: for-${USERNAME}
+    name: for-${SPACE_NAME}
   spec:
     quota:
       hard:
@@ -2036,14 +2039,14 @@ var (
         limits.memory: 10Gi
     selector:
       annotations:
-        openshift.io/requester: ${USERNAME}
+        openshift.io/requester: ${SPACE_NAME}
     labels: null
   `
 	teamCrq test.TemplateObject = `
 - apiVersion: quota.openshift.io/v1
   kind: ClusterResourceQuota
   metadata:
-    name: for-${USERNAME}
+    name: for-${SPACE_NAME}
   spec:
     quota:
       hard:
@@ -2051,7 +2054,7 @@ var (
         limits.memory: 15Gi
     selector:
       annotations:
-        openshift.io/requester: ${USERNAME}
+        openshift.io/requester: ${SPACE_NAME}
     labels: null
   `
 
@@ -2067,11 +2070,11 @@ var (
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
-    name: ${USERNAME}-tekton-view
+    name: ${SPACE_NAME}-tekton-view
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: tekton-view-for-${USERNAME}
+    name: tekton-view-for-${SPACE_NAME}
   subjects:
     - kind: User
       name: ${USERNAME}
@@ -2080,7 +2083,7 @@ var (
 - apiVersion: toolchain.dev.openshift.com/v1alpha1
   kind: Idler
   metadata:
-    name: ${USERNAME}-dev
+    name: ${SPACE_NAME}-dev
   spec:
     timeoutSeconds: 28800 # 8 hours
   `
@@ -2088,7 +2091,7 @@ var (
 - apiVersion: toolchain.dev.openshift.com/v1alpha1
   kind: Idler
   metadata:
-    name: ${USERNAME}-stage
+    name: ${SPACE_NAME}-stage
   spec:
     timeoutSeconds: 28800 # 8 hours
   `

--- a/controllers/nstemplateset/nstemplatetier_test.go
+++ b/controllers/nstemplateset/nstemplatetier_test.go
@@ -56,12 +56,12 @@ objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    name: ${USERNAME}
+    name: ${SPACE_NAME}
     namespace: ${MEMBER_OPERATOR_NAMESPACE}
   data:
     test: test
 parameters:
-- name: USERNAME
+- name: SPACE_NAME
   required: true
 - name: MEMBER_OPERATOR_NAMESPACE
   required: true
@@ -77,7 +77,6 @@ parameters:
 
 	// when
 	obj, err := tierTemplate.process(s, map[string]string{
-		Username:  "johnsmith",
 		SpaceName: "johnsmith",
 	})
 

--- a/controllers/nstemplateset/space_roles.go
+++ b/controllers/nstemplateset/space_roles.go
@@ -109,7 +109,6 @@ func (r *spaceRolesManager) getSpaceRolesObjects(ns *corev1.Namespace, spaceRole
 			objs, err := tierTemplate.process(r.Scheme, map[string]string{
 				Namespace: ns.Name,
 				Username:  username,
-				SpaceName: username,
 			})
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to process space roles template '%s' for the user '%s' in namespace '%s'", spaceRole.TemplateRef, username, ns.Name)


### PR DESCRIPTION
This is part of the work to revisit/rename the parameters in the NSTemplateTier templates.

Jira: https://issues.redhat.com/browse/CRT-1766

This is third and last PR for renaming USERNAME parameter into SPACE_NAME.

List of all PRs required for the renaming process: 
member-operator - Introduce the usage of the new parameter SPACE_NAME along with the existing one USERNAME (merged see https://github.com/codeready-toolchain/member-operator/pull/432)
host-operator -  Rename USERNAME with SPACE_NAME (merged see https://github.com/codeready-toolchain/host-operator/pull/801)
member-operator - (current one) Remove/replace usage of USERNAME in favor of SPACE_NAME
As mentioned, this PR is for 3rd point.