### PR TITLE
Rename pipelines-scc to appstudio-pipelines-scc 1/2

### DIFF
--- a/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
+++ b/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
@@ -48,6 +48,7 @@ rules:
   resourceNames:
   - csi-scc
   - pipelines-scc
+  - appstudio-pipelines-scc
   resources:
   - securitycontextconstraints
   verbs:


### PR DESCRIPTION
The name is conflicting with the SCC created by OSP, and triggered the RHTAPBUGS-304 issue.

This PR prepares the migration to the new SCC name. Another PR will be submitted to deprecate the old name once the new SCC is deployed on all environments.