### PR TITLE
Rename pipelines-scc to appstudio-pipelines-scc 2/2

### DIFF
--- a/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
+++ b/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
@@ -47,7 +47,6 @@ rules:
   - security.openshift.io
   resourceNames:
   - csi-scc
-  - pipelines-scc
   - appstudio-pipelines-scc
   resources:
   - securitycontextconstraints


### PR DESCRIPTION
The name is conflicting with the SCC created by OSP, and triggered the RHTAPBUGS-304 issue.

This PR deprecates the old SCC name.