### PR TITLE
fix: drop toolchainv1alpha1.OwnerLabelKey label

### DIFF
--- a/controllers/nstemplateset/client_test.go
+++ b/controllers/nstemplateset/client_test.go
@@ -224,7 +224,6 @@ func newOptionalDeployment(name, owner string) *appsv1.Deployment {
 			Name: name,
 			Labels: map[string]string{
 				toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
-				toolchainv1alpha1.OwnerLabelKey:    owner,
 				toolchainv1alpha1.SpaceLabelKey:    owner,
 			},
 			Annotations: map[string]string{

--- a/controllers/nstemplateset/cluster_resources.go
+++ b/controllers/nstemplateset/cluster_resources.go
@@ -176,7 +176,6 @@ func (r *clusterResourcesManager) ensure(logger logr.Logger, nsTmplSet *toolchai
 // but if there was an error then it returns 'false, error'.
 func (r *clusterResourcesManager) apply(logger logr.Logger, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate, object runtimeclient.Object) (bool, error) {
 	var labels = map[string]string{
-		toolchainv1alpha1.OwnerLabelKey:       nsTmplSet.GetName(),
 		toolchainv1alpha1.SpaceLabelKey:       nsTmplSet.GetName(),
 		toolchainv1alpha1.TypeLabelKey:        toolchainv1alpha1.ClusterResourcesTemplateType,
 		toolchainv1alpha1.TemplateRefLabelKey: tierTemplate.templateRef,

--- a/controllers/nstemplateset/cluster_resources_test.go
+++ b/controllers/nstemplateset/cluster_resources_test.go
@@ -37,7 +37,7 @@ func TestClusterResourceKinds(t *testing.T) {
 		johnyRuntimeObject := clusterResourceKind.object.DeepCopyObject()
 		johnyObject, ok := johnyRuntimeObject.(client.Object)
 		require.True(t, ok)
-		johnyObjectLabels := map[string]string{toolchainv1alpha1.OwnerLabelKey: "johny", toolchainv1alpha1.SpaceLabelKey: "johny"}
+		johnyObjectLabels := map[string]string{toolchainv1alpha1.SpaceLabelKey: "johny"}
 		johnyObject.SetLabels(johnyObjectLabels)
 		johnyObject.SetName("johny-object")
 
@@ -50,7 +50,7 @@ func TestClusterResourceKinds(t *testing.T) {
 		anotherRuntimeObject := clusterResourceKind.object.DeepCopyObject()
 		anotherObject, ok := anotherRuntimeObject.(client.Object)
 		require.True(t, ok)
-		anotherObject.SetLabels(map[string]string{toolchainv1alpha1.OwnerLabelKey: "another", toolchainv1alpha1.SpaceLabelKey: "another"})
+		anotherObject.SetLabels(map[string]string{toolchainv1alpha1.SpaceLabelKey: "another"})
 		anotherObject.SetName("another-object")
 		namespace := newNamespace("basic", "johny", "code")
 
@@ -399,7 +399,6 @@ func TestDeleteClusterResources(t *testing.T) {
 		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 		crq := newClusterResourceQuota(spacename, "withemptycrq")
 		emptyCrq := newClusterResourceQuota("empty", "withemptycrq")
-		emptyCrq.Labels[toolchainv1alpha1.OwnerLabelKey] = spacename
 		emptyCrq.Labels[toolchainv1alpha1.SpaceLabelKey] = spacename
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq, crb)
 
@@ -435,7 +434,6 @@ func TestDeleteClusterResources(t *testing.T) {
 		deletionTS := metav1.NewTime(time.Now())
 		crq.SetDeletionTimestamp(&deletionTS)
 		emptyCrq := newClusterResourceQuota("empty", "withemptycrq")
-		emptyCrq.Labels[toolchainv1alpha1.OwnerLabelKey] = spacename
 		emptyCrq.Labels[toolchainv1alpha1.SpaceLabelKey] = spacename
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq)
 

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -156,7 +156,6 @@ func (r *namespacesManager) ensureNamespaceResource(logger logr.Logger, nsTmplSe
 	}
 
 	labels := map[string]string{
-		toolchainv1alpha1.OwnerLabelKey:    nsTmplSet.GetName(),
 		toolchainv1alpha1.SpaceLabelKey:    nsTmplSet.GetName(),
 		toolchainv1alpha1.TypeLabelKey:     tierTemplate.typeName,
 		toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
@@ -208,7 +207,6 @@ func (r *namespacesManager) ensureInnerNamespaceResources(logger logr.Logger, ns
 
 	var labels = map[string]string{
 		toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
-		toolchainv1alpha1.OwnerLabelKey:    nsTmplSet.GetName(),
 		toolchainv1alpha1.SpaceLabelKey:    nsTmplSet.GetName(),
 	}
 	if _, err = r.ApplyToolchainObjects(logger, newObjs, labels); err != nil {

--- a/controllers/nstemplateset/namespaces_test.go
+++ b/controllers/nstemplateset/namespaces_test.go
@@ -160,7 +160,6 @@ func TestNextNamespaceToProvisionOrUpdate(t *testing.T) {
 					toolchainv1alpha1.TierLabelKey:        "basic",
 					toolchainv1alpha1.TypeLabelKey:        "other",
 					toolchainv1alpha1.TemplateRefLabelKey: "basic-other-abcde15",
-					toolchainv1alpha1.OwnerLabelKey:       "johnsmith",
 					toolchainv1alpha1.SpaceLabelKey:       "johnsmith",
 				},
 			},
@@ -218,7 +217,6 @@ func createUserNamespacesAndTierTemplates() ([]corev1.Namespace, []*tierTemplate
 					toolchainv1alpha1.TierLabelKey:        "basic",
 					toolchainv1alpha1.TypeLabelKey:        "dev",
 					toolchainv1alpha1.TemplateRefLabelKey: "basic-dev-abcde11",
-					toolchainv1alpha1.OwnerLabelKey:       "johnsmith",
 					toolchainv1alpha1.SpaceLabelKey:       "johnsmith",
 				},
 			},
@@ -230,7 +228,6 @@ func createUserNamespacesAndTierTemplates() ([]corev1.Namespace, []*tierTemplate
 					toolchainv1alpha1.TierLabelKey:        "basic",
 					toolchainv1alpha1.TypeLabelKey:        "stage",
 					toolchainv1alpha1.TemplateRefLabelKey: "basic-stage-abcde21",
-					toolchainv1alpha1.OwnerLabelKey:       "johnsmith",
 					toolchainv1alpha1.SpaceLabelKey:       "johnsmith",
 				},
 			},
@@ -416,7 +413,6 @@ func TestEnsureNamespacesOK(t *testing.T) {
 			HasConditions(Provisioning())
 		AssertThatNamespace(t, spacename+"-dev", manager.Client).
 			HasNoOwnerReference().
-			HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -445,7 +441,6 @@ func TestEnsureNamespacesOK(t *testing.T) {
 			HasConditions(Provisioning())
 		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasNoOwnerReference().
-			HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.TypeLabelKey, "stage").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -471,7 +466,6 @@ func TestEnsureNamespacesOK(t *testing.T) {
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Provisioning())
 		AssertThatNamespace(t, spacename+"-dev", fakeClient).
-			HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 			HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-dev-abcde11").
@@ -502,7 +496,6 @@ func TestEnsureNamespacesOK(t *testing.T) {
 			HasConditions(Provisioning())
 		for _, nsType := range []string{"stage", "dev"} {
 			AssertThatNamespace(t, spacename+"-"+nsType, fakeClient).
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, nsType).
 				HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-"+nsType+"-abcde11").
@@ -826,7 +819,6 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11"). // upgraded
 				HasLabel(toolchainv1alpha1.TierLabelKey, "advanced").
@@ -857,7 +849,6 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11"). // upgraded
 				HasLabel(toolchainv1alpha1.TierLabelKey, "advanced").
@@ -888,7 +879,6 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-dev-abcde11"). // downgraded
@@ -920,7 +910,6 @@ func TestPromoteNamespaces(t *testing.T) {
 				DoesNotExist() // namespace was deleted
 			AssertThatNamespace(t, devNS.Name, cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -940,7 +929,6 @@ func TestPromoteNamespaces(t *testing.T) {
 					HasConditions(Updating())
 				AssertThatNamespace(t, devNS.Name, cl).
 					HasNoOwnerReference().
-					HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 					HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11"). // upgraded
@@ -972,7 +960,6 @@ func TestPromoteNamespaces(t *testing.T) {
 					"unable to retrieve the TierTemplate 'fail-dev-abcde11' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"fail-dev-abcde11\" not found"))
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1000,7 +987,6 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasConditions(UpdateFailed("mock error: '*v1.Namespace'")) // failed to delete NS
 			AssertThatNamespace(t, spacename+"-stage", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "stage").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1008,7 +994,6 @@ func TestPromoteNamespaces(t *testing.T) {
 				HasLabel(toolchainv1alpha1.TierLabelKey, "basic")
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1051,7 +1036,6 @@ func TestUpdateNamespaces(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde12"). // upgraded
 				HasLabel(toolchainv1alpha1.TierLabelKey, "advanced").
@@ -1082,7 +1066,6 @@ func TestUpdateNamespaces(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11"). // upgraded
 				HasLabel(toolchainv1alpha1.TierLabelKey, "advanced").
@@ -1113,7 +1096,6 @@ func TestUpdateNamespaces(t *testing.T) {
 				DoesNotExist() // namespace was deleted
 			AssertThatNamespace(t, devNS.Name, cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1137,7 +1119,6 @@ func TestUpdateNamespaces(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1153,7 +1134,6 @@ func TestUpdateNamespaces(t *testing.T) {
 					HasConditions(Updating())
 				AssertThatNamespace(t, spacename+"-dev", cl).
 					HasNoOwnerReference().
-					HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 					HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1180,7 +1160,6 @@ func TestUpdateNamespaces(t *testing.T) {
 				HasConditions(Updating())
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1196,7 +1175,6 @@ func TestUpdateNamespaces(t *testing.T) {
 					HasConditions(Updating())
 				AssertThatNamespace(t, spacename+"-dev", cl).
 					HasNoOwnerReference().
-					HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 					HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1226,7 +1204,6 @@ func TestUpdateNamespaces(t *testing.T) {
 					"unable to retrieve the TierTemplate 'basic-dev-abcde15' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"basic-dev-abcde15\" not found"))
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1251,7 +1228,6 @@ func TestUpdateNamespaces(t *testing.T) {
 					"unable to retrieve the TierTemplate 'basic-dev-abcde15' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"basic-dev-abcde15\" not found"))
 			AssertThatNamespace(t, spacename+"-dev", cl).
 				HasNoOwnerReference().
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 				HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -1298,7 +1274,6 @@ func TestIsUpToDateAndProvisioned(t *testing.T) {
 					toolchainv1alpha1.TypeLabelKey:        "dev",
 					toolchainv1alpha1.TierLabelKey:        "advanced",
 					toolchainv1alpha1.TemplateRefLabelKey: "advanced-dev-abcde11",
-					toolchainv1alpha1.OwnerLabelKey:       "johnsmith",
 					toolchainv1alpha1.SpaceLabelKey:       "johnsmith",
 				},
 			},

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -107,14 +107,12 @@ func TestReconcileProvisionOK(t *testing.T) {
 			HasSpecNamespaces("dev", "stage").
 			HasConditions(Provisioned())
 		AssertThatNamespace(t, spacename+"-dev", fakeClient).
-			HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 			HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-dev-abcde11").
 			HasLabel(toolchainv1alpha1.TierLabelKey, "basic").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
 		AssertThatNamespace(t, spacename+"-stage", fakeClient).
-			HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.TypeLabelKey, "stage").
 			HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-stage-abcde11").
@@ -209,7 +207,6 @@ func TestReconcileProvisionOK(t *testing.T) {
 			HasConditions(Provisioning())
 		AssertThatNamespace(t, spacename+"-dev", r.Client).
 			HasNoOwnerReference().
-			HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 			HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 			HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
@@ -663,7 +660,6 @@ func TestProvisionTwoUsers(t *testing.T) {
 						HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
 						HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{})
 					AssertThatNamespace(t, spacename+"-dev", fakeClient).
-						HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 						HasNoLabel(toolchainv1alpha1.TemplateRefLabelKey). // no label until all the namespace inner resources have been created
@@ -685,7 +681,6 @@ func TestProvisionTwoUsers(t *testing.T) {
 							HasSpecNamespaces("dev").
 							HasConditions(Provisioning())
 						AssertThatNamespace(t, spacename+"-dev", fakeClient).
-							HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 							HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 							HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 							HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11").
@@ -779,7 +774,6 @@ func TestProvisionTwoUsers(t *testing.T) {
 											HasSpecNamespaces("dev").
 											HasConditions(Provisioning())
 										AssertThatNamespace(t, joeUsername+"-dev", fakeClient).
-											HasLabel(toolchainv1alpha1.OwnerLabelKey, joeUsername).
 											HasLabel(toolchainv1alpha1.SpaceLabelKey, joeUsername).
 											HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 											HasNoLabel(toolchainv1alpha1.TemplateRefLabelKey).
@@ -804,7 +798,6 @@ func TestProvisionTwoUsers(t *testing.T) {
 												HasSpecNamespaces("dev").
 												HasConditions(Provisioning())
 											AssertThatNamespace(t, joeUsername+"-dev", fakeClient).
-												HasLabel(toolchainv1alpha1.OwnerLabelKey, joeUsername).
 												HasLabel(toolchainv1alpha1.SpaceLabelKey, joeUsername).
 												HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
 												HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11").
@@ -872,7 +865,6 @@ func TestReconcilePromotion(t *testing.T) {
 			for _, nsType := range []string{"stage", "dev"} {
 				AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 					HasNoOwnerReference().
-					HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-"+nsType+"-abcde11"). // not upgraded yet
 					HasLabel(toolchainv1alpha1.TierLabelKey, "basic").
@@ -899,7 +891,6 @@ func TestReconcilePromotion(t *testing.T) {
 					AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 						HasNoOwnerReference().
 						HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-"+nsType+"-abcde11"). // not upgraded yet
-						HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.TierLabelKey, "basic"). // not upgraded yet
 						HasLabel(toolchainv1alpha1.TypeLabelKey, nsType).
@@ -948,7 +939,6 @@ func TestReconcilePromotion(t *testing.T) {
 							DoesNotExist() // namespace was deleted
 						AssertThatNamespace(t, devNS.Name, r.Client).
 							HasNoOwnerReference().
-							HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 							HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 							HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "basic-dev-abcde11").
 							HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
@@ -973,7 +963,6 @@ func TestReconcilePromotion(t *testing.T) {
 								DoesNotExist()
 							AssertThatNamespace(t, spacename+"-dev", r.Client).
 								HasNoOwnerReference().
-								HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 								HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 								HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11").
 								HasLabel(toolchainv1alpha1.TierLabelKey, "advanced").
@@ -1002,7 +991,6 @@ func TestReconcilePromotion(t *testing.T) {
 								AssertThatNamespace(t, spacename+"-dev", r.Client).
 									HasNoOwnerReference().
 									HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11").
-									HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 									HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 									HasLabel(toolchainv1alpha1.TierLabelKey, "advanced"). // not updgraded yet
 									HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
@@ -1070,7 +1058,6 @@ func TestReconcileUpdate(t *testing.T) {
 			for _, nsType := range []string{"stage", "dev"} {
 				AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 					HasNoOwnerReference().
-					HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 					HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-"+nsType+"-abcde11"). // not upgraded yet
 					HasLabel(toolchainv1alpha1.TierLabelKey, "advanced").
@@ -1098,7 +1085,6 @@ func TestReconcileUpdate(t *testing.T) {
 				for _, nsType := range []string{"stage", "dev"} {
 					AssertThatNamespace(t, spacename+"-"+nsType, r.Client).
 						HasNoOwnerReference().
-						HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-"+nsType+"-abcde11"). // not upgraded yet
 						HasLabel(toolchainv1alpha1.TierLabelKey, "advanced").
@@ -1128,7 +1114,6 @@ func TestReconcileUpdate(t *testing.T) {
 						DoesNotExist() // namespace was deleted
 					AssertThatNamespace(t, devNS.Name, r.Client).
 						HasNoOwnerReference().
-						HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 						HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde11"). // not upgraded yet
 						HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
@@ -1157,7 +1142,6 @@ func TestReconcileUpdate(t *testing.T) {
 							DoesNotExist()
 						AssertThatNamespace(t, devNS.Name, r.Client).
 							HasNoOwnerReference().
-							HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 							HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 							HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde12"). // upgraded
 							HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
@@ -1189,7 +1173,6 @@ func TestReconcileUpdate(t *testing.T) {
 								DoesNotExist()
 							AssertThatNamespace(t, devNS.Name, r.Client).
 								HasNoOwnerReference().
-								HasLabel(toolchainv1alpha1.OwnerLabelKey, spacename).
 								HasLabel(toolchainv1alpha1.SpaceLabelKey, spacename).
 								HasLabel(toolchainv1alpha1.TemplateRefLabelKey, "advanced-dev-abcde12"). // upgraded
 								HasLabel(toolchainv1alpha1.TypeLabelKey, "dev").
@@ -1678,7 +1661,6 @@ func withConditions(conditions ...toolchainv1alpha1.Condition) nsTmplSetOption {
 
 func newNamespace(tier, spacename, typeName string, options ...objectMetaOption) *corev1.Namespace {
 	labels := map[string]string{
-		toolchainv1alpha1.OwnerLabelKey:    spacename,
 		toolchainv1alpha1.SpaceLabelKey:    spacename,
 		toolchainv1alpha1.TypeLabelKey:     typeName,
 		toolchainv1alpha1.ProviderLabelKey: "codeready-toolchain",
@@ -1707,7 +1689,6 @@ func newRoleBinding(namespace, name, spacename string) *rbacv1.RoleBinding { //n
 			Name:      name,
 			Labels: map[string]string{
 				toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
-				toolchainv1alpha1.OwnerLabelKey:    spacename,
 				toolchainv1alpha1.SpaceLabelKey:    spacename,
 			},
 		},
@@ -1721,7 +1702,6 @@ func newRole(namespace, name, spacename string) *rbacv1.Role { //nolint: unparam
 			Name:      name,
 			Labels: map[string]string{
 				toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
-				toolchainv1alpha1.OwnerLabelKey:    spacename,
 				toolchainv1alpha1.SpaceLabelKey:    spacename,
 			},
 		},
@@ -1739,7 +1719,6 @@ func newTektonClusterRoleBinding(spacename, tier string) *rbacv1.ClusterRoleBind
 				toolchainv1alpha1.ProviderLabelKey:    toolchainv1alpha1.ProviderLabelValue,
 				toolchainv1alpha1.TierLabelKey:        tier,
 				toolchainv1alpha1.TemplateRefLabelKey: NewTierTemplateName(tier, "clusterresources", "abcde11"),
-				toolchainv1alpha1.OwnerLabelKey:       spacename,
 				toolchainv1alpha1.SpaceLabelKey:       spacename,
 				toolchainv1alpha1.TypeLabelKey:        "clusterresources",
 			},
@@ -1770,7 +1749,6 @@ func newClusterResourceQuota(spacename, tier string, options ...objectMetaOption
 				toolchainv1alpha1.ProviderLabelKey:    toolchainv1alpha1.ProviderLabelValue,
 				toolchainv1alpha1.TierLabelKey:        tier,
 				toolchainv1alpha1.TemplateRefLabelKey: NewTierTemplateName(tier, "clusterresources", "abcde11"),
-				toolchainv1alpha1.OwnerLabelKey:       spacename,
 				toolchainv1alpha1.SpaceLabelKey:       spacename,
 				toolchainv1alpha1.TypeLabelKey:        "clusterresources",
 			},
@@ -1809,7 +1787,6 @@ func newIdler(spacename, name, tierName string) *toolchainv1alpha1.Idler { // no
 				toolchainv1alpha1.ProviderLabelKey:    "codeready-toolchain",
 				toolchainv1alpha1.TierLabelKey:        tierName,
 				toolchainv1alpha1.TemplateRefLabelKey: NewTierTemplateName(tierName, "clusterresources", "abcde11"),
-				toolchainv1alpha1.OwnerLabelKey:       spacename,
 				toolchainv1alpha1.SpaceLabelKey:       spacename,
 				toolchainv1alpha1.TypeLabelKey:        "clusterresources",
 			},

--- a/controllers/nstemplateset/space_roles.go
+++ b/controllers/nstemplateset/space_roles.go
@@ -60,7 +60,6 @@ func (r *spaceRolesManager) ensure(logger logr.Logger, nsTmplSet *toolchainv1alp
 		// labels to apply on all new objects
 		var labels = map[string]string{
 			toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
-			toolchainv1alpha1.OwnerLabelKey:    nsTmplSet.GetName(),
 			toolchainv1alpha1.SpaceLabelKey:    nsTmplSet.GetName(),
 		}
 		logger.Info("applying space role objects", "count", len(spaceRoleObjs))

--- a/controllers/nstemplateset/space_roles_test.go
+++ b/controllers/nstemplateset/space_roles_test.go
@@ -53,32 +53,26 @@ func TestEnsureSpaceRoles(t *testing.T) {
 			AssertThatRole(t, "oddity-appstudio", "space-admin", memberClient).
 				Exists(). // created
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, nsTmplSet.GetName()).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, nsTmplSet.GetName())
 			AssertThatRoleBinding(t, "oddity-appstudio", "user1-space-admin", memberClient).
 				Exists(). // created
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, nsTmplSet.GetName()).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, nsTmplSet.GetName())
 			AssertThatRoleBinding(t, "oddity-appstudio", "user2-space-admin", memberClient).
 				Exists(). // created
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, nsTmplSet.GetName()).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, nsTmplSet.GetName())
 			AssertThatRole(t, "oddity-appstudio", "space-viewer", memberClient).
 				Exists(). // created
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, nsTmplSet.GetName()).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, nsTmplSet.GetName())
 			AssertThatRoleBinding(t, "oddity-appstudio", "user3-space-viewer", memberClient).
 				Exists(). // created
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, nsTmplSet.GetName()).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, nsTmplSet.GetName())
 			AssertThatRoleBinding(t, "oddity-appstudio", "user4-space-viewer", memberClient).
 				Exists(). // created
 				HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue).
-				HasLabel(toolchainv1alpha1.OwnerLabelKey, nsTmplSet.GetName()).
 				HasLabel(toolchainv1alpha1.SpaceLabelKey, nsTmplSet.GetName())
 			// also verify that the `last-applied-space-roles` annotation was set on namespace
 			lastApplied, err := json.Marshal(nsTmplSet.Spec.SpaceRoles)

--- a/test/namespace_assertion.go
+++ b/test/namespace_assertion.go
@@ -119,7 +119,6 @@ func (a *NamespaceAssertion) ResourceHasSpaceLabel(name string, obj client.Objec
 	// check for toolchain.dev.openshift.com/owner label
 	labels := obj.GetLabels()
 	assert.Equal(a.t, labels[toolchainv1alpha1.ProviderLabelKey], toolchainv1alpha1.ProviderLabelValue)
-	assert.Equal(a.t, labels[toolchainv1alpha1.OwnerLabelKey], spacename)
 	assert.Equal(a.t, labels[toolchainv1alpha1.SpaceLabelKey], spacename)
 	return a
 }


### PR DESCRIPTION
Drop OwnerLabelKey in favor of the newly introduced SpaceLabelKey

Part of Jira: https://issues.redhat.com/browse/SANDBOX-51

Paired with:
- e2e : https://github.com/codeready-toolchain/toolchain-e2e/pull/747