### PR TITLE
fix: move member operator unit test for revision check to All components ready test

### DIFF
--- a/controllers/memberstatus/memberstatus_controller.go
+++ b/controllers/memberstatus/memberstatus_controller.go
@@ -171,7 +171,7 @@ func (r *Reconciler) hostConnectionHandleStatus(reqLogger logr.Logger, memberSta
 // memberOperatorHandleStatus retrieves the Deployment for the member operator and adds its status to MemberStatus. It returns an error
 // if any of the conditions have a status that is not 'true'
 func (r *Reconciler) memberOperatorHandleStatus(_ logr.Logger, memberStatus *toolchainv1alpha1.MemberStatus, memberConfig membercfg.Configuration) error {
-	// ensure host operator status is set
+	// ensure member operator status is set
 	if memberStatus.Status.MemberOperator == nil {
 		memberStatus.Status.MemberOperator = &toolchainv1alpha1.MemberOperatorStatus{}
 	}


### PR DESCRIPTION
Move member operator version is up to date check to "All components ready test" 

See discussion in previous PR: https://github.com/codeready-toolchain/member-operator/pull/446#discussion_r1255544115