### PR TITLE
fix: go vet

### DIFF
--- a/make/go.mk
+++ b/make/go.mk
@@ -36,7 +36,7 @@ vendor:
 generate-assets: go-bindata
 	@echo "generating webhooks template data..."
 	@rm ./pkg/webhook/deploy/webhooks/template_assets.go 2>/dev/null || true
-	@$(GO_BINDATA) -pkg templates -o ./pkg/webhook/deploy/webhooks/template_assets.go -nocompress -prefix deploy/webhook deploy/webhook
+	@$(GO_BINDATA) -pkg webhooks -o ./pkg/webhook/deploy/webhooks/template_assets.go -nocompress -prefix deploy/webhook deploy/webhook
 	@echo "generating autoscaler buffer template data..."
 	@rm ./pkg/autoscaler/template_assets.go 2>/dev/null || true
 	@$(GO_BINDATA) -pkg autoscaler -o ./pkg/autoscaler/template_assets.go -nocompress -prefix deploy/autoscaler deploy/autoscaler

--- a/pkg/webhook/deploy/deployment.go
+++ b/pkg/webhook/deploy/deployment.go
@@ -46,7 +46,7 @@ func Webhook(cl runtimeclient.Client, s *runtime.Scheme, namespace, image string
 }
 
 func getTemplateObjects(s *runtime.Scheme, namespace, image string, caBundle []byte) ([]runtimeclient.Object, error) {
-	deployment, err := templates.Asset("member-operator-webhook.yaml")
+	deployment, err := webhooks.Asset("member-operator-webhook.yaml")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`go vet ./...` seems to be broken.

```
❯ go vet ./...
# github.com/codeready-toolchain/member-operator/pkg/webhook/deploy
pkg/webhook/deploy/deployment.go:7:2: "github.com/codeready-toolchain/member-operator/pkg/webhook/deploy/webhooks" imported and not used
pkg/webhook/deploy/deployment.go:49:21: undefined: templates
# github.com/codeready-toolchain/member-operator/pkg/webhook/deploy
vet: pkg/webhook/deploy/deployment.go:49:21: undefined: templates
```

As the folder containing the generated code is named `webhooks`, I changed the pkg name from `templates` to `webhooks`.