### PR TITLE
No Notification for "Completed" and without controller Pods

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -134,11 +134,9 @@ func (r *Reconciler) ensureIdling(logger logr.Logger, idler *toolchainv1alpha1.I
 				podLogger.Info("Pod running for too long. Killing the pod.", "start_time", trackedPod.StartTime.Format("2006-01-02T15:04:05Z"), "timeout_seconds", idler.Spec.TimeoutSeconds)
 				var podreason string
 				podcondition := pod.Status.Conditions
-				if podcondition != nil {
-					for _, podtype := range podcondition {
-						if podtype.Type == "Ready" {
-							podreason = podtype.Reason
-						}
+				for _, podtype := range podcondition {
+					if podtype.Type == "Ready" {
+						podreason = podtype.Reason
 					}
 				}
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -135,9 +135,11 @@ func (r *Reconciler) ensureIdling(logger logr.Logger, idler *toolchainv1alpha1.I
 				var podreason string
 				podcondition := pod.Status.Conditions
 				if podcondition != nil {
-					podreason = podcondition[0].Reason
-				} else {
-					podreason = ""
+					for _, podtype := range podcondition {
+						if podtype.Type == "Ready" {
+							podreason = podtype.Reason
+						}
+					}
 				}
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				appType, appName, deletedByController, err := r.scaleControllerToZero(podLogger, pod.ObjectMeta)

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -132,7 +132,13 @@ func (r *Reconciler) ensureIdling(logger logr.Logger, idler *toolchainv1alpha1.I
 			// Already tracking this pod. Check the timeout.
 			if time.Now().After(trackedPod.StartTime.Add(time.Duration(idler.Spec.TimeoutSeconds) * time.Second)) {
 				podLogger.Info("Pod running for too long. Killing the pod.", "start_time", trackedPod.StartTime.Format("2006-01-02T15:04:05Z"), "timeout_seconds", idler.Spec.TimeoutSeconds)
-
+				var podreason string
+				podcondition := pod.Status.Conditions
+				if podcondition != nil {
+					podreason = podcondition[0].Reason
+				} else {
+					podreason = ""
+				}
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				appType, appName, deletedByController, err := r.scaleControllerToZero(podLogger, pod.ObjectMeta)
 				if err != nil {
@@ -150,13 +156,15 @@ func (r *Reconciler) ensureIdling(logger logr.Logger, idler *toolchainv1alpha1.I
 					appName = pod.Name
 					appType = "Pod"
 				}
-
-				// By now either a pod has been deleted or scaled to zero by controller, idler Triggered notification should be sent
-				if err := r.createNotification(logger, idler, appName, appType); err != nil {
-					logger.Error(err, "failed to create Notification")
-					if err = r.setStatusIdlerNotificationCreationFailed(idler, err.Error()); err != nil {
-						logger.Error(err, "failed to set status IdlerNotificationCreationFailed")
-					} // not returning error to continue tracking remaining pods
+				// Do not send notification if Pod Not managed by a controller and is in completed state
+				if podreason != "PodCompleted" && !deletedByController {
+					// By now either a pod has been deleted or scaled to zero by controller, idler Triggered notification should be sent
+					if err := r.createNotification(logger, idler, appName, appType); err != nil {
+						logger.Error(err, "failed to create Notification")
+						if err = r.setStatusIdlerNotificationCreationFailed(idler, err.Error()); err != nil {
+							logger.Error(err, "failed to set status IdlerNotificationCreationFailed")
+						} // not returning error to continue tracking remaining pods
+					}
 				}
 
 			} else {

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -729,6 +729,51 @@ func TestAppNameTypeForInidividualPods(t *testing.T) {
 	})
 
 }
+
+func TestNoNotifyForInidividualCompletedPods(t *testing.T) {
+	//given
+	idler := &toolchainv1alpha1.Idler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "alex-stage",
+			Labels: map[string]string{
+				toolchainv1alpha1.SpaceLabelKey: "alex",
+			},
+		},
+		Spec: toolchainv1alpha1.IdlerSpec{TimeoutSeconds: 60},
+	}
+
+	t.Run("Test No notification sent for no controller and completed status pod", func(t *testing.T) {
+		namespaces := []string{"dev", "stage"}
+		usernames := []string{"alex"}
+		nsTmplSet := newNSTmplSet(test.MemberOperatorNs, "alex", "advanced", "abcde11", namespaces, usernames)
+		mur := newMUR("alex")
+		reconciler, req, cl, _ := prepareReconcile(t, idler.Name, getHostCluster, idler, nsTmplSet, mur)
+		idlerTimeoutPlusOneSecondAgo := time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds+1) * time.Second)
+		pcond := corev1.PodCondition{Type: "Ready", Reason: "PodCompleted"}
+		preparePayloadsSinglePod(t, reconciler, idler.Name, "todelete-", idlerTimeoutPlusOneSecondAgo, pcond)
+		// first reconcile to track pods
+		res, err := reconciler.Reconcile(context.TODO(), req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+
+		// second reconcile should delete pods and create notification
+		res, err = reconciler.Reconcile(context.TODO(), req)
+		//then
+		assert.NoError(t, err)
+		memberoperatortest.AssertThatIdler(t, idler.Name, cl).
+			HasConditions(memberoperatortest.Running())
+		//check the notification is not created
+		hostCl, _ := reconciler.GetHostCluster()
+		notification := &toolchainv1alpha1.Notification{}
+		err = hostCl.Client.Get(context.TODO(), types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      "alex-stage-idled",
+		}, notification)
+		require.EqualError(t, err, "notifications.toolchain.dev.openshift.com \"alex-stage-idled\" not found")
+
+	})
+
+}
 func TestCreateNotification(t *testing.T) {
 	idler := &toolchainv1alpha1.Idler{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1135,7 +1180,7 @@ func preparePayloads(t *testing.T, r *Reconciler, namespace, namePrefix string, 
 	}
 }
 
-func preparePayloadsSinglePod(t *testing.T, r *Reconciler, namespace, namePrefix string, startTime time.Time) payloads {
+func preparePayloadsSinglePod(t *testing.T, r *Reconciler, namespace, namePrefix string, startTime time.Time, conditions ...corev1.PodCondition) payloads {
 	sTime := metav1.NewTime(startTime)
 
 	// Pods with no owner.
@@ -1143,7 +1188,7 @@ func preparePayloadsSinglePod(t *testing.T, r *Reconciler, namespace, namePrefix
 	for i := 0; i < 1; i++ {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s%s-pod-%d", namePrefix, namespace, i), Namespace: namespace},
-			Status:     corev1.PodStatus{StartTime: &sTime},
+			Status:     corev1.PodStatus{StartTime: &sTime, Conditions: conditions},
 		}
 		standalonePods = append(standalonePods, pod)
 		err := r.AllNamespacesClient.Create(context.TODO(), pod)

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -699,31 +699,31 @@ func TestNotificationAppNameTypeForPods(t *testing.T) {
 	mur := newMUR("feny")
 	var pname string
 	testpod := map[string]struct {
-		pcond                       corev1.PodCondition
+		pcond                       []corev1.PodCondition
 		expectedAppType             string
 		expectedNotificationCreated bool
 		controllerOwned             bool
 	}{
 		"Individual-Completed-Pod": {
-			pcond:                       corev1.PodCondition{Type: "Ready", Reason: "PodCompleted"},
+			pcond:                       []corev1.PodCondition{{Type: "Ready", Reason: "PodCompleted"}},
 			expectedAppType:             "Pod",
 			expectedNotificationCreated: false,
 			controllerOwned:             false,
 		},
 		"Individual-NonCompleted-Pod": {
-			pcond:                       corev1.PodCondition{Type: "Ready", Reason: ""},
+			pcond:                       []corev1.PodCondition{{Type: "Ready", Reason: ""}},
 			expectedAppType:             "Pod",
 			expectedNotificationCreated: true,
 			controllerOwned:             false,
 		},
 		"Controlled-Completed-Pod": {
-			pcond:                       corev1.PodCondition{Type: "Ready", Reason: "PodCompleted"},
+			pcond:                       []corev1.PodCondition{{Type: "Ready", Reason: "PodCompleted"}},
 			expectedAppType:             "Deployment",
 			expectedNotificationCreated: true,
 			controllerOwned:             true,
 		},
 		"Controlled-NonCompleted-Pod": {
-			pcond:                       corev1.PodCondition{Type: "Ready", Reason: ""},
+			pcond:                       []corev1.PodCondition{{Type: "Ready", Reason: ""}},
 			expectedAppType:             "Deployment",
 			expectedNotificationCreated: true,
 			controllerOwned:             true,
@@ -734,7 +734,9 @@ func TestNotificationAppNameTypeForPods(t *testing.T) {
 			controllerOwned:             true,
 		},
 		"Controlled-Pod-multiplecondition": {
-			pcond:                       corev1.PodCondition{Type: "Ready", Reason: "initiated"},
+			pcond: []corev1.PodCondition{{Type: "Ready", Reason: ""},
+				{Type: "Initiated"},
+				{Type: "ContainersReady"}},
 			expectedAppType:             "Deployment",
 			expectedNotificationCreated: true,
 			controllerOwned:             true,
@@ -747,9 +749,9 @@ func TestNotificationAppNameTypeForPods(t *testing.T) {
 			idlerTimeoutPlusOneSecondAgo := time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds+1) * time.Second)
 
 			if tcs.controllerOwned {
-				preparePayloads(t, reconciler, idler.Name, "todelete-", idlerTimeoutPlusOneSecondAgo, tcs.pcond)
+				preparePayloads(t, reconciler, idler.Name, "todelete-", idlerTimeoutPlusOneSecondAgo, tcs.pcond...)
 			} else {
-				p := preparePayloadsSinglePod(t, reconciler, idler.Name, "todelete-", idlerTimeoutPlusOneSecondAgo, tcs.pcond).standalonePods[0]
+				p := preparePayloadsSinglePod(t, reconciler, idler.Name, "todelete-", idlerTimeoutPlusOneSecondAgo, tcs.pcond...).standalonePods[0]
 				pname = p.Name
 			}
 


### PR DESCRIPTION
If the Pod is in complete state and doesn't have a controller, no notification should be sent to the user.

This relates to #478 