### PR TITLE
disable HTTP/2 on kube-rbac-proxy container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
             cpu: 500m
             memory: 500M
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13.0
+        image: quay.io/repository/openshift/origin-kube-rbac-proxy:v4.14
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,7 +73,8 @@ spec:
             memory: 500M
       - name: kube-rbac-proxy
         image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13.0
-        securityContext:
+         imagePullPolicy: Always
+         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
@@ -82,6 +83,7 @@ spec:
           - "--secure-listen-address=0.0.0.0:8443"
           - "--upstream=http://127.0.0.1:8080/"
           - "--logtostderr=true"
+          - "--http2-disable=true"
           - "--v=3"
         ports:
           - containerPort: 8443

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
             cpu: 500m
             memory: 500M
       - name: kube-rbac-proxy
-        image: quay.io/repository/openshift/origin-kube-rbac-proxy:v4.14
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,8 +73,8 @@ spec:
             memory: 500M
       - name: kube-rbac-proxy
         image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13.0
-         imagePullPolicy: Always
-         securityContext:
+        imagePullPolicy: Always
+        securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
