### PR TITLE
Update VM webhook to add cloud init user data

### DIFF
--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller.go
@@ -61,7 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	if err := r.handleUserPodsWebhookDeploy(reqLogger, crtConfig, request.Namespace); err != nil {
+	if err := r.handleWebhookDeploy(reqLogger, crtConfig, request.Namespace); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -93,7 +93,7 @@ func (r *Reconciler) handleAutoscalerDeploy(logger logr.Logger, cfg Configuratio
 	return nil
 }
 
-func (r *Reconciler) handleUserPodsWebhookDeploy(logger logr.Logger, cfg Configuration, namespace string) error {
+func (r *Reconciler) handleWebhookDeploy(logger logr.Logger, cfg Configuration, namespace string) error {
 	// By default the users' pods webhook will be deployed, however in some cases (eg. e2e tests) there can be multiple member operators
 	// installed in the same cluster. In those cases only 1 webhook is needed because the MutatingWebhookConfiguration is a cluster-scoped resource and naming can conflict.
 	if cfg.Webhook().Deploy() {

--- a/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
+++ b/controllers/memberoperatorconfig/memberoperatorconfig_controller_test.go
@@ -214,7 +214,7 @@ func TestHandleAutoscalerDeploy(t *testing.T) {
 	})
 }
 
-func TestHandleUsersPodsWebhookDeploy(t *testing.T) {
+func TestHandleWebhookDeploy(t *testing.T) {
 	t.Run("deployment not created when webhook deploy is false", func(t *testing.T) {
 		// given
 		config := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.Webhook().Deploy(false))
@@ -224,7 +224,7 @@ func TestHandleUsersPodsWebhookDeploy(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		err = controller.handleUserPodsWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+		err = controller.handleWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestHandleUsersPodsWebhookDeploy(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		err = controller.handleUserPodsWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+		err = controller.handleWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -262,7 +262,7 @@ func TestHandleUsersPodsWebhookDeploy(t *testing.T) {
 		cl.(*test.FakeClient).MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			return fmt.Errorf("client error")
 		}
-		err = controller.handleUserPodsWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
+		err = controller.handleWebhookDeploy(controller.Log, actualConfig, test.MemberOperatorNs)
 
 		// then
 		require.EqualError(t, err, "cannot deploy webhook template: client error")

--- a/make/test.mk
+++ b/make/test.mk
@@ -96,17 +96,18 @@ ifeq ($(E2E_REPO_PATH),"")
 	git clone https://github.com/codeready-toolchain/toolchain-e2e.git ${E2E_REPO_PATH}
     ifneq ($(CI),)
         ifneq ($(GITHUB_ACTIONS),)
-			$(eval BRANCH_NAME = ${GITHUB_HEAD_REF})
+			$(eval BRANCH_REF = refs/heads/${GITHUB_HEAD_REF})
 			$(eval AUTHOR_LINK = https://github.com/${AUTHOR})
         else
 			$(eval AUTHOR_LINK = $(shell jq -r '.refs[0].pulls[0].author_link' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]'))
-			@echo "found author link ${AUTHOR_LINK}"
-			$(eval BRANCH_NAME := $(shell jq -r '.refs[0].pulls[0].head_ref' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]'))
+			@echo "using pull sha ${PULL_PULL_SHA}"
+			# get branch ref of the fork the PR was created from
+			$(eval BRANCH_REF := $(shell curl ${AUTHOR_LINK}/member-operator.git/info/refs?service=git-upload-pack --output - /dev/null 2>&1 | grep -a ${PULL_PULL_SHA} | awk '{print $$2}'))
         endif
 		@echo "using author link ${AUTHOR_LINK}"
 		@echo "detected branch ref ${BRANCH_REF}"
 		# check if a branch with the same ref exists in the user's fork of toolchain-e2e repo
-		$(eval REMOTE_E2E_BRANCH := $(shell curl ${AUTHOR_LINK}/toolchain-e2e.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "refs/heads/${BRANCH_NAME}$$" | awk '{print $$2}'))
+		$(eval REMOTE_E2E_BRANCH := $(shell curl ${AUTHOR_LINK}/toolchain-e2e.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "${BRANCH_REF}$$" | awk '{print $$2}'))
 		@echo "branch ref of the user's fork: \"${REMOTE_E2E_BRANCH}\" - if empty then not found"
 		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master
 		if [[ -n "${REMOTE_E2E_BRANCH}" ]]; then \

--- a/make/test.mk
+++ b/make/test.mk
@@ -120,7 +120,6 @@ ifeq ($(E2E_REPO_PATH),"")
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${BRANCH_REF}; \
 			# merge the branch with master \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD; \
-			cat ${E2E_REPO_PATH}/test/e2e/parallel/vm_webhook_test.go; \
 		fi;
     endif
 endif

--- a/make/test.mk
+++ b/make/test.mk
@@ -120,6 +120,7 @@ ifeq ($(E2E_REPO_PATH),"")
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${BRANCH_REF}; \
 			# merge the branch with master \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD; \
+			cat ${E2E_REPO_PATH}/test/e2e/parallel/vm_webhook_test.go; \
 		fi;
     endif
 endif

--- a/make/test.mk
+++ b/make/test.mk
@@ -96,18 +96,17 @@ ifeq ($(E2E_REPO_PATH),"")
 	git clone https://github.com/codeready-toolchain/toolchain-e2e.git ${E2E_REPO_PATH}
     ifneq ($(CI),)
         ifneq ($(GITHUB_ACTIONS),)
-			$(eval BRANCH_REF = refs/heads/${GITHUB_HEAD_REF})
+			$(eval BRANCH_NAME = ${GITHUB_HEAD_REF})
 			$(eval AUTHOR_LINK = https://github.com/${AUTHOR})
         else
 			$(eval AUTHOR_LINK = $(shell jq -r '.refs[0].pulls[0].author_link' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]'))
-			@echo "using pull sha ${PULL_PULL_SHA}"
-			# get branch ref of the fork the PR was created from
-			$(eval BRANCH_REF := $(shell curl ${AUTHOR_LINK}/member-operator.git/info/refs?service=git-upload-pack --output - /dev/null 2>&1 | grep -a ${PULL_PULL_SHA} | awk '{print $$2}'))
+			@echo "found author link ${AUTHOR_LINK}"
+			$(eval BRANCH_NAME := $(shell jq -r '.refs[0].pulls[0].head_ref' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]'))
         endif
 		@echo "using author link ${AUTHOR_LINK}"
 		@echo "detected branch ref ${BRANCH_REF}"
 		# check if a branch with the same ref exists in the user's fork of toolchain-e2e repo
-		$(eval REMOTE_E2E_BRANCH := $(shell curl ${AUTHOR_LINK}/toolchain-e2e.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "${BRANCH_REF}$$" | awk '{print $$2}'))
+		$(eval REMOTE_E2E_BRANCH := $(shell curl ${AUTHOR_LINK}/toolchain-e2e.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "refs/heads/${BRANCH_NAME}$$" | awk '{print $$2}'))
 		@echo "branch ref of the user's fork: \"${REMOTE_E2E_BRANCH}\" - if empty then not found"
 		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master
 		if [[ -n "${REMOTE_E2E_BRANCH}" ]]; then \

--- a/pkg/webhook/mutatingwebhook/mutate.go
+++ b/pkg/webhook/mutatingwebhook/mutate.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 
 	"github.com/go-logr/logr"
+	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -22,48 +24,55 @@ var (
 type mutateHandler func(admReview v1.AdmissionReview) *v1.AdmissionResponse
 
 func handleMutate(logger logr.Logger, w http.ResponseWriter, r *http.Request, mutator mutateHandler) {
-	var respBody []byte
-	body, err := io.ReadAll(r.Body)
+	admReviewBody, err := io.ReadAll(r.Body)
 	defer func() {
 		if err := r.Body.Close(); err != nil {
 			logger.Error(err, "unable to close the body")
 		}
 	}()
 	if err != nil {
-		logger.Error(err, "unable to read the body of the request")
-		w.WriteHeader(http.StatusInternalServerError)
-		respBody = []byte("unable to read the body of the request")
-	} else {
-		// mutate the request
-		respBody = mutate(logger, body, mutator)
-		w.WriteHeader(http.StatusOK)
+		msg := "unable to read the body of the request"
+		logger.Error(err, msg)
+		writeResponse(logger, http.StatusInternalServerError, w, []byte(msg))
+		return
 	}
-	if _, err := io.WriteString(w, string(respBody)); err != nil {
-		logger.Error(err, "unable to write response")
-	}
-}
 
-func mutate(logger logr.Logger, body []byte, mutator mutateHandler) []byte {
-	admReview := v1.AdmissionReview{}
-	if _, _, err := deserializer.Decode(body, nil, &admReview); err != nil {
-		logger.Error(err, "unable to deserialize the admission review object", "body", string(body))
-		admReview.Response = responseWithError(err)
+	// deserialize the request
+	admReview := admissionv1.AdmissionReview{}
+	if _, _, err := deserializer.Decode(admReviewBody, nil, &admReview); err != nil {
+		logger.Error(err, "unable to deserialize the admission review object", "body", string(admReviewBody))
+		writeResponse(logger, http.StatusBadRequest, w, []byte("unable to read the body of the request"))
+		return
 	} else if admReview.Request == nil {
-		err := fmt.Errorf("admission review request is nil")
-		logger.Error(err, "cannot read the admission review request", "AdmissionReview", admReview)
-		admReview.Response = responseWithError(err)
-	} else {
-		admReview.Response = mutator(admReview)
+		err = fmt.Errorf("admission review request is nil")
+		logger.Error(err, "invalid admission review request", "AdmissionReview", admReview)
+		writeResponse(logger, http.StatusBadRequest, w, []byte("unable to read the body of the request"))
+		return
 	}
-	responseBody, err := json.Marshal(admReview)
+
+	// mutate the request
+	admReview.Response = mutator(admReview)
+
+	respBody, err := json.Marshal(admReview)
 	if err != nil {
 		logger.Error(err, "unable to marshal the admission review with response", "admissionReview", admReview)
+		writeResponse(logger, http.StatusInternalServerError, w, []byte("failed to marshal the adm review resposne"))
+		return
 	}
-	return responseBody
+	writeResponse(logger, http.StatusOK, w, respBody)
 }
 
-func responseWithError(err error) *v1.AdmissionResponse {
-	return &v1.AdmissionResponse{
+func writeResponse(logger logr.Logger, responseCode int, w http.ResponseWriter, respBody []byte) {
+	w.WriteHeader(responseCode)
+	if _, err := io.WriteString(w, string(respBody)); err != nil {
+		logger.Error(err, "unable to write adm review response")
+	}
+}
+
+func responseWithError(uid types.UID, err error) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
+		Allowed: false,
+		UID:     uid,
 		Result: &metav1.Status{
 			Message: err.Error(),
 		},

--- a/pkg/webhook/mutatingwebhook/mutate.go
+++ b/pkg/webhook/mutatingwebhook/mutate.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
-	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -21,8 +20,10 @@ var (
 	deserializer  = codecs.UniversalDeserializer()
 )
 
-type mutateHandler func(admReview v1.AdmissionReview) *v1.AdmissionResponse
+type mutateHandler func(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 
+// handleMutate is a common function that decodes an admission review request before handing it off to the
+// mutator for processing and then writes the response
 func handleMutate(logger logr.Logger, w http.ResponseWriter, r *http.Request, mutator mutateHandler) {
 	admReviewBody, err := io.ReadAll(r.Body)
 	defer func() {

--- a/pkg/webhook/mutatingwebhook/mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/mutate_test.go
@@ -105,7 +105,7 @@ func toReviewResponse(t *testing.T, admReviewContent []byte) admissionv1.Admissi
 }
 
 // fakeMutator is a mutator that returns a blank AdmissionResponse
-func fakeMutator(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+func fakeMutator(_ admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	return &admissionv1.AdmissionResponse{}
 }
 

--- a/pkg/webhook/mutatingwebhook/mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/mutate_test.go
@@ -180,14 +180,6 @@ func fakeMutator(t *testing.T, success bool) mutateHandler {
 	}
 }
 
-func combinePatches(patches ...map[string]interface{}) []map[string]interface{} {
-	patchItems := []map[string]interface{}{}
-	for _, patch := range patches {
-		patchItems = append(patchItems, patch)
-	}
-	return patchItems
-}
-
 func assertPatchesEqual(t *testing.T, expected, actual []map[string]interface{}) {
 	assert.Equal(t, len(expected), len(actual))
 	expectedPatchContent, err := json.Marshal(expected)

--- a/pkg/webhook/mutatingwebhook/mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/mutate_test.go
@@ -35,7 +35,7 @@ func TestHandleMutate(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// when
-		handleMutate(testLogger, rr, req, fakeMutator())
+		handleMutate(testLogger, rr, req, fakeMutator)
 
 		// then
 		assert.Equal(t, http.StatusOK, rr.Code)
@@ -50,7 +50,7 @@ func TestHandleMutate(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// when
-		handleMutate(testLogger, rr, req, fakeMutator())
+		handleMutate(testLogger, rr, req, fakeMutator)
 
 		// then
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
@@ -105,10 +105,8 @@ func toReviewResponse(t *testing.T, admReviewContent []byte) admissionv1.Admissi
 }
 
 // fakeMutator is a mutator that returns a blank AdmissionResponse
-func fakeMutator() mutateHandler {
-	return func(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-		return &admissionv1.AdmissionResponse{}
-	}
+func fakeMutator(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{}
 }
 
 func assertPatchesEqual(t *testing.T, expected, actual []map[string]interface{}) {

--- a/pkg/webhook/mutatingwebhook/mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/mutate_test.go
@@ -11,22 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var testLogger = logf.Log.WithName("test_mutate")
-
-type expectedSuccessResponse struct {
-	patch              string
-	auditAnnotationKey string
-	auditAnnotationVal string
-	uid                string
-}
-
-type expectedFailedResponse struct {
-	auditAnnotationKey string
-	errMsg             string
-}
 
 type badReader struct{}
 
@@ -44,18 +33,12 @@ func TestHandleMutate(t *testing.T) {
 			t.Fatal(err)
 		}
 		rr := httptest.NewRecorder()
-		expectedRespSuccess := expectedSuccessResponse{
-			auditAnnotationKey: "users_pods_mutating_webhook",
-			auditAnnotationVal: "the sandbox-users-pods PriorityClass was set",
-			uid:                "a68769e5-d817-4617-bec5-90efa2bad6f6",
-		}
 
 		// when
-		handleMutate(testLogger, rr, req, fakeMutator())
+		handleMutate(testLogger, rr, req, fakeMutator(t, true))
 
 		// then
 		assert.Equal(t, http.StatusOK, rr.Code)
-		verifySuccessfulResponse(t, rr.Body.Bytes(), expectedRespSuccess)
 	})
 
 	t.Run("fail to write response", func(t *testing.T) {
@@ -67,7 +50,7 @@ func TestHandleMutate(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// when
-		handleMutate(testLogger, rr, req, fakeMutator())
+		handleMutate(testLogger, rr, req, fakeMutator(t, false))
 
 		// then
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
@@ -75,42 +58,141 @@ func TestHandleMutate(t *testing.T) {
 	})
 }
 
-func verifySuccessfulResponse(t *testing.T, response []byte, expectedResp expectedSuccessResponse) {
-	reviewResponse := toReviewResponse(t, response)
-	assert.Equal(t, expectedResp.patch, string(reviewResponse.Patch))
-	assert.Contains(t, expectedResp.auditAnnotationVal, reviewResponse.AuditAnnotations[expectedResp.auditAnnotationKey])
-	assert.True(t, reviewResponse.Allowed)
-	assert.Equal(t, admissionv1.PatchTypeJSONPatch, *reviewResponse.PatchType)
-	assert.Empty(t, reviewResponse.Result)
-	assert.Equal(t, expectedResp.uid, string(reviewResponse.UID))
-}
-
-func verifyFailedResponse(t *testing.T, response []byte, expectedResp expectedFailedResponse) {
-	reviewResponse := toReviewResponse(t, response)
-	assert.Empty(t, string(reviewResponse.Patch))
-	assert.Empty(t, reviewResponse.AuditAnnotations[expectedResp.auditAnnotationKey])
-	assert.False(t, reviewResponse.Allowed)
-	assert.Nil(t, reviewResponse.PatchType)
-	assert.Empty(t, string(reviewResponse.UID))
-
-	require.NotEmpty(t, reviewResponse.Result)
-	assert.Contains(t, reviewResponse.Result.Message, expectedResp.errMsg)
-}
-
-func toReviewResponse(t *testing.T, content []byte) *admissionv1.AdmissionResponse {
-	r := admissionv1.AdmissionReview{}
-	err := json.Unmarshal(content, &r)
+func admissionReview(t *testing.T, admissionReviewJSONTemplate []byte, options ...admissionReviewOption) admissionv1.AdmissionReview {
+	// start with the unstructured AdmReview object from the fixed template
+	unstructuredAdmReview := &unstructured.Unstructured{}
+	err := unstructuredAdmReview.UnmarshalJSON(admissionReviewJSONTemplate)
 	require.NoError(t, err)
-	return r.Response
+
+	// apply any options to the unstructured AdmReview object
+	for _, opt := range options {
+		opt(t, unstructuredAdmReview)
+	}
+
+	// get the request object from the admReview
+	admReviewJSON, err := unstructuredAdmReview.MarshalJSON()
+	require.NoError(t, err)
+
+	// deserialize the request
+	admReview := admissionv1.AdmissionReview{}
+	_, _, err = deserializer.Decode(admReviewJSON, nil, &admReview)
+	require.NoError(t, err)
+
+	return admReview
 }
 
-func fakeMutator() mutateHandler {
+func admReviewRequestObject(t *testing.T, admissionReviewJSONTemplate []byte, options ...admissionReviewOption) *unstructured.Unstructured {
+	admReview := admissionReview(t, admissionReviewJSONTemplate, options...)
+	unstructuredRequestObj := &unstructured.Unstructured{}
+	err := unstructuredRequestObj.UnmarshalJSON(admReview.Request.Object.Raw)
+	require.NoError(t, err)
+	return unstructuredRequestObj
+}
+
+// func TestMutate(t *testing.T) {
+// 	t.Run("success", func(t *testing.T) {
+// 		// given
+// 		vmAdmReview := vmAdmissionReview(t)
+// 		// expectedResp := vmSuccessResponse(withVolumesPatch(t, cloudInitVolume()))
+
+// 		patchType := admissionv1.PatchTypeJSONPatch
+// 		expectedResp := admissionv1.AdmissionResponse{
+// 			Allowed: true,
+// 			AuditAnnotations: map[string]string{
+// 				"virtual_machines_mutating_webhook": "the resource limits and ssh key were set",
+// 			},
+// 			UID:       "d68b4f8c-c62d-4e83-bd73-de991ab8a56a",
+// 			Patch:     []byte{},
+// 			PatchType: &patchType,
+// 		}
+// 		addPatchToResponse(t, &expectedResp, volumesPatch(t, expectedCloudInitVolumeWithSSH()))
+
+// 		// when
+// 		response := mutate(podLogger, vmAdmReview, vmMutator)
+
+// 		// then
+// 		verifySuccessfulResponse(t, response, expectedResp)
+// 	})
+
+// 	t.Run("fails with invalid JSON", func(t *testing.T) {
+// 		// given
+// 		rawJSON := []byte(`something wrong !`)
+// 		var expectedResp = admissionv1.AdmissionResponse{
+// 			Result: &metav1.Status{
+// 				Message: "couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }",
+// 			},
+// 			UID: "",
+// 		}
+
+// 		// when
+// 		response := mutate(vmLogger, rawJSON, vmMutator)
+
+// 		// then
+// 		verifyFailedResponse(t, response, expectedResp)
+// 	})
+
+// 	t.Run("fails with invalid VM", func(t *testing.T) {
+// 		// when
+// 		rawJSON := []byte(`{
+//             "request": {
+//                 "object": 111
+//             }
+//         }`)
+// 		var expectedResp = admissionv1.AdmissionResponse{
+// 			Result: &metav1.Status{
+// 				Message: "unable unmarshal VirtualMachine json object - raw request object: [49 49 49]: json: cannot unmarshal number into Go value of type map[string]interface {}",
+// 			},
+// 			UID: "",
+// 		}
+
+// 		// when
+// 		response := mutate(vmLogger, rawJSON, vmMutator)
+
+// 		// then
+// 		verifyFailedResponse(t, response, expectedResp)
+// 	})
+// }
+
+func assertResponseEqual(t *testing.T, mutateHandlerResponse []byte, expectedResp admissionv1.AdmissionResponse) {
+	actualReviewResponse := toReviewResponse(t, mutateHandlerResponse)
+
+	t.Log("actualReviewResponse " + string(actualReviewResponse.Patch))
+	t.Log("expectedReviewResponse " + string(expectedResp.Patch))
+	assert.Equal(t, expectedResp, actualReviewResponse)
+}
+
+func verifyFailedResponse(t *testing.T, response []byte, expectedResp admissionv1.AdmissionResponse) {
+	actualReviewResponse := toReviewResponse(t, response)
+	assert.Equal(t, expectedResp, actualReviewResponse)
+}
+
+func toReviewResponse(t *testing.T, admReviewContent []byte) admissionv1.AdmissionResponse {
+	r := admissionv1.AdmissionReview{}
+	err := json.Unmarshal(admReviewContent, &r)
+	require.NoError(t, err)
+	return *r.Response
+}
+
+// fakeMutator is a mutator that returns a blank AdmissionResponse
+func fakeMutator(t *testing.T, success bool) mutateHandler {
 	return func(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-		patchType := admissionv1.PatchTypeJSONPatch
-		return &admissionv1.AdmissionResponse{
-			Allowed:   true,
-			UID:       admReview.Request.UID,
-			PatchType: &patchType,
-		}
+		return &admissionv1.AdmissionResponse{}
 	}
+}
+
+func combinePatches(patches ...map[string]interface{}) []map[string]interface{} {
+	patchItems := []map[string]interface{}{}
+	for _, patch := range patches {
+		patchItems = append(patchItems, patch)
+	}
+	return patchItems
+}
+
+func assertPatchesEqual(t *testing.T, expected, actual []map[string]interface{}) {
+	assert.Equal(t, len(expected), len(actual))
+	expectedPatchContent, err := json.Marshal(expected)
+	require.NoError(t, err)
+	actualPatchContent, err := json.Marshal(actual)
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedPatchContent), string(actualPatchContent))
 }

--- a/pkg/webhook/mutatingwebhook/mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/mutate_test.go
@@ -35,7 +35,7 @@ func TestHandleMutate(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// when
-		handleMutate(testLogger, rr, req, fakeMutator(t, true))
+		handleMutate(testLogger, rr, req, fakeMutator())
 
 		// then
 		assert.Equal(t, http.StatusOK, rr.Code)
@@ -50,7 +50,7 @@ func TestHandleMutate(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		// when
-		handleMutate(testLogger, rr, req, fakeMutator(t, false))
+		handleMutate(testLogger, rr, req, fakeMutator())
 
 		// then
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
@@ -89,80 +89,11 @@ func admReviewRequestObject(t *testing.T, admissionReviewJSONTemplate []byte, op
 	return unstructuredRequestObj
 }
 
-// func TestMutate(t *testing.T) {
-// 	t.Run("success", func(t *testing.T) {
-// 		// given
-// 		vmAdmReview := vmAdmissionReview(t)
-// 		// expectedResp := vmSuccessResponse(withVolumesPatch(t, cloudInitVolume()))
-
-// 		patchType := admissionv1.PatchTypeJSONPatch
-// 		expectedResp := admissionv1.AdmissionResponse{
-// 			Allowed: true,
-// 			AuditAnnotations: map[string]string{
-// 				"virtual_machines_mutating_webhook": "the resource limits and ssh key were set",
-// 			},
-// 			UID:       "d68b4f8c-c62d-4e83-bd73-de991ab8a56a",
-// 			Patch:     []byte{},
-// 			PatchType: &patchType,
-// 		}
-// 		addPatchToResponse(t, &expectedResp, volumesPatch(t, expectedCloudInitVolumeWithSSH()))
-
-// 		// when
-// 		response := mutate(podLogger, vmAdmReview, vmMutator)
-
-// 		// then
-// 		verifySuccessfulResponse(t, response, expectedResp)
-// 	})
-
-// 	t.Run("fails with invalid JSON", func(t *testing.T) {
-// 		// given
-// 		rawJSON := []byte(`something wrong !`)
-// 		var expectedResp = admissionv1.AdmissionResponse{
-// 			Result: &metav1.Status{
-// 				Message: "couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }",
-// 			},
-// 			UID: "",
-// 		}
-
-// 		// when
-// 		response := mutate(vmLogger, rawJSON, vmMutator)
-
-// 		// then
-// 		verifyFailedResponse(t, response, expectedResp)
-// 	})
-
-// 	t.Run("fails with invalid VM", func(t *testing.T) {
-// 		// when
-// 		rawJSON := []byte(`{
-//             "request": {
-//                 "object": 111
-//             }
-//         }`)
-// 		var expectedResp = admissionv1.AdmissionResponse{
-// 			Result: &metav1.Status{
-// 				Message: "unable unmarshal VirtualMachine json object - raw request object: [49 49 49]: json: cannot unmarshal number into Go value of type map[string]interface {}",
-// 			},
-// 			UID: "",
-// 		}
-
-// 		// when
-// 		response := mutate(vmLogger, rawJSON, vmMutator)
-
-// 		// then
-// 		verifyFailedResponse(t, response, expectedResp)
-// 	})
-// }
-
 func assertResponseEqual(t *testing.T, mutateHandlerResponse []byte, expectedResp admissionv1.AdmissionResponse) {
 	actualReviewResponse := toReviewResponse(t, mutateHandlerResponse)
 
 	t.Log("actualReviewResponse " + string(actualReviewResponse.Patch))
 	t.Log("expectedReviewResponse " + string(expectedResp.Patch))
-	assert.Equal(t, expectedResp, actualReviewResponse)
-}
-
-func verifyFailedResponse(t *testing.T, response []byte, expectedResp admissionv1.AdmissionResponse) {
-	actualReviewResponse := toReviewResponse(t, response)
 	assert.Equal(t, expectedResp, actualReviewResponse)
 }
 
@@ -174,7 +105,7 @@ func toReviewResponse(t *testing.T, admReviewContent []byte) admissionv1.Admissi
 }
 
 // fakeMutator is a mutator that returns a blank AdmissionResponse
-func fakeMutator(t *testing.T, success bool) mutateHandler {
+func fakeMutator() mutateHandler {
 	return func(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 		return &admissionv1.AdmissionResponse{}
 	}

--- a/pkg/webhook/mutatingwebhook/userpods_mutate.go
+++ b/pkg/webhook/mutatingwebhook/userpods_mutate.go
@@ -52,8 +52,8 @@ func podMutator(admReview v1.AdmissionReview) *v1.AdmissionResponse {
 	// let's unmarshal the object to be sure that it's a pod
 	var pod *corev1.Pod
 	if err := json.Unmarshal(admReview.Request.Object.Raw, &pod); err != nil {
-		podLogger.Error(err, "unable unmarshal pod json object", "AdmissionReview", admReview)
-		return responseWithError(admReview.Request.UID, errors.Wrapf(err, "unable unmarshal pod json object - raw request object: %v", admReview.Request.Object.Raw))
+		podLogger.Error(err, "failed to unmarshal pod json object", "AdmissionReview", admReview)
+		return responseWithError(admReview.Request.UID, errors.Wrap(err, "failed to unmarshal pod json object"))
 	}
 
 	patchType := v1.PatchTypeJSONPatch

--- a/pkg/webhook/mutatingwebhook/userpods_mutate.go
+++ b/pkg/webhook/mutatingwebhook/userpods_mutate.go
@@ -53,7 +53,7 @@ func podMutator(admReview v1.AdmissionReview) *v1.AdmissionResponse {
 	var pod *corev1.Pod
 	if err := json.Unmarshal(admReview.Request.Object.Raw, &pod); err != nil {
 		podLogger.Error(err, "unable unmarshal pod json object", "AdmissionReview", admReview)
-		return responseWithError(errors.Wrapf(err, "unable unmarshal pod json object - raw request object: %v", admReview.Request.Object.Raw))
+		return responseWithError(admReview.Request.UID, errors.Wrapf(err, "unable unmarshal pod json object - raw request object: %v", admReview.Request.Object.Raw))
 	}
 
 	patchType := v1.PatchTypeJSONPatch
@@ -66,7 +66,7 @@ func podMutator(admReview v1.AdmissionReview) *v1.AdmissionResponse {
 		"users_pods_mutating_webhook": "the sandbox-users-pods PriorityClass was set",
 	}
 
-	// instead of changing the pod object we need to tell K8s how to change the object
+	// instead of changing the pod object we need to tell K8s how to change the object via patch
 	resp.Patch = patchedContent
 
 	podLogger.Info("the sandbox-users-pods PriorityClass was set to the pod", "pod-name", pod.Name, "namespace", pod.Namespace)

--- a/pkg/webhook/mutatingwebhook/userpods_mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/userpods_mutate_test.go
@@ -95,7 +95,7 @@ func TestMutateUserPodsFailsOnInvalidJson(t *testing.T) {
 
 	// then
 	assert.Empty(t, actualResponse.UID)
-	assert.Contains(t, actualResponse.Result.Message, "unable unmarshal pod json object")
+	assert.Contains(t, actualResponse.Result.Message, "failed to unmarshal pod json object")
 }
 
 var userPodsRawAdmissionReviewJSON = []byte(`{

--- a/pkg/webhook/mutatingwebhook/vm_mutate.go
+++ b/pkg/webhook/mutatingwebhook/vm_mutate.go
@@ -140,7 +140,8 @@ func addSSHKeyToUserData(userDataString string, sshKey string) (string, error) {
 		return "", err
 	}
 
-	authorizedKeys, authorizedKeysFound := userData["ssh_authorized_keys"].([]string)
+	authorizedKeysInfc, authorizedKeysFound := userData["ssh_authorized_keys"]
+
 	sshValue := sshKey
 	// ensure the ssh key has a newline at the end so that it is properly unmarshalled later
 	if !strings.HasSuffix(sshKey, "\n") {
@@ -148,8 +149,9 @@ func addSSHKeyToUserData(userDataString string, sshKey string) (string, error) {
 	}
 
 	if authorizedKeysFound {
+		authKeys := authorizedKeysInfc.([]interface{})
 		// append the key to the existing list
-		userData["ssh_authorized_keys"] = append(authorizedKeys, sshValue)
+		userData["ssh_authorized_keys"] = append(authKeys, sshValue)
 	} else {
 		// create a new list with the key
 		userData["ssh_authorized_keys"] = []string{sshValue}

--- a/pkg/webhook/mutatingwebhook/vm_mutate.go
+++ b/pkg/webhook/mutatingwebhook/vm_mutate.go
@@ -26,8 +26,8 @@ func HandleMutateVirtualMachines(w http.ResponseWriter, r *http.Request) {
 func vmMutator(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	unstructuredRequestObj := &unstructured.Unstructured{}
 	if err := unstructuredRequestObj.UnmarshalJSON(admReview.Request.Object.Raw); err != nil {
-		vmLogger.Error(err, "unable unmarshal VirtualMachine json object", "AdmissionReview", admReview)
-		return responseWithError(admReview.Request.UID, errors.Wrapf(err, "unable unmarshal VirtualMachine json object - raw request object: %v", admReview.Request.Object.Raw))
+		vmLogger.Error(err, "failed to unmarshal VirtualMachine json object", "AdmissionReview", admReview)
+		return responseWithError(admReview.Request.UID, errors.Wrap(err, "failed to unmarshal VirtualMachine json object"))
 	}
 
 	patchType := admissionv1.PatchTypeJSONPatch
@@ -57,7 +57,7 @@ func vmMutator(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResp
 	patchContent, err := json.Marshal(vmPatchItems)
 	if err != nil {
 		vmLogger.Error(err, "failed to marshal patch items for VirtualMachine", "AdmissionReview", admReview, "Patch-Items", vmPatchItems)
-		return responseWithError(admReview.Request.UID, errors.Wrapf(err, "unable to marshal patch items for VirtualMachine - raw request object: %v", admReview.Request.Object.Raw))
+		return responseWithError(admReview.Request.UID, errors.Wrapf(err, "failed to marshal patch items for VirtualMachine - raw request object: %v", admReview.Request.Object.Raw))
 	}
 	resp.Patch = patchContent
 

--- a/pkg/webhook/mutatingwebhook/vm_mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/vm_mutate_test.go
@@ -20,7 +20,7 @@ var cloudInitConfigDrive cloudInitConfigType = "cloudInitConfigDrive"
 func TestVMMutator(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// given
-		admReview := admissionReview(t, vmRawAdmissionReviewJSONTemplate, setVolumes(t, rootDiskVolume(), cloudInitVolume(cloudInitNoCloud, userDataWithoutSSHKey)))
+		admReview := admissionReview(t, vmRawAdmissionReviewJSONTemplate, setVolumes(rootDiskVolume(), cloudInitVolume(cloudInitNoCloud, userDataWithoutSSHKey)))
 		expectedVolumes := cloudInitVolume(cloudInitNoCloud, userDataWithSSHKey) // expect SSH key will be added to userData
 		expectedVolumesPatch := []map[string]interface{}{volumesPatch(expectedVolumes)}
 
@@ -63,7 +63,7 @@ func TestEnsureLimits(t *testing.T) {
 	t.Run("only memory request is set", func(t *testing.T) {
 		// given
 		req := resourceList("1Gi", "")
-		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(t, req))
+		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(req))
 
 		expectedLimits := resourceList("1Gi", "")
 		expectedPatchItems := []map[string]interface{}{limitsPatch(expectedLimits)} // only memory limits patch expected
@@ -79,7 +79,7 @@ func TestEnsureLimits(t *testing.T) {
 	t.Run("memory and cpu requests are set", func(t *testing.T) {
 		// given
 		req := resourceList("1Gi", "1")
-		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(t, req))
+		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(req))
 		expectedLimits := resourceList("1Gi", "1")
 		expectedPatchItems := []map[string]interface{}{limitsPatch(expectedLimits)} // limits patch with memory and cpu expected
 		actualPatchItems := []map[string]interface{}{}
@@ -95,7 +95,7 @@ func TestEnsureLimits(t *testing.T) {
 		// given
 		req := resourceList("1Gi", "1")
 		lim := resourceList("2Gi", "2")
-		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(t, req), setLimits(t, lim))
+		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(req), setLimits(lim))
 		actualPatchItems := []map[string]interface{}{}
 
 		// when
@@ -109,7 +109,7 @@ func TestEnsureLimits(t *testing.T) {
 		// given
 		req := resourceList("1Gi", "1")
 		lim := resourceList("2Gi", "")
-		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(t, req), setLimits(t, lim))
+		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(req), setLimits(lim))
 		actualPatchItems := []map[string]interface{}{}
 		expectedLimits := resourceList("2Gi", "1") // expect cpu limit to be set to the value of the cpu request
 		expectedPatchItems := []map[string]interface{}{limitsPatch(expectedLimits)}
@@ -125,7 +125,7 @@ func TestEnsureLimits(t *testing.T) {
 		// given
 		req := resourceList("1Gi", "1")
 		lim := resourceList("", "2")
-		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(t, req), setLimits(t, lim))
+		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(req), setLimits(lim))
 		actualPatchItems := []map[string]interface{}{}
 		expectedLimits := resourceList("1Gi", "2") // expect memory limit to be set to the value of the memory request
 		expectedPatchItems := []map[string]interface{}{limitsPatch(expectedLimits)}
@@ -141,7 +141,7 @@ func TestEnsureLimits(t *testing.T) {
 		// given
 		req := resourceList("1Gi", "1")
 		lim := resourceList("", "2")
-		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(t, req), setLimits(t, lim))
+		vmAdmReviewRequest := vmAdmReviewRequestObject(t, setRequests(req), setLimits(lim))
 		existingPatch := map[string]interface{}{
 			"op":    "add",
 			"path":  "/spec/template/spec/test",
@@ -166,7 +166,7 @@ func TestEnsureVolumeConfig(t *testing.T) {
 		t.Run("cloudinitdisk with cloudInitNoCloud config found", func(t *testing.T) {
 			t.Run("userData found", func(t *testing.T) {
 				// given
-				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(t, rootDiskVolume(), cloudInitVolume(cloudInitNoCloud, userDataWithoutSSHKey))) // userData without SSH key
+				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(rootDiskVolume(), cloudInitVolume(cloudInitNoCloud, userDataWithoutSSHKey))) // userData without SSH key
 				actualPatchItems := []map[string]interface{}{}
 				expectedVolumes := cloudInitVolume(cloudInitNoCloud, userDataWithSSHKey) // expect SSH key will be added to userData
 				expectedPatchItems := []map[string]interface{}{volumesPatch(expectedVolumes)}
@@ -181,7 +181,7 @@ func TestEnsureVolumeConfig(t *testing.T) {
 
 			t.Run("userData not found", func(t *testing.T) {
 				// given
-				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(t, rootDiskVolume(), cloudInitVolume(cloudInitNoCloud, ""))) // no userData
+				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(rootDiskVolume(), cloudInitVolume(cloudInitNoCloud, ""))) // no userData
 				actualPatchItems := []map[string]interface{}{}
 				expectedVolumes := cloudInitVolume(cloudInitNoCloud, defaultUserData("ssh-rsa tmpkey human@machine")) // expect default userData will be set
 				expectedPatchItems := []map[string]interface{}{volumesPatch(expectedVolumes)}
@@ -199,7 +199,7 @@ func TestEnsureVolumeConfig(t *testing.T) {
 		t.Run("cloudinitdisk with cloudInitConfigDrive config found", func(t *testing.T) {
 			t.Run("userData found", func(t *testing.T) {
 				// given
-				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(t, rootDiskVolume(), cloudInitVolume(cloudInitConfigDrive, userDataWithoutSSHKey))) // userData without SSH key
+				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(rootDiskVolume(), cloudInitVolume(cloudInitConfigDrive, userDataWithoutSSHKey))) // userData without SSH key
 				actualPatchItems := []map[string]interface{}{}
 				expectedVolumes := cloudInitVolume(cloudInitConfigDrive, userDataWithSSHKey) // expect SSH key will be added to userData
 				expectedPatchItems := []map[string]interface{}{volumesPatch(expectedVolumes)}
@@ -214,7 +214,7 @@ func TestEnsureVolumeConfig(t *testing.T) {
 
 			t.Run("userData not found", func(t *testing.T) {
 				// given
-				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(t, rootDiskVolume(), cloudInitVolume(cloudInitConfigDrive, ""))) // no userData
+				vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(rootDiskVolume(), cloudInitVolume(cloudInitConfigDrive, ""))) // no userData
 				actualPatchItems := []map[string]interface{}{}
 				expectedVolumes := cloudInitVolume(cloudInitConfigDrive, defaultUserData("ssh-rsa tmpkey human@machine")) // expect default userData will be set
 				expectedPatchItems := []map[string]interface{}{volumesPatch(expectedVolumes)}
@@ -264,7 +264,7 @@ func TestEnsureVolumeConfig(t *testing.T) {
 
 		t.Run("cloudinitdisk volume not found", func(t *testing.T) {
 			// given
-			vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(t, rootDiskVolume())) // missing cloudinitdisk volume
+			vmAdmReviewRequest := vmAdmReviewRequestObject(t, setVolumes(rootDiskVolume())) // missing cloudinitdisk volume
 			actualPatchItems := []map[string]interface{}{}
 
 			// when
@@ -310,39 +310,23 @@ func TestAddSSHKeyToUserData(t *testing.T) {
 	})
 }
 
-func addPatchToResponse(t *testing.T, resp *admissionv1.AdmissionResponse, expectedPatch map[string]interface{}) {
-	respPatches := []map[string]interface{}{}
-
-	if string(resp.Patch) != "" {
-		err := json.Unmarshal(resp.Patch, &respPatches)
-		require.NoError(t, err)
-	}
-
-	respPatches = append(respPatches, expectedPatch)
-
-	updatedPatchContent, err := json.Marshal(respPatches)
-	require.NoError(t, err)
-
-	resp.Patch = updatedPatchContent
-}
-
 type admissionReviewOption func(t *testing.T, unstructuredAdmReview *unstructured.Unstructured)
 
-func setRequests(t *testing.T, requests map[string]interface{}) admissionReviewOption {
+func setRequests(requests map[string]interface{}) admissionReviewOption {
 	return func(t *testing.T, unstructuredAdmReview *unstructured.Unstructured) {
 		err := unstructured.SetNestedMap(unstructuredAdmReview.Object, requests, "request", "object", "spec", "template", "spec", "domain", "resources", "requests")
 		require.NoError(t, err)
 	}
 }
 
-func setLimits(t *testing.T, limits map[string]interface{}) admissionReviewOption {
+func setLimits(limits map[string]interface{}) admissionReviewOption {
 	return func(t *testing.T, unstructuredAdmReview *unstructured.Unstructured) {
 		err := unstructured.SetNestedMap(unstructuredAdmReview.Object, limits, "request", "object", "spec", "template", "spec", "domain", "resources", "limits")
 		require.NoError(t, err)
 	}
 }
 
-func setVolumes(t *testing.T, volumes ...interface{}) admissionReviewOption {
+func setVolumes(volumes ...interface{}) admissionReviewOption {
 	return func(t *testing.T, unstructuredAdmReview *unstructured.Unstructured) {
 		err := unstructured.SetNestedSlice(unstructuredAdmReview.Object, volumes, "request", "object", "spec", "template", "spec", "volumes")
 		require.NoError(t, err)


### PR DESCRIPTION
https://issues.redhat.com/browse/SANDBOX-363

- Adds logic to parse userData for both cloudInitNoCloud and cloudInitConfigDrive volumes and update the data
- Refactored and simplified the unit tests for mutating webhooks
- Temporarily hardcoding a fake key, will have a separate PR for retrieval from config

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/830