### PR TITLE
refactored member operator to only use properties from propagated claims

### DIFF
--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -244,8 +244,8 @@ func (r *Reconciler) ensureUser(ctx context.Context, config membercfg.Configurat
 		expectedIdentities = append(expectedIdentities, commonidentity.NewIdentityNamingStandard(userAcc.Spec.PropagatedClaims.OriginalSub, config.Auth().Idp()).IdentityName())
 	}
 
-	// Also if the sso-user-id annotation is set, then another additional identity is required if it is a different value to the Spec.UserID
-	if userAcc.Spec.PropagatedClaims.UserID != "" && userAcc.Spec.PropagatedClaims.UserID != userAcc.Spec.UserID {
+	// Also if the UserID property is set, then an additional identity is required if it is a different value to the Sub
+	if userAcc.Spec.PropagatedClaims.UserID != "" && userAcc.Spec.PropagatedClaims.UserID != userAcc.Spec.PropagatedClaims.Sub {
 		expectedIdentities = append(expectedIdentities, commonidentity.NewIdentityNamingStandard(
 			userAcc.Spec.PropagatedClaims.UserID, config.Auth().Idp()).IdentityName())
 	}
@@ -630,7 +630,7 @@ func newUser(userAcc *toolchainv1alpha1.UserAccount, config membercfg.Configurat
 	if userAcc.Spec.PropagatedClaims.OriginalSub != "" {
 		identities = append(identities, commonidentity.NewIdentityNamingStandard(userAcc.Spec.PropagatedClaims.OriginalSub, config.Auth().Idp()).IdentityName())
 	}
-	if userAcc.Spec.PropagatedClaims.UserID != "" && userAcc.Spec.PropagatedClaims.UserID != userAcc.Spec.PropagatedClaims.OriginalSub {
+	if userAcc.Spec.PropagatedClaims.UserID != "" && userAcc.Spec.PropagatedClaims.UserID != userAcc.Spec.PropagatedClaims.Sub {
 		identities = append(identities, commonidentity.NewIdentityNamingStandard(userAcc.Spec.PropagatedClaims.UserID, config.Auth().Idp()).IdentityName())
 	}
 

--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -282,7 +282,7 @@ func (r *Reconciler) ensureUser(ctx context.Context, config membercfg.Configurat
 }
 
 func (r *Reconciler) ensureIdentity(ctx context.Context, config membercfg.Configuration, userAcc *toolchainv1alpha1.UserAccount, user *userv1.User) (*userv1.Identity, bool, error) {
-	identity, createdOrUpdated, err := r.loadIdentityAndEnsureMapping(ctx, config, userAcc.Spec.UserID, userAcc, user)
+	identity, createdOrUpdated, err := r.loadIdentityAndEnsureMapping(ctx, config, userAcc.Spec.PropagatedClaims.Sub, userAcc, user)
 	if createdOrUpdated || err != nil {
 		return nil, createdOrUpdated, err
 	}
@@ -626,7 +626,7 @@ func (r *Reconciler) updateStatusConditions(ctx context.Context, userAcc *toolch
 }
 
 func newUser(userAcc *toolchainv1alpha1.UserAccount, config membercfg.Configuration) *userv1.User {
-	identities := []string{commonidentity.NewIdentityNamingStandard(userAcc.Spec.UserID, config.Auth().Idp()).IdentityName()}
+	identities := []string{commonidentity.NewIdentityNamingStandard(userAcc.Spec.PropagatedClaims.Sub, config.Auth().Idp()).IdentityName()}
 	if userAcc.Spec.PropagatedClaims.OriginalSub != "" {
 		identities = append(identities, commonidentity.NewIdentityNamingStandard(userAcc.Spec.PropagatedClaims.OriginalSub, config.Auth().Idp()).IdentityName())
 	}


### PR DESCRIPTION
This PR is a total refactor of the UserAccountController to use the values stored in PropagatedClaims instead of any other property or annotation values that are derived from the user's SSO token.

Fixes https://issues.redhat.com/browse/SANDBOX-431

E2E tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/858