### PR TITLE
Don't use email annotation, use PropagatedClaims instead

### DIFF
--- a/controllers/useraccount/useraccount_controller.go
+++ b/controllers/useraccount/useraccount_controller.go
@@ -394,7 +394,7 @@ func setLabelsAndAnnotations(object metav1.Object, userAcc *toolchainv1alpha1.Us
 			if annotations == nil {
 				annotations = map[string]string{}
 			}
-			annotations[toolchainv1alpha1.UserEmailAnnotationKey] = userAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey]
+			annotations[toolchainv1alpha1.UserEmailAnnotationKey] = userAcc.Spec.PropagatedClaims.Email
 			object.SetAnnotations(annotations)
 			changed = true
 		}

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -88,7 +88,7 @@ func TestReconcile(t *testing.T) {
 				toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue,
 			},
 			Annotations: map[string]string{
-				toolchainv1alpha1.UserEmailAnnotationKey: userAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey],
+				toolchainv1alpha1.UserEmailAnnotationKey: userAcc.Spec.PropagatedClaims.Email,
 			},
 		},
 		Identities: []string{
@@ -1176,7 +1176,7 @@ func TestCreateIdentitiesOKWhenSSOUserIDAnnotationPresent(t *testing.T) {
 				toolchainv1alpha1.ProviderLabelKey:  toolchainv1alpha1.ProviderLabelValue,
 			},
 			Annotations: map[string]string{
-				toolchainv1alpha1.UserEmailAnnotationKey: userAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey],
+				toolchainv1alpha1.UserEmailAnnotationKey: userAcc.Spec.PropagatedClaims.Email,
 			},
 		},
 		Identities: []string{
@@ -1551,7 +1551,7 @@ func assertUser(t *testing.T, r *Reconciler, userAcc *toolchainv1alpha1.UserAcco
 	assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, user.Labels[toolchainv1alpha1.ProviderLabelKey])
 
 	assert.NotNil(t, user.Annotations)
-	assert.Equal(t, userAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey], user.Annotations[toolchainv1alpha1.UserEmailAnnotationKey])
+	assert.Equal(t, userAcc.Spec.PropagatedClaims.Email, user.Annotations[toolchainv1alpha1.UserEmailAnnotationKey])
 
 	assert.Empty(t, user.OwnerReferences) // User has no explicit owner reference.// Check the user identity mapping
 	return user
@@ -1605,9 +1605,6 @@ func newUserAccount(userName, userID string, opts ...userAccountOption) *toolcha
 			UID:       types.UID(uuid.Must(uuid.NewV4()).String()),
 			Labels: map[string]string{
 				toolchainv1alpha1.TierLabelKey: "basic",
-			},
-			Annotations: map[string]string{
-				toolchainv1alpha1.UserEmailAnnotationKey: userName + "@acme.com",
 			},
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -1608,7 +1608,6 @@ func newUserAccount(userName, userID string, opts ...userAccountOption) *toolcha
 			},
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{
-			UserID: userID,
 			PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
 				Email:     userName + "@acme.com",
 				UserID:    "123456",


### PR DESCRIPTION
Minor addition to previous refactoring of UserAccountController to use the Email property from PropagatedClaims instead of the `email` annotation.