### PR TITLE
Updating the APi Dependencies for Drop unused parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20231107202930-b028ae440a26
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb
+	github.com/codeready-toolchain/api v0.0.0-20231122125952-9e6527f5e746
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20231122135421-3933b292cbb6
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
 	// using latest commit from 'github.com/openshift/api branch release-4.12'

--- a/go.sum
+++ b/go.sum
@@ -134,12 +134,10 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20231107202930-b028ae440a26 h1:7l/9jcykzh/Qq93EnPYQYpaejPkWaaHB6BLCwTKngJE=
-github.com/codeready-toolchain/api v0.0.0-20231107202930-b028ae440a26/go.mod h1:bImSKnxrpNmCmW/YEGiiZnZqJm3kAmfP5hW4YndK0hE=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231113200037-9a9f915098e3 h1:sPXhmaRcT7y5rsuXFp3p0dgl6a7SixFVnZLAPRJYClU=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231113200037-9a9f915098e3/go.mod h1:gyyXkpyEXoJJyHLuHBh/fckZ9XqjeP2AKlKkG/r9wpk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb h1:TVgy4tO2oy2YwWTZXXYytY9soshylURDzmdkY6ch1+o=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231117145902-3e7430ae48bb/go.mod h1:fmMAvkwt/OfANx8l/BDbuaHkjInlRJ3uYmIjjVmjd9w=
+github.com/codeready-toolchain/api v0.0.0-20231122125952-9e6527f5e746 h1:By8gc3SbJl1GHf7LfPTxfLYC0IuTeF4wiZHvtBxPx4s=
+github.com/codeready-toolchain/api v0.0.0-20231122125952-9e6527f5e746/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231122135421-3933b292cbb6 h1:+xecIaHMA1T9fioEVWsR9hyh736xHLBZEY6h3LWdj9M=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231122135421-3933b292cbb6/go.mod h1:SonFn2Nu9p70l4gYaf4+XUzCn9dQdpFfpqQ+E4MVILU=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
Updating the APi Dependencies
This is to Drop unused parameters from the embedded MUR.Status.UserAccounts.Clusters type
Related PRs
API - https://github.com/codeready-toolchain/api/pull/387