### PR TITLE
RHTAPBUGS-1070 tasks can overwrite others

### DIFF
--- a/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
+++ b/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
@@ -5,19 +5,6 @@ metadata:
   name: appstudio-pipelines-runner
 rules:
 - apiGroups:
-  - tekton.dev
-  resources:
-  - taskruns
-  verbs:
-  - get
-  - patch
-- apiGroups:
-  - tekton.dev
-  resources:
-  - taskruns/status
-  verbs:
-  - patch
-- apiGroups:
   - ""
   resources:
   - secrets


### PR DESCRIPTION
This removes the ability for TaskRuns to modify themselves. This was previously used by the JVM build service but should no longer be nessesary.