### PR TITLE
chore(RHTAPWATCH-765): appstudio-pipeline can manage SpaceRequests

### DIFF
--- a/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
+++ b/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
@@ -1,4 +1,4 @@
-# permissions to be able to apply templates for appstudio tier
+# permissions to be able to apply templates for appstudio tier and create SpaceRequests
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -25,3 +25,12 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - spacerequests
+  verbs:
+  - get
+  - create
+  - delete
+


### PR DESCRIPTION
In order to create ephemeral namespaces for
testing konflux components, the appstudio-pipeline
service account needs to be able to manage (create, delete, get) the SpaceRequest custom resource.

~Related PR:  https://github.com/redhat-appstudio/infra-deployments/pull/3203~