### PR TITLE
chore: grant pipelines-runner additional spacerequest permissions

### DIFF
--- a/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
+++ b/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
@@ -33,4 +33,6 @@ rules:
   - get
   - create
   - delete
+  - list
+  - watch
 


### PR DESCRIPTION
The appstudio-pipelines-runner needs watch/list/delete permissions for spacerequests.