### PR TITLE
Ensure sandbox toleration

### DIFF
--- a/pkg/webhook/mutatingwebhook/vm_mutate.go
+++ b/pkg/webhook/mutatingwebhook/vm_mutate.go
@@ -265,7 +265,12 @@ func ensureTolerations(unstructuredRequestObj *unstructured.Unstructured, patchI
 		return patchItems
 	}
 
-	// no need to check original contents of tolerations, if there were existing tolerations the sandbox one will be appended; if there were no tolerations then the patch will add the sandbox toleration
+	for _, toleration := range tolerations {
+		tol, ok := toleration.(map[string]interface{})
+		if ok && tol["key"] == "sandbox-cnv" {
+			return patchItems // the toleration already exists
+		}
+	}
 	tolerations = append(tolerations, sandboxToleration)
 	patchItems = append(patchItems, addTolerations(tolerations))
 

--- a/pkg/webhook/mutatingwebhook/vm_mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/vm_mutate_test.go
@@ -434,6 +434,23 @@ func TestEnsureTolerations(t *testing.T) {
 			// then
 			assertPatchesEqual(t, expectedPatchItems, actualPatchItems)
 		})
+
+		t.Run("existing sandbox-cnv toleration", func(t *testing.T) {
+			// given
+			anotherToleration := map[string]interface{}{
+				"effect":   "NoSchedule",
+				"key":      "another",
+				"operator": "Exists",
+			}
+			// expect existing toleration and sandbox toleration
+			vmAdmReviewRequestObj := vmAdmReviewRequestObject(t, setTolerations(anotherToleration, sandboxToleration))
+
+			// when
+			actualPatchItems := ensureTolerations(vmAdmReviewRequestObj, []map[string]interface{}{})
+
+			// then
+			assert.Empty(t, actualPatchItems) // sandbox toleration exists so patch not needed
+		})
 	})
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SANDBOX-499

Updates the member webhook to ensure the sandbox toleration is set on VM resources so that the VM can be scheduled on the BM node.
```
      tolerations:
      - effect: NoSchedule
        key: sandbox-cnv
        operator: Exists
```

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/898