### PR TITLE
Create templates with member ToolchainCluster-related manifests

### DIFF
--- a/deploy/toolchaincluster/member-sa.yaml
+++ b/deploy/toolchaincluster/member-sa.yaml
@@ -23,9 +23,13 @@ rules:
   - tokenreviews
   verbs:
   - create
-- apiGroups: [""]
-  resources: ["users", "groups"]
-  verbs: ["impersonate"]
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  verbs:
+  - impersonate
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:

--- a/deploy/toolchaincluster/member-sa.yaml
+++ b/deploy/toolchaincluster/member-sa.yaml
@@ -1,0 +1,109 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: toolchaincluster-member
+  namespace: {{.Namespace}}
+rules:
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - "idlers"
+  - "nstemplatesets"
+  - "memberoperatorconfigs"
+  - "memberstatuses"
+  - "toolchainclusters"
+  - "useraccounts"
+  verbs:
+  - "*"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: toolchaincluster-member-toolchain-member-operator-toolchaincluster
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: [""]
+  resources: ["users", "groups"]
+  verbs: ["impersonate"]
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - "spacerequests"
+  verbs:
+  - "*"
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - spacerequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - spacerequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  - "serviceaccounts/token"
+  verbs:
+  - "*"
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - "spacebindingrequests"
+  verbs:
+  - "*"
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - spacebindingrequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - spacebindingrequests/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: toolchaincluster-member-toolchain-member-operator-toolchaincluster
+subjects:
+- kind: ServiceAccount
+  name: toolchaincluster-member
+  namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: toolchaincluster-member-toolchain-member-operator-toolchaincluster
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/toolchaincluster/member-sa.yaml
+++ b/deploy/toolchaincluster/member-sa.yaml
@@ -8,12 +8,7 @@ rules:
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:
-  - "idlers"
-  - "nstemplatesets"
-  - "memberoperatorconfigs"
-  - "memberstatuses"
-  - "toolchainclusters"
-  - "useraccounts"
+  - "*"
   verbs:
   - "*"
 ---

--- a/deploy/toolchaincluster/member-sa.yaml
+++ b/deploy/toolchaincluster/member-sa.yaml
@@ -20,7 +20,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: toolchaincluster-member-toolchain-member-operator-toolchaincluster
+  name: toolchaincluster-member-{{.Namespace}}-toolchaincluster
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -98,12 +98,12 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: toolchaincluster-member-toolchain-member-operator-toolchaincluster
+  name: toolchaincluster-member-{{.Namespace}}-toolchaincluster
 subjects:
 - kind: ServiceAccount
   name: toolchaincluster-member
   namespace: {{.Namespace}}
 roleRef:
   kind: ClusterRole
-  name: toolchaincluster-member-toolchain-member-operator-toolchaincluster
+  name: toolchaincluster-member-{{.Namespace}}-toolchaincluster
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/toolchaincluster/member-sa.yaml
+++ b/deploy/toolchaincluster/member-sa.yaml
@@ -15,7 +15,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: toolchaincluster-member-{{.Namespace}}-toolchaincluster
+  name: toolchaincluster-{{.Namespace}}
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -93,12 +93,12 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: toolchaincluster-member-{{.Namespace}}-toolchaincluster
+  name: toolchaincluster-{{.Namespace}}
 subjects:
 - kind: ServiceAccount
   name: toolchaincluster-member
   namespace: {{.Namespace}}
 roleRef:
   kind: ClusterRole
-  name: toolchaincluster-member-{{.Namespace}}-toolchaincluster
+  name: toolchaincluster-{{.Namespace}}
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR adds only the manifests for the member toolchaincluster SA, ClusterRole and ClusterRoleBinding. The functionality for applying the manifests in the cluster will be implemented in follow up PRs.

For now there's a common functionality that parses those manifests from `embed.FS` filesystem.
https://github.com/codeready-toolchain/toolchain-common/pull/365

Those resources are now applied by the `add-cluster.sh` script, see: https://github.com/codeready-toolchain/toolchain-cicd/blob/34ea85fe21ae05c9bb1a0a2bbdc986b94c8d9e92/scripts/add-cluster.sh#L36

Jira: https://issues.redhat.com/browse/KSPACE-7

Related PRs:
common: https://github.com/codeready-toolchain/toolchain-common/pull/365
host-operator: https://github.com/codeready-toolchain/host-operator/pull/974