### PR TITLE
fix octokit/request-action version

### DIFF
--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
     # Is executed only for comment events - in that case the pull_request field is empty
     - name: Send Github API Request to get PR data
       id: request
-      uses: octokit/request-action@v2
+      uses: octokit/request-action@v2.1.9
       if: ${{ github.event.pull_request == '' }}
       with:
         route: ${{ github.event.issue.pull_request.url }}


### PR DESCRIPTION
my bad, I thought '@v2' would work, but it does not: https://github.com/codeready-toolchain/member-operator/actions/runs/8157751678/job/22298124082\?pr\=539

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>