### PR TITLE
KSPACE-43: Adding common GetClusters func

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -56,7 +56,7 @@ type Reconciler struct {
 	AllNamespacesClient client.Client
 	ScalesClient        scale.ScalesGetter
 	DynamicClient       dynamic.Interface
-	GetHostCluster      cluster.GetHostClusterFunc
+	GetHostCluster      cluster.GetClustersFunc
 	Namespace           string
 }
 
@@ -195,8 +195,8 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 func (r *Reconciler) createNotification(ctx context.Context, idler *toolchainv1alpha1.Idler, appName string, appType string) error {
 	log.FromContext(ctx).Info("Create Notification")
 	//Get the HostClient
-	hostCluster, ok := r.GetHostCluster()
-	if !ok {
+	clusters := r.GetHostCluster()
+	if len(clusters) != 1 {
 		return fmt.Errorf("unable to get the host cluster")
 	}
 	//check the condition on Idler if notification already sent, only create a notification if not created before
@@ -204,7 +204,7 @@ func (r *Reconciler) createNotification(ctx context.Context, idler *toolchainv1a
 		// notification already created
 		return nil
 	}
-
+	hostCluster := clusters[0]
 	notificationName := fmt.Sprintf("%s-%s", idler.Name, toolchainv1alpha1.NotificationTypeIdled)
 	notification := &toolchainv1alpha1.Notification{}
 	// Check if notification already exists in host

--- a/controllers/memberstatus/memberstatus_controller.go
+++ b/controllers/memberstatus/memberstatus_controller.go
@@ -61,7 +61,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 type Reconciler struct {
 	Client              client.Client
 	Scheme              *runtime.Scheme
-	GetHostCluster      func() (*cluster.CachedToolchainCluster, bool)
+	GetHostCluster      cluster.GetClustersFunc
 	AllNamespacesClient client.Client
 	VersionCheckManager status.VersionCheckManager
 }
@@ -150,9 +150,9 @@ func (r *Reconciler) aggregateAndUpdateStatus(ctx context.Context, memberStatus 
 func (r *Reconciler) hostConnectionHandleStatus(ctx context.Context, memberStatus *toolchainv1alpha1.MemberStatus, config membercfg.Configuration) error {
 
 	attributes := status.ToolchainClusterAttributes{
-		GetClusterFunc: r.GetHostCluster,
-		Period:         config.ToolchainCluster().HealthCheckPeriod(),
-		Timeout:        config.ToolchainCluster().HealthCheckTimeout(),
+		GetClustersFunc: r.GetHostCluster,
+		Period:          config.ToolchainCluster().HealthCheckPeriod(),
+		Timeout:         config.ToolchainCluster().HealthCheckTimeout(),
 	}
 
 	// look up host connection status

--- a/controllers/memberstatus/memberstatus_controller_test.go
+++ b/controllers/memberstatus/memberstatus_controller_test.go
@@ -695,26 +695,26 @@ func newMemberDeploymentWithConditions(deploymentConditions ...appsv1.Deployment
 	}
 }
 
-func newGetHostClusterReady(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterReady(fakeClient client.Client) cluster.GetClustersFunc {
 	return NewGetHostClusterWithProbe(fakeClient, true, corev1.ConditionTrue, metav1.Now())
 }
 
-func newGetHostClusterNotReady(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterNotReady(fakeClient client.Client) cluster.GetClustersFunc {
 	return NewGetHostClusterWithProbe(fakeClient, true, corev1.ConditionFalse, metav1.Now())
 }
 
-func newGetHostClusterProbeNotWorking(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterProbeNotWorking(fakeClient client.Client) cluster.GetClustersFunc {
 	aMinuteAgo := metav1.Time{
 		Time: time.Now().Add(time.Duration(-60 * time.Second)),
 	}
 	return NewGetHostClusterWithProbe(fakeClient, true, corev1.ConditionTrue, aMinuteAgo)
 }
 
-func newGetHostClusterNotExist(fakeClient client.Client) cluster.GetHostClusterFunc {
+func newGetHostClusterNotExist(fakeClient client.Client) cluster.GetClustersFunc {
 	return NewGetHostClusterWithProbe(fakeClient, false, corev1.ConditionFalse, metav1.Now())
 }
 
-func prepareReconcile(t *testing.T, requestName string, getHostClusterFunc func(fakeClient client.Client) cluster.GetHostClusterFunc, allNamespacesClient *test.FakeClient, lastGitHubAPICall time.Time, mockedGitHubClient commonclient.GetGitHubClientFunc, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
+func prepareReconcile(t *testing.T, requestName string, getHostClusterFunc func(fakeClient client.Client) cluster.GetClustersFunc, allNamespacesClient *test.FakeClient, lastGitHubAPICall time.Time, mockedGitHubClient commonclient.GetGitHubClientFunc, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	os.Setenv("WATCH_NAMESPACE", test.MemberOperatorNs)
 	fakeClient := test.NewFakeClient(t, initObjs...)

--- a/controllers/nstemplateset/client.go
+++ b/controllers/nstemplateset/client.go
@@ -19,7 +19,7 @@ type APIClient struct {
 	AllNamespacesClient runtimeclient.Client
 	Client              runtimeclient.Client
 	Scheme              *runtime.Scheme
-	GetHostCluster      cluster.GetHostClusterFunc
+	GetHostCluster      cluster.GetClustersFunc
 	AvailableAPIGroups  []metav1.APIGroup
 }
 

--- a/controllers/nstemplateset/nstemplatetier.go
+++ b/controllers/nstemplateset/nstemplatetier.go
@@ -23,7 +23,7 @@ var tierTemplatesCache = newTierTemplateCache()
 // getTierTemplate retrieves the TierTemplate resource with the given name from the host cluster
 // and returns an instance of the tierTemplate type for it whose template content can be parsable.
 // The returned tierTemplate contains all data from TierTemplate including its name.
-func getTierTemplate(ctx context.Context, hostClusterFunc cluster.GetHostClusterFunc, templateRef string) (*tierTemplate, error) {
+func getTierTemplate(ctx context.Context, hostClusterFunc cluster.GetClustersFunc, templateRef string) (*tierTemplate, error) {
 	if templateRef == "" {
 		return nil, fmt.Errorf("templateRef is not provided - it's not possible to fetch related TierTemplate resource")
 	}
@@ -46,12 +46,14 @@ func getTierTemplate(ctx context.Context, hostClusterFunc cluster.GetHostCluster
 }
 
 // getToolchainTierTemplate gets the TierTemplate resource from the host cluster.
-func getToolchainTierTemplate(ctx context.Context, hostClusterFunc cluster.GetHostClusterFunc, templateRef string) (*toolchainv1alpha1.TierTemplate, error) {
+func getToolchainTierTemplate(ctx context.Context, hostClusterFunc cluster.GetClustersFunc, templateRef string) (*toolchainv1alpha1.TierTemplate, error) {
 	// retrieve the ToolchainCluster instance representing the host cluster
-	host, ok := hostClusterFunc()
-	if !ok {
+	clusters := hostClusterFunc()
+	if len(clusters) != 1 {
 		return nil, fmt.Errorf("unable to connect to the host cluster: unknown cluster")
 	}
+
+	host := clusters[0]
 	if !cluster.IsReady(host.ClusterStatus) {
 		return nil, fmt.Errorf("the host cluster is not ready")
 	}

--- a/go.mod
+++ b/go.mod
@@ -110,3 +110,5 @@ require (
 )
 
 go 1.20
+
+replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240314072551-61beb0c3429f
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598
@@ -99,7 +101,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -110,5 +112,3 @@ require (
 )
 
 go 1.20
-
-replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
+github.com/fbm3307/toolchain-common v0.0.0-20240314072551-61beb0c3429f h1:TcxrjEm61AiEQsZAzMJkVJJTQ15I/9zsKnjwOgZIFHA=
+github.com/fbm3307/toolchain-common v0.0.0-20240314072551-61beb0c3429f/go.mod h1:gTXxfr21LX9fQeldm16BhVbLJPSU1D4mbhHQd4S3ZiQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -1101,8 +1103,9 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87 h1:eQLsrMqfjAzGfuO9t6pVxO4K6cUDKOMxEvl0ujQq/2I=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598 h1:06nit/nCQFVKp51ZtIOyY49ncmxEK5shJGTaM+Ogicw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598/go.mod h1:c2JxboVI7keMD5fx5bB7LwzowFYYTwbepJhzPWSYXVs=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func main() {
 		Client:              mgr.GetClient(),
 		ScalesClient:        scalesClient,
 		DynamicClient:       dynamicClient,
-		GetHostCluster:      cluster.GetHostCluster,
+		GetHostCluster:      cluster.GetClusters,
 		Namespace:           namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Idler")
@@ -228,7 +228,7 @@ func main() {
 	if err = (&memberstatus.Reconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),
-		GetHostCluster:      cluster.GetHostCluster,
+		GetHostCluster:      cluster.GetClusters,
 		AllNamespacesClient: allNamespacesClient,
 		VersionCheckManager: status.VersionCheckManager{GetGithubClientFunc: commonclient.NewGitHubClient},
 	}).SetupWithManager(mgr); err != nil {
@@ -239,7 +239,7 @@ func main() {
 		Client:              mgr.GetClient(),
 		AllNamespacesClient: allNamespacesClient,
 		Scheme:              mgr.GetScheme(),
-		GetHostCluster:      cluster.GetHostCluster,
+		GetHostCluster:      cluster.GetClusters,
 	})).SetupWithManager(mgr, allNamespacesCluster, discoveryClient); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NSTemplateSet")
 		os.Exit(1)

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -14,14 +14,14 @@ import (
 // NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.CachedToolchainCluster
 // that is returned by the function then contains the given client and the given status.
 // If ok == false, then the function returns nil for the cluster.
-func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) cluster.GetHostClusterFunc {
+func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) cluster.GetClustersFunc {
 	if !ok {
-		return func() (*cluster.CachedToolchainCluster, bool) {
-			return nil, false
+		return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
+			return nil
 		}
 	}
-	return func() (toolchainCluster *cluster.CachedToolchainCluster, b bool) {
-		return &cluster.CachedToolchainCluster{
+	return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
+		return []*cluster.CachedToolchainCluster{{
 			Config: &cluster.Config{
 				OperatorNamespace: test.HostOperatorNs,
 				OwnerClusterName:  test.MemberClusterName,
@@ -33,7 +33,7 @@ func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) clu
 					Status: status,
 				}},
 			},
-		}, true
+		}}
 	}
 
 }
@@ -41,14 +41,14 @@ func NewGetHostCluster(cl client.Client, ok bool, status v1.ConditionStatus) clu
 // NewGetHostClusterWithProbe returns a cluster.GetHostClusterFunc function which returns a cluster.CachedToolchainCluster.
 // The returned cluster.CachedToolchainCluster contains the given client and the given status and lastProbeTime.
 // If ok == false, then the function returns nil for the cluster.
-func NewGetHostClusterWithProbe(cl client.Client, ok bool, status v1.ConditionStatus, lastProbeTime metav1.Time) cluster.GetHostClusterFunc {
+func NewGetHostClusterWithProbe(cl client.Client, ok bool, status v1.ConditionStatus, lastProbeTime metav1.Time) cluster.GetClustersFunc {
 	if !ok {
-		return func() (*cluster.CachedToolchainCluster, bool) {
-			return nil, false
+		return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
+			return nil
 		}
 	}
-	return func() (toolchainCluster *cluster.CachedToolchainCluster, b bool) {
-		return &cluster.CachedToolchainCluster{
+	return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
+		return []*cluster.CachedToolchainCluster{{
 			Config: &cluster.Config{
 				OperatorNamespace: test.HostOperatorNs,
 				OwnerClusterName:  test.MemberClusterName,
@@ -61,7 +61,7 @@ func NewGetHostClusterWithProbe(cl client.Client, ok bool, status v1.ConditionSt
 					LastProbeTime: lastProbeTime,
 				}},
 			},
-		}, true
+		}}
 	}
 
 }


### PR DESCRIPTION
Adding a new common function GetClusters() to fetch the clusters from cache as we have dropped the cluster type as per changes in toolchain-common

Related PRs
Toolchain-common - https://github.com/codeready-toolchain/toolchain-common/pull/372
Paired-Toolchain-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/923