### PR TITLE
KUBESAW43: Make LastProbeTime optional

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -196,7 +196,6 @@ spec:
                           description: Type of cluster condition, Ready or Offline.
                           type: string
                       required:
-                      - lastProbeTime
                       - status
                       - type
                       type: object

--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -181,6 +181,10 @@ spec:
                             to another.
                           format: date-time
                           type: string
+                        lastUpdatedTime:
+                          description: Last time the condition was updated
+                          format: date-time
+                          type: string
                         message:
                           description: Human readable message indicating details about
                             last transition.

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -93,6 +93,10 @@ spec:
                         to another.
                       format: date-time
                       type: string
+                    lastUpdatedTime:
+                      description: Last time the condition was updated
+                      format: date-time
+                      type: string
                     message:
                       description: Human readable message indicating details about
                         last transition.

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -107,7 +107,6 @@ spec:
                       description: Type of cluster condition, Ready or Offline.
                       type: string
                   required:
-                  - lastProbeTime
                   - status
                   - type
                   type: object


### PR DESCRIPTION
This is related to https://github.com/codeready-toolchain/host-operator/pull/1017#issuecomment-2082716929 . Making the LastProbeTime optional first