### PR TITLE
Receive the updates from the API repo for the new fields in the ToolchainCluster status

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -208,9 +208,7 @@ spec:
                       runs in the remote cluster
                     type: string
                 required:
-                - apiEndpoint
                 - conditions
-                - operatorNamespace
                 type: object
               memberOperator:
                 description: MemberOperator is the status of a toolchain member operator

--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -166,6 +166,10 @@ spec:
                 description: HostConnection is the status of the connection with the
                   host cluster
                 properties:
+                  apiEndpoint:
+                    description: APIEndpoint is the API endpoint of the remote cluster.
+                      This can be a hostname, hostname:port, IP or IP:port.
+                    type: string
                   conditions:
                     description: Conditions is an array of current cluster conditions.
                     items:
@@ -199,6 +203,10 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
+                  operatorNamespace:
+                    description: OperatorNamespace is the namespace in which the operator
+                      runs in the remote cluster
+                    type: string
                 required:
                 - conditions
                 type: object

--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -208,7 +208,9 @@ spec:
                       runs in the remote cluster
                     type: string
                 required:
+                - apiEndpoint
                 - conditions
+                - operatorNamespace
                 type: object
               memberOperator:
                 description: MemberOperator is the status of a toolchain member operator

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -127,7 +127,9 @@ spec:
                   runs in the remote cluster
                 type: string
             required:
+            - apiEndpoint
             - conditions
+            - operatorNamespace
             type: object
         required:
         - spec

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -127,9 +127,7 @@ spec:
                   runs in the remote cluster
                 type: string
             required:
-            - apiEndpoint
             - conditions
-            - operatorNamespace
             type: object
         required:
         - spec

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -44,25 +44,33 @@ spec:
             description: ToolchainClusterSpec defines the desired state of ToolchainCluster
             properties:
               apiEndpoint:
-                description: The API endpoint of the member cluster. This can be a
-                  hostname, hostname:port, IP or IP:port.
+                description: "The API endpoint of the member cluster. This can be
+                  a hostname, hostname:port, IP or IP:port. \n Be aware that this
+                  field is going to be replaced with the Status.APIEndpoint in the
+                  future."
                 type: string
               caBundle:
-                description: CABundle contains the certificate authority information.
+                description: "CABundle contains the certificate authority information.
+                  \n Note that this is going to be deprecated and removed. It will
+                  be replaced by a field in the kubecondig of the connection secret"
                 type: string
               disabledTLSValidations:
-                description: DisabledTLSValidations defines a list of checks to ignore
+                description: "DisabledTLSValidations defines a list of checks to ignore
                   when validating the TLS connection to the member cluster.  This
                   can be any of *, SubjectName, or ValidityPeriod. If * is specified,
-                  it is expected to be the only option in list.
+                  it is expected to be the only option in list. \n Note that this
+                  is going to be deprecated and removed. It will be replaced by the
+                  kubeconfig stored in the connection secret."
                 items:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
               secretRef:
-                description: Name of the secret containing the token required to access
-                  the member cluster. The secret needs to exist in the same namespace
-                  as the control plane and should have a "token" key.
+                description: "Name of the secret containing the token required to
+                  access the member cluster. The secret needs to exist in the same
+                  namespace as the control plane and should have a \"token\" key.
+                  \n In the near future, the secret will contain the whole kubeconfig
+                  required to connect to the cluster."
                 properties:
                   name:
                     description: Name of a secret within the enclosing namespace
@@ -78,6 +86,10 @@ spec:
             description: ToolchainClusterStatus contains information about the current
               status of a cluster updated periodically by cluster controller.
             properties:
+              apiEndpoint:
+                description: APIEndpoint is the API endpoint of the remote cluster.
+                  This can be a hostname, hostname:port, IP or IP:port.
+                type: string
               conditions:
                 description: Conditions is an array of current cluster conditions.
                 items:
@@ -110,6 +122,10 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              operatorNamespace:
+                description: OperatorNamespace is the namespace in which the operator
+                  runs in the remote cluster
+                type: string
             required:
             - conditions
             type: object

--- a/go.mod
+++ b/go.mod
@@ -110,4 +110,4 @@ require (
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/metlos/api v0.0.0-20240704185630-4a086a7f3529
+replace github.com/codeready-toolchain/api => github.com/metlos/api v0.0.0-20240708084953-3d53a2121f9f

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/member-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20240620205422-a29b6c658d03
+	github.com/codeready-toolchain/api v0.0.0-20240708122235-0af5a9a178bb
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240628050807-7f226f55a34a
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
@@ -109,5 +109,3 @@ require (
 )
 
 go 1.20
-
-replace github.com/codeready-toolchain/api => github.com/metlos/api v0.0.0-20240708084953-3d53a2121f9f

--- a/go.mod
+++ b/go.mod
@@ -109,3 +109,5 @@ require (
 )
 
 go 1.20
+
+replace github.com/codeready-toolchain/api => github.com/metlos/api v0.0.0-20240703104250-40b2c66a959f

--- a/go.mod
+++ b/go.mod
@@ -110,4 +110,4 @@ require (
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/metlos/api v0.0.0-20240703104250-40b2c66a959f
+replace github.com/codeready-toolchain/api => github.com/metlos/api v0.0.0-20240704185630-4a086a7f3529

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metlos/api v0.0.0-20240704185630-4a086a7f3529 h1:4WmVEQYXa5773pclUZ8MammQQSoAqkx97J7Z8/JDnfM=
-github.com/metlos/api v0.0.0-20240704185630-4a086a7f3529/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/metlos/api v0.0.0-20240708084953-3d53a2121f9f h1:WGc6MXX9nBYxDPbGqV84Zc9+1PDHQBVrl9OLYlTXcok=
+github.com/metlos/api v0.0.0-20240708084953-3d53a2121f9f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metlos/api v0.0.0-20240703104250-40b2c66a959f h1:0b5eSlDzCtvIjz8yKhgqouOjlJsKXTttQ7mWTAh2G4Y=
-github.com/metlos/api v0.0.0-20240703104250-40b2c66a959f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/metlos/api v0.0.0-20240704185630-4a086a7f3529 h1:4WmVEQYXa5773pclUZ8MammQQSoAqkx97J7Z8/JDnfM=
+github.com/metlos/api v0.0.0-20240704185630-4a086a7f3529/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20240708122235-0af5a9a178bb h1:Wc9CMsv0ODZv9dM5qF3OI0mFDO95YNIXV/8oRvoz8aE=
+github.com/codeready-toolchain/api v0.0.0-20240708122235-0af5a9a178bb/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20240628050807-7f226f55a34a h1:hXS9egkRRCyvUE//MJf+LDhH3mt1DDaWNFwTenex2dA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20240628050807-7f226f55a34a/go.mod h1:ZwfGkrTArynbvIPOJwQQCwFVW7Dj0XOgi5XzkNG1ov8=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -420,8 +422,6 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metlos/api v0.0.0-20240708084953-3d53a2121f9f h1:WGc6MXX9nBYxDPbGqV84Zc9+1PDHQBVrl9OLYlTXcok=
-github.com/metlos/api v0.0.0-20240708084953-3d53a2121f9f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20240620205422-a29b6c658d03 h1:uqApdceOkNQI1wy2gwA6pEUzhLlqqbbc+ChTvEshIW0=
-github.com/codeready-toolchain/api v0.0.0-20240620205422-a29b6c658d03/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20240628050807-7f226f55a34a h1:hXS9egkRRCyvUE//MJf+LDhH3mt1DDaWNFwTenex2dA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20240628050807-7f226f55a34a/go.mod h1:ZwfGkrTArynbvIPOJwQQCwFVW7Dj0XOgi5XzkNG1ov8=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -422,6 +420,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/metlos/api v0.0.0-20240703104250-40b2c66a959f h1:0b5eSlDzCtvIjz8yKhgqouOjlJsKXTttQ7mWTAh2G4Y=
+github.com/metlos/api v0.0.0-20240703104250-40b2c66a959f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=


### PR DESCRIPTION
This trivially just updates the API and gets the updated CRD definitions.

Associated PRs:
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1056
- api: https://github.com/codeready-toolchain/api/pull/433