### PR TITLE
SANDBOX-677 use go-version-file

### DIFF
--- a/.github/workflows/ci-golang-sbom.yml
+++ b/.github/workflows/ci-golang-sbom.yml
@@ -14,14 +14,14 @@ jobs:
     name: GolangCI Lint
     runs-on: ubuntu-20.04
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
-        
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
+        go-version-file: go.mod
+
     - name: Generate Assets
       run: |
         make generate-assets

--- a/.github/workflows/operator-cd.yml
+++ b/.github/workflows/operator-cd.yml
@@ -7,7 +7,6 @@ on:
       - '*.*'
 env:
   GOPATH: /tmp/go
-  GO_VERSION: 1.20.x
 
 jobs:
   binary:
@@ -24,7 +23,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   GOPATH: /tmp/go
-  GO_VERSION: 1.20.x
 
 jobs:
   binary:
@@ -49,7 +48,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -15,18 +15,18 @@ jobs:
     name: Test with Coverage
     runs-on: ubuntu-20.04
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.20.x
-    
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
-    
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
     - name: Generate Assets
       run: |
         make generate-assets


### PR DESCRIPTION
uses go-version-file instead of go-version. One less place to change when making updates.
Changes order in github action to first checkout code and then install go.

related PRs:
https://github.com/codeready-toolchain/api/pull/434
https://github.com/codeready-toolchain/toolchain-common/pull/415