### PR TITLE
silence member config logs when there's no error

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -148,8 +148,9 @@ func main() {
 func reloadMemberConfig(cl client.Client) context.Context {
 	ctx := ctrl.SetupSignalHandler()
 	go wait.Until(func() {
-		_, _, err := configuration.LoadLatest(cl, &toolchainv1alpha1.MemberOperatorConfig{})
-		setupLog.Error(err, "unable to load latest member config")
+		if _, _, err := configuration.LoadLatest(cl, &toolchainv1alpha1.MemberOperatorConfig{}); err != nil {
+			setupLog.Error(err, "unable to load latest member config")
+		}
 	}, 5*time.Second, ctx.Done())
 	return ctx
 }


### PR DESCRIPTION
Member-operator was spamming this message in its logs, but there was no `err` field set.  Check that an error actually exists before logging it.