### PR TITLE
Don't set limits for Autoscaler Buffer

### DIFF
--- a/deploy/autoscaler/member-operator-autoscaler.yaml
+++ b/deploy/autoscaler/member-operator-autoscaler.yaml
@@ -40,9 +40,6 @@ objects:
                 requests:
                   memory: ${MEMORY}
                   cpu: ${CPU}
-                limits:
-                  memory: ${MEMORY}
-                  cpu: ${CPU}
 parameters:
   - name: NAMESPACE
     value: 'toolchain-member-operator'

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -225,7 +225,7 @@ func priorityClass() string {
 }
 
 func deployment(memory, cpu string, replicas int) string {
-	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"autoscaling-buffer","namespace":"%[1]s","labels":{"app":"autoscaling-buffer","toolchain.dev.openshift.com/provider":"codeready-toolchain"}},"spec":{"replicas":%[2]d,"selector":{"matchLabels":{"app":"autoscaling-buffer"}},"template":{"metadata":{"labels":{"app":"autoscaling-buffer"}},"spec":{"priorityClassName":"member-operator-autoscaling-buffer","terminationGracePeriodSeconds":0,"containers":[{"name":"autoscaling-buffer","image":"gcr.io/google_containers/pause-amd64:3.2","imagePullPolicy":"IfNotPresent","resources":{"requests":{"memory":"%[3]s","cpu":"%[4]s"},"limits":{"memory":"%[3]s","cpu":"%[4]s"}}}]}}}}`, test.MemberOperatorNs, replicas, memory, cpu)
+	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"autoscaling-buffer","namespace":"%[1]s","labels":{"app":"autoscaling-buffer","toolchain.dev.openshift.com/provider":"codeready-toolchain"}},"spec":{"replicas":%[2]d,"selector":{"matchLabels":{"app":"autoscaling-buffer"}},"template":{"metadata":{"labels":{"app":"autoscaling-buffer"}},"spec":{"priorityClassName":"member-operator-autoscaling-buffer","terminationGracePeriodSeconds":0,"containers":[{"name":"autoscaling-buffer","image":"gcr.io/google_containers/pause-amd64:3.2","imagePullPolicy":"IfNotPresent","resources":{"requests":{"memory":"%[3]s","cpu":"%[4]s"}}}]}}}}`, test.MemberOperatorNs, replicas, memory, cpu)
 }
 
 func bufferConfiguration(memory, cpu string, replicas int) BufferConfiguration {


### PR DESCRIPTION
It's actually not a good idea to set both limits and requests to the same value for our autoscaler buffer.

There are three `Quality of Service Classes (QoS)` in Kube:

- Guaranteed
- Burstable
- BestEffort

The Pod has the `Guaranteed` QoS if:
- Every Container in the Pod must have a memory limit and a memory request.
- For every Container in the Pod, the memory limit must equal the memory request.
- Every Container in the Pod must have a CPU limit and a CPU request.
- For every Container in the Pod, the CPU limit must equal the CPU request.

The `Guaranteed` pods are evicted last if there is memory pressure in the node. But removing the limits and keeping the requests only we move the Autoscaler Buffer to the `Burstable` QoS. Same `QoS` as most user pods (some of the user pods can be `Guaranteed` though). So the Autoscaler Buffer pods should be evicted first due their lower Priority Class.

To be clear. This effect only the eviction case when there is a memory pressure in the node. It doesn't affect pod scheduling. We should be already good with the pod scheduling due to lower Priority Class for Autoscaler Buffer pods.

For more details see:
- https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/
- https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1029