### PR TITLE
KUBESAW-187: Have a unique label for our operators

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: kubesaw-controller-manager
+    control-plane: controller-manager
+    kubesaw-control-plane: kubesaw-controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,18 +12,21 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: kubesaw-controller-manager
+    control-plane: controller-manager
+    kubesaw-control-plane: kubesaw-controller-manager
   annotations:
     kubectl.kubernetes.io/default-container: manager
 spec:
   selector:
     matchLabels:
-      control-plane: kubesaw-controller-manager
+      control-plane: controller-manager
+      kubesaw-control-plane: kubesaw-controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: kubesaw-controller-manager
+        control-plane: controller-manager
+        kubesaw-control-plane: kubesaw-controller-manager
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: kubesaw-controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,18 +11,18 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: kubesaw-controller-manager
   annotations:
     kubectl.kubernetes.io/default-container: manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: kubesaw-controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: kubesaw-controller-manager
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Have a unique label instead of default controller-manger, so that it becomes easier to perform operations to only our operators
this is a predecessor for PR 
KSCTL - https://github.com/kubesaw/ksctl/pull/79 

Similar PR 
 Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1087
 