### PR TITLE
KUBESAW-192: Introduce a make command for pre-requisite of verify-replace

### DIFF
--- a/make/go.mk
+++ b/make/go.mk
@@ -38,7 +38,7 @@ generate-assets: go-bindata
 
 .PHONY: verify-dependencies
 ## Runs commands to verify after the updated dependecies of toolchain-common/API(go mod replace), if the repo needs any changes to be made
-verify-dependencies: generate-assets tidy vet build test lint-go-code
+verify-dependencies: tidy vet build test lint-go-code
 
 .PHONY: tidy
 tidy: 
@@ -47,3 +47,7 @@ tidy:
 .PHONY: vet
 vet:
 	go vet ./...
+
+.PHONY: pre-verify
+pre-verify: generate-assets
+	echo "Pre-requisite completed"


### PR DESCRIPTION
Introduce a make command for pre-requisite of verify-replace script

Related PRs:
Toolchain-common - https://github.com/codeready-toolchain/toolchain-common/pull/429 
Host Operator - https://github.com/codeready-toolchain/host-operator/pull/1091
Toolchain-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1049
Registration service - https://github.com/codeready-toolchain/registration-service/pull/465
Ksctl - https://github.com/kubesaw/ksctl/pull/81