### PR TITLE
Revert "Use the streamlined ToolchainCluster and update its CRD."

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -43,9 +43,34 @@ spec:
           spec:
             description: ToolchainClusterSpec defines the desired state of ToolchainCluster
             properties:
+              apiEndpoint:
+                description: "The API endpoint of the member cluster. This can be
+                  a hostname, hostname:port, IP or IP:port. \n Be aware that this
+                  field is going to be replaced with the Status.APIEndpoint in the
+                  future."
+                type: string
+              caBundle:
+                description: "CABundle contains the certificate authority information.
+                  \n Note that this is going to be deprecated and removed. It will
+                  be replaced by a field in the kubecondig of the connection secret"
+                type: string
+              disabledTLSValidations:
+                description: "DisabledTLSValidations defines a list of checks to ignore
+                  when validating the TLS connection to the member cluster.  This
+                  can be any of *, SubjectName, or ValidityPeriod. If * is specified,
+                  it is expected to be the only option in list. \n Note that this
+                  is going to be deprecated and removed. It will be replaced by the
+                  kubeconfig stored in the connection secret."
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               secretRef:
-                description: Name of the secret containing the kubeconfig required
-                  to connect to the cluster.
+                description: "Name of the secret containing the token required to
+                  access the member cluster. The secret needs to exist in the same
+                  namespace as the control plane and should have a \"token\" key.
+                  \n In the near future, the secret will contain the whole kubeconfig
+                  required to connect to the cluster."
                 properties:
                   name:
                     description: Name of a secret within the enclosing namespace
@@ -54,6 +79,7 @@ spec:
                 - name
                 type: object
             required:
+            - apiEndpoint
             - secretRef
             type: object
           status:


### PR DESCRIPTION
Reverts codeready-toolchain/member-operator#602

I didn't push the last update that brought back `spec.apiEndpoint` to ensure back-compat. 🤦🏼 