### PR TITLE
webhook: load TLS certificate at runtime

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -120,6 +121,14 @@ func main() {
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			NextProtos: []string{"http/1.1"}, // disable HTTP/2 for now
+
+			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				cert, err := tls.LoadX509KeyPair("/etc/webhook/certs/"+cert.ServerCert, "/etc/webhook/certs/"+cert.ServerKey)
+				if err != nil {
+					return nil, fmt.Errorf("could not load TLS certs: %w", err)
+				}
+				return &cert, err
+			},
 		},
 	}
 
@@ -127,7 +136,7 @@ func main() {
 
 	go func() {
 		setupLog.Info("Listening...")
-		if err := webhookServer.ListenAndServeTLS("/etc/webhook/certs/"+cert.ServerCert, "/etc/webhook/certs/"+cert.ServerKey); err != nil {
+		if err := webhookServer.ListenAndServeTLS("", ""); err != nil {
 			setupLog.Error(err, "Listening and serving TLS failed")
 			os.Exit(1)
 		}


### PR DESCRIPTION
This avoid the need of restarting the webhook when the certificate is rotated

Signed-off-by: Francesco Ilario <filario@redhat.com>
