### PR TITLE
KUBESAW-250: Updating GolangCiLint to v1.63.1

### DIFF
--- a/.github/workflows/ci-golang-sbom.yml
+++ b/.github/workflows/ci-golang-sbom.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.56.2
+        version: v1.63.1
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose

--- a/controllers/memberstatus/memberstatus_controller_test.go
+++ b/controllers/memberstatus/memberstatus_controller_test.go
@@ -74,7 +74,7 @@ func TestNoMemberStatusFound(t *testing.T) {
 		getHostClusterFunc := newGetHostClusterReady
 		reconciler, req, fakeClient := prepareReconcile(t, requestName, getHostClusterFunc, allNamespacesCl, mockLastGitHubAPICall, defaultGitHubClient)
 		fakeClient.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
-			return fmt.Errorf(expectedErrMsg)
+			return fmt.Errorf("%s", expectedErrMsg)
 		}
 
 		// when

--- a/controllers/nstemplateset/space_roles.go
+++ b/controllers/nstemplateset/space_roles.go
@@ -78,7 +78,7 @@ func (r *spaceRolesManager) ensure(ctx context.Context, nsTmplSet *toolchainv1al
 			sr, err := json.Marshal(nsTmplSet.Spec.SpaceRoles)
 			if err != nil {
 				return false, r.wrapErrorWithStatusUpdate(lctx, nsTmplSet, r.setStatusProvisionFailed, err,
-					"failed to marshal space roles to update '%v' annotation on namespace", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey)
+					"failed to marshal space roles to update '%s' annotation on namespace", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey)
 			}
 			if ns.Annotations == nil {
 				ns.Annotations = map[string]string{}
@@ -86,7 +86,7 @@ func (r *spaceRolesManager) ensure(ctx context.Context, nsTmplSet *toolchainv1al
 			ns.Annotations[toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey] = string(sr)
 			if err := r.Client.Update(ctx, &ns); err != nil {
 				return false, r.wrapErrorWithStatusUpdate(lctx, nsTmplSet, r.setStatusProvisionFailed, err,
-					"failed to update namespace with '%q' annotation", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey)
+					"failed to update namespace with '%s' annotation", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey)
 			}
 			logger.Info("updated annotation on namespace", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey, string(sr))
 			return true, nil

--- a/controllers/nstemplateset/space_roles.go
+++ b/controllers/nstemplateset/space_roles.go
@@ -3,7 +3,6 @@ package nstemplateset
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -79,7 +78,7 @@ func (r *spaceRolesManager) ensure(ctx context.Context, nsTmplSet *toolchainv1al
 			sr, err := json.Marshal(nsTmplSet.Spec.SpaceRoles)
 			if err != nil {
 				return false, r.wrapErrorWithStatusUpdate(lctx, nsTmplSet, r.setStatusProvisionFailed, err,
-					fmt.Sprintf("failed to marshal space roles to update '%s' annotation on namespace", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey))
+					"failed to marshal space roles to update '%v' annotation on namespace", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey)
 			}
 			if ns.Annotations == nil {
 				ns.Annotations = map[string]string{}
@@ -87,7 +86,7 @@ func (r *spaceRolesManager) ensure(ctx context.Context, nsTmplSet *toolchainv1al
 			ns.Annotations[toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey] = string(sr)
 			if err := r.Client.Update(ctx, &ns); err != nil {
 				return false, r.wrapErrorWithStatusUpdate(lctx, nsTmplSet, r.setStatusProvisionFailed, err,
-					fmt.Sprintf("failed to update namespace with '%s' annotation", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey))
+					"failed to update namespace with '%q' annotation", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey)
 			}
 			logger.Info("updated annotation on namespace", toolchainv1alpha1.LastAppliedSpaceRolesAnnotationKey, string(sr))
 			return true, nil

--- a/pkg/webhook/mutatingwebhook/mutate.go
+++ b/pkg/webhook/mutatingwebhook/mutate.go
@@ -63,7 +63,7 @@ func handleMutate(logger logr.Logger, w http.ResponseWriter, r *http.Request, mu
 
 func writeResponse(logger logr.Logger, responseCode int, w http.ResponseWriter, respBody []byte) {
 	w.WriteHeader(responseCode)
-	if _, err := io.WriteString(w, string(respBody)); err != nil {
+	if _, err := io.Writer.Write(w, respBody); err != nil { //using 'io.Writer.Write' as per the static check SA6006: use io.Writer.Write instead of converting from []byte to string to use io.WriteString (staticcheck)
 		logger.Error(err, "unable to write adm review response")
 	}
 }

--- a/pkg/webhook/validatingwebhook/validate_rolebinding_request.go
+++ b/pkg/webhook/validatingwebhook/validate_rolebinding_request.go
@@ -40,7 +40,7 @@ func (v RoleBindingRequestValidator) HandleValidate(w http.ResponseWriter, r *ht
 		respBody = v.validate(r.Context(), body)
 		w.WriteHeader(http.StatusOK)
 	}
-	if _, err := io.WriteString(w, string(respBody)); err != nil {
+	if _, err := io.Writer.Write(w, respBody); err != nil { //using 'io.Writer.Write' as per the static check SA6006: use io.Writer.Write instead of converting from []byte to string to use io.WriteString (staticcheck)
 		log.Error(err, "unable to write response")
 	}
 }

--- a/pkg/webhook/validatingwebhook/validate_spacebindingrequest.go
+++ b/pkg/webhook/validatingwebhook/validate_spacebindingrequest.go
@@ -42,7 +42,7 @@ func (v SpaceBindingRequestValidator) HandleValidate(w http.ResponseWriter, r *h
 		respBody = v.validate(r.Context(), body)
 		w.WriteHeader(http.StatusOK)
 	}
-	if _, err := io.WriteString(w, string(respBody)); err != nil {
+	if _, err := io.Writer.Write(w, respBody); err != nil { //using 'io.Writer.Write' as per the static check SA6006: use io.Writer.Write instead of converting from []byte to string to use io.WriteString (staticcheck)
 		log.Error(err, "unable to write response")
 	}
 }

--- a/pkg/webhook/validatingwebhook/validate_ssp_request.go
+++ b/pkg/webhook/validatingwebhook/validate_ssp_request.go
@@ -37,7 +37,7 @@ func (v SSPRequestValidator) HandleValidate(w http.ResponseWriter, r *http.Reque
 		respBody = v.validate(r.Context(), body)
 		w.WriteHeader(http.StatusOK)
 	}
-	if _, err := io.WriteString(w, string(respBody)); err != nil {
+	if _, err := io.Writer.Write(w, respBody); err != nil { //using 'io.Writer.Write' as per the static check SA6006: use io.Writer.Write instead of converting from []byte to string to use io.WriteString (staticcheck)
 		log.Error(err, "unable to write response")
 	}
 }

--- a/pkg/webhook/validatingwebhook/validate_vm_request.go
+++ b/pkg/webhook/validatingwebhook/validate_vm_request.go
@@ -32,7 +32,7 @@ func (v VMRequestValidator) HandleValidate(w http.ResponseWriter, r *http.Reques
 		respBody = v.validate(body)
 		w.WriteHeader(http.StatusOK)
 	}
-	if _, err := io.WriteString(w, string(respBody)); err != nil {
+	if _, err := io.Writer.Write(w, respBody); err != nil { //using 'io.Writer.Write' as per the static check SA6006: use io.Writer.Write instead of converting from []byte to string to use io.WriteString (staticcheck)
 		log.Error(err, "unable to write response")
 	}
 }


### PR DESCRIPTION
Updating the GolangciLint to v1.63.1 across all repos fix the linter error which were caught as a result of upgrading the linter

Similar PRs

- API - https://github.com/codeready-toolchain/api/pull/454
- Toolchain-common - https://github.com/codeready-toolchain/toolchain-common/pull/442
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1116
- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/491
- Toolchain-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1092
- Ksctl - https://github.com/kubesaw/ksctl/pull/97