### PR TITLE
Update idler test for VMs to stabilize it

### DIFF
--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -1469,10 +1469,10 @@ func newMUR(name string) *toolchainv1alpha1.MasterUserRecord {
 
 func freshStartTimes(idler *toolchainv1alpha1.Idler) payloadStartTimes {
 	halfOfIdlerTimeoutAgo := time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds/2) * time.Second)
-	quarterOfIdlerTimeoutAgo := time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds/13) * time.Second) // needs to be smaller than 1/12 which is the vm idler time
+	twelfthOfIdlerTimeoutMinusOneSecondAgo := time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds/12-1) * time.Second) // needs to be smaller than 1/12 which is the vm idler time
 	return payloadStartTimes{
 		defaultStartTime: halfOfIdlerTimeoutAgo,
-		vmStartTime:      quarterOfIdlerTimeoutAgo, // vms are killed in 1/12 of the idler time
+		vmStartTime:      twelfthOfIdlerTimeoutMinusOneSecondAgo, // vms are killed in 1/12 of the idler time
 	}
 }
 


### PR DESCRIPTION
The idler timeout in the unit tests is set to 60s and since the VM idler timeout was recently changed to 1/12 of the idler timeout this makes the VM idler timeout 5 seconds. In the unit tests I used the current time minus 1/13 of the idler timeout as the VM pod start time but that would be just 4.61 seconds so I suspect the fractions of a second are causing some flakiness depending on when the tests are running since we use `time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds/13) * time.Second)` and then later logic to track the pod is `if time.Now().After(trackedPod.StartTime.Add(time.Duration(timeoutSeconds) * time.Second)) {`

So the problem seems to be sometimes the vm pod is not being tracked due to the start time that is set

## Hypothesis

### Constants:
idler timeout in test: 60s
vm idler timeout: 60s / 12 = 5 Seconds
vm idler start time in test was set to 1/13 of idler timeout: 60s / 13 = 4.61 Seconds

### Scenario 1: test started at 7:40

vmStartTime in test:
timeoutSeconds = time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds/13) * time.Second) = 7:40 - 4.61 = 7:35.39

trackedPod.StartTime.Add(time.Duration(timeoutSeconds) * time.Second) = 7:35.39 + 5 seconds = 7:40.39

logic to track pod
time.Now().After(trackedPod.StartTime.Add(time.Duration(timeoutSeconds) * time.Second) = 7:40.02 *IS NOT* after 7:40.39 

### Scenario 2: test started at 7:40.7

timeoutSeconds = vmStartTime in test: time.Now().Add(-time.Duration(idler.Spec.TimeoutSeconds/13) * time.Second) = 7:40.7 - 4.61 = 7:36.09

trackedPod.StartTime.Add(time.Duration(timeoutSeconds) * time.Second) = 7:36.09 + 5 seconds = 7:41.09

logic to track: time.Now().After(trackedPod.StartTime.Add(time.Duration(timeoutSeconds) * time.Second) = 7:40.9 IS after 7:40.39 

## Flaky test failure:
https://github.com/codeready-toolchain/api/actions/runs/13068360395/job/36464549897?pr=458
```
--- FAIL: TestEnsureIdling (0.31s)
    --- FAIL: TestEnsureIdling/Idle_pods (0.23s)
        --- FAIL: TestEnsureIdling/Idle_pods/First_reconcile._Start_tracking. (0.18s)
            --- FAIL: TestEnsureIdling/Idle_pods/First_reconcile._Start_tracking./Second_Reconcile._Delete_long_running_pods. (0.12s)
                --- FAIL: TestEnsureIdling/Idle_pods/First_reconcile._Start_tracking./Second_Reconcile._Delete_long_running_pods./Third_Reconcile._Stop_tracking_deleted_pods. (0.03s)
                        	Error Trace:	/tmp/replace-verify.EFD/member-operator/test/idler_assertion.go:58
make: *** [make/go.mk:19: verify-replace-run] Error 1
                        	Error:      	"[{alex-stage-binding-deployment-replicaset-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-binding-deployment-replicaset-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-binding-deployment-replicaset-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-daemonset-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-daemonset-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-daemonset-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-deployment-replicaset-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-deployment-replicaset-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-deployment-replicaset-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-deploymentconfig-replicationcontroller-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-deploymentconfig-replicationcontroller-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-deploymentconfig-replicationcontroller-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-integration-deployment-replicaset-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-integration-deployment-replicaset-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-integration-deployment-replicaset-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-job-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-job-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-job-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-replicaset-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-replicaset-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-replicaset-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-replicationcontroller-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-replicationcontroller-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-replicationcontroller-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-somename-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-somename-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-somename-pod-2 2025-01-31 07:40:47 +0000 UTC} {alex-stage-statefulset-pod-0 2025-01-31 07:40:47 +0000 UTC} {alex-stage-statefulset-pod-1 2025-01-31 07:40:47 +0000 UTC} {alex-stage-statefulset-pod-2 2025-01-31 07:40:47 +0000 UTC} {todelete-alex-stage-binding-deployment-replicaset-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-binding-deployment-replicaset-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-binding-deployment-replicaset-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-daemonset-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-daemonset-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-daemonset-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-deployment-replicaset-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-deployment-replicaset-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-deployment-replicaset-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-deploymentconfig-replicationcontroller-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-deploymentconfig-replicationcontroller-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-deploymentconfig-replicationcontroller-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-integration-deployment-replicaset-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-integration-deployment-replicaset-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-integration-deployment-replicaset-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-job-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-job-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-job-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-replicaset-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-replicaset-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-replicaset-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-replicationcontroller-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-replicationcontroller-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-replicationcontroller-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-statefulset-pod-0 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-statefulset-pod-1 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-statefulset-pod-2 2025-01-31 07:40:16 +0000 UTC} {todelete-alex-stage-virtualmachineinstance-pod-0 2025-01-31 07:40:47 +0000 UTC} {todelete-alex-stage-virtualmachineinstance-pod-1 2025-01-31 07:40:47 +0000 UTC} {todelete-alex-stage-virtualmachineinstance-pod-2 2025-01-31 07:40:47 +0000 UTC}]" should have 66 item(s), but has 63
FAIL
FAIL	github.com/codeready-toolchain/member-operator/controllers/idler	0.551s
FAIL
```