### PR TITLE
remove logic of deletion of console setting resources using label

### DIFF
--- a/controllers/useraccount/console_usersettings.go
+++ b/controllers/useraccount/console_usersettings.go
@@ -16,7 +16,7 @@ const (
 )
 
 // deleteResource deletes the specified resource associated with a user from console setting.
-// It first attempts to delete the resource by name, and if not found, it deletes all resources with matching labels.
+// It attempts to delete the resource by name, and does nothing if not found.
 //
 // userUID : The unique identifier of the user for whom the resource is being deleted.
 // Returns an error if the deletion operation fails. Returns nil if the operation is successful or there is nothing to delete.
@@ -32,10 +32,7 @@ func deleteResource(ctx context.Context, cl client.Client, userUID string, toDel
 	toDelete.SetName(name)
 	toDelete.SetNamespace(UserSettingNS)
 	if err := cl.Delete(ctx, toDelete); err != nil {
-		if errors.IsNotFound(err) {
-			labels := map[string]string{ConsoleUserSettingsIdentifier: "true", ConsoleUserSettingsUID: userUID}
-			return cl.DeleteAllOf(ctx, toDelete, client.MatchingLabels(labels), client.InNamespace(UserSettingNS))
-		} else {
+		if !errors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/controllers/useraccount/console_usersettings_test.go
+++ b/controllers/useraccount/console_usersettings_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	. "github.com/codeready-toolchain/member-operator/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -73,84 +72,6 @@ func TestDeleteConsoleSettingObjects(t *testing.T) {
 		require.NoError(t, err)
 		// check that the rolebinding doesn't exist anymore
 		AssertObjectNotFound(t, cl, UserSettingNS, "user-settings-johnsmith-rolebinding", &rbac.RoleBinding{})
-	})
-
-	t.Run("Object found by label and deletes successfully", func(t *testing.T) {
-		// given
-		cm := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "user-settings-name-no-match",
-				Namespace: UserSettingNS,
-				Labels: map[string]string{
-					ConsoleUserSettingsIdentifier: "true",
-					ConsoleUserSettingsUID:        "johnsmith",
-				},
-			},
-		}
-		// create a noise objects where the labels don't match
-		noiseObject := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ConfigMap",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "user-settings-name-no-match-noise",
-				Namespace: UserSettingNS,
-				Labels: map[string]string{
-					ConsoleUserSettingsIdentifier: "true",
-				},
-			},
-		}
-		cl := test.NewFakeClient(t, cm, noiseObject)
-
-		// when
-		err := deleteResource(context.TODO(), cl, "johnsmith", &corev1.ConfigMap{})
-
-		// then
-		require.NoError(t, err)
-		// check that the configmap doesn't exist anymore
-		AssertObjectNotFound(t, cl, UserSettingNS, "johnsmith", &corev1.ConfigMap{})
-		// check that the noise object still exists
-		retrievedNoise := &corev1.ConfigMap{}
-		AssertObject(t, cl, UserSettingNS, "user-settings-name-no-match-noise", retrievedNoise, func() {
-			assert.Equal(t, noiseObject, retrievedNoise)
-		})
-	})
-	t.Run("multiple objects found by label and deletes successfully", func(t *testing.T) {
-		// given
-		cm1 := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "user-settings-name-no-match",
-				Namespace: UserSettingNS,
-				Labels: map[string]string{
-					ConsoleUserSettingsIdentifier: "true",
-					ConsoleUserSettingsUID:        "johnsmith",
-				},
-			},
-		}
-		cm2 := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "user-settings-name-no-match-second",
-				Namespace: UserSettingNS,
-				Labels: map[string]string{
-					ConsoleUserSettingsIdentifier: "true",
-					ConsoleUserSettingsUID:        "johnsmith",
-				},
-			},
-		}
-		cl := test.NewFakeClient(t, cm1, cm2)
-
-		// when
-		err := deleteResource(context.TODO(), cl, "johnsmith", &corev1.ConfigMap{})
-
-		// then
-		require.NoError(t, err)
-		// check that the configmaps don't exist anymore
-		AssertObjectNotFound(t, cl, UserSettingNS, "user-settings-name-no-match", &corev1.ConfigMap{})
-		AssertObjectNotFound(t, cl, UserSettingNS, "user-settings-name-no-match-second", &corev1.ConfigMap{})
 	})
 
 	t.Run("Error is returned when error in deleting configmap", func(t *testing.T) {

--- a/controllers/useraccount/useraccount_controller_test.go
+++ b/controllers/useraccount/useraccount_controller_test.go
@@ -427,12 +427,8 @@ func TestReconcile(t *testing.T) {
 				APIVersion: "rbac.authorization.k8s.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName + "random",
+				Name:      resourceName + ConsoleUserSettingsRoleSuffix,
 				Namespace: UserSettingNS,
-				Labels: map[string]string{
-					ConsoleUserSettingsIdentifier: "true",
-					ConsoleUserSettingsUID:        string(userUID),
-				},
 			},
 		}
 		rb := &rbac.RoleBinding{
@@ -464,9 +460,6 @@ func TestReconcile(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      noiseResourceName,
 				Namespace: UserSettingNS,
-				Labels: map[string]string{
-					ConsoleUserSettingsIdentifier: "true",
-				},
 			},
 		}
 		noiseRb := &rbac.RoleBinding{


### PR DESCRIPTION
Since labels were never added by console and ownerReferences have now been added back in 4.17 - we can delete the logic to delete console setting resources using labels.
Will keep the part of deleting console setting resources using name for a while before deleting.

slack thread for reference - https://redhat-internal.slack.com/archives/CHK0J6HT6/p1738683125581909 