### PR TITLE
fix requeue in idler controller

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -125,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 	} else {
 		// if nothing is being tracked then only wait for the next reconcile triggered
-		// by starting the pod
+		// by a pod starting
 		logger.Info("no pods being tracked")
 	}
 

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	RestartThreshold = 50
+	restartThreshold = 50
 )
 
 var SupportedScaleResources = map[schema.GroupVersionKind]schema.GroupVersionResource{
@@ -125,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 	} else {
 		// if nothing is being tracked then only wait for the next reconcile triggered
-		// by starting (or crashlooping) the pod
+		// by starting the pod
 		logger.Info("no pods being tracked")
 	}
 
@@ -153,7 +153,7 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 		if trackedPod := findPodByName(idler, pod.Name); trackedPod != nil {
 			// check the restart count for the trackedPod
 			restartCount := getHighestRestartCount(pod.Status)
-			if restartCount > RestartThreshold {
+			if restartCount > restartThreshold {
 				podLogger.Info("Pod is restarting too often. Killing the pod", "restart_count", restartCount)
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				err := deletePodsAndCreateNotification(podCtx, pod, r, idler)

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -125,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 	} else {
 		// if nothing is being tracked then only wait for the next reconcile triggered
-		// by the pod creation event
+		// by starting (or crashlooping) the pod
 		logger.Info("no pods being tracked")
 	}
 

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -124,11 +124,8 @@ func TestEnsureIdling(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		// no pods found - the controller will requeue after 6 hours
-		assert.Equal(t, reconcile.Result{
-			Requeue:      true,
-			RequeueAfter: RequeueTimeThreshold,
-		}, res)
+		// no pods found - the controller won't schedule requeue
+		assert.Equal(t, reconcile.Result{}, res)
 		memberoperatortest.AssertThatIdler(t, idler.Name, cl).HasConditions(memberoperatortest.Running())
 	})
 
@@ -298,11 +295,8 @@ func TestEnsureIdling(t *testing.T) {
 							TracksPods([]*corev1.Pod{}).
 							HasConditions(memberoperatortest.Running(), memberoperatortest.IdlerNotificationCreated())
 
-						// requeue after the idler timeout
-						assert.Equal(t, reconcile.Result{
-							Requeue:      true,
-							RequeueAfter: TestIdlerTimeOutSeconds * time.Second,
-						}, res)
+						// no pods being tracked -> no scheduled requeue
+						assert.Equal(t, reconcile.Result{}, res)
 					})
 				})
 			})
@@ -584,11 +578,8 @@ func TestEnsureIdlingFailed(t *testing.T) {
 				res, err := reconciler.Reconcile(context.TODO(), req)
 
 				// then
-				require.NoError(t, err) // 'NotFound' errors are ignored!
-				assert.Equal(t, reconcile.Result{
-					Requeue:      true,
-					RequeueAfter: TestIdlerTimeOutSeconds * time.Second,
-				}, res)
+				require.NoError(t, err)                  // 'NotFound' errors are ignored!
+				assert.Equal(t, reconcile.Result{}, res) // no other pods being tracked
 				memberoperatortest.AssertThatIdler(t, idler.Name, cl).ContainsCondition(memberoperatortest.Running())
 			}
 

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -107,7 +107,7 @@ func TestEnsureIdling(t *testing.T) {
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	t.Run("No pods in namespace managed by idler, idler timeout is longer than requeue-time-threshold", func(t *testing.T) {
+	t.Run("No pods in namespace managed by idler, no requeue time", func(t *testing.T) {
 		// given
 		idler := &toolchainv1alpha1.Idler{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/idler/mapper.go
+++ b/controllers/idler/mapper.go
@@ -1,0 +1,19 @@
+package idler
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// MapPodToIdler maps the pod to the idler
+func MapPodToIdler(_ context.Context, obj runtimeclient.Object) []reconcile.Request {
+	return []reconcile.Request{{
+		// the idler should have the same name as the user's namespace
+		NamespacedName: types.NamespacedName{
+			Name: obj.GetNamespace(),
+		},
+	}}
+}

--- a/controllers/idler/mapper_test.go
+++ b/controllers/idler/mapper_test.go
@@ -1,0 +1,24 @@
+package idler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMapper(t *testing.T) {
+	// given
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "jane-dev", Name: "my-pod"}}
+
+	// when
+	requests := MapPodToIdler(context.TODO(), pod)
+
+	// then
+	require.Len(t, requests, 1)
+	assert.Equal(t, "jane-dev", requests[0].Name)
+	assert.Empty(t, requests[0].Namespace)
+}

--- a/controllers/idler/predicate.go
+++ b/controllers/idler/predicate.go
@@ -1,0 +1,48 @@
+package idler
+
+import (
+	"github.com/codeready-toolchain/member-operator/pkg/webhook/mutatingwebhook"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeevent "sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+type PodIdlerPredicate struct {
+}
+
+// Update triggers reconcile if the pod runs in users namespace
+// and if the highest restart count is higher than the threshold
+func (p PodIdlerPredicate) Update(event runtimeevent.UpdateEvent) bool {
+	isUserPod, pod := isUserPod(event.ObjectNew)
+	if !isUserPod {
+		return false
+	}
+
+	return getHighestRestartCount(pod.Status) > RestartThreshold
+}
+
+// Create triggers reconcile only if the pod runs in users namespace
+func (PodIdlerPredicate) Create(event runtimeevent.CreateEvent) bool {
+	isUserPod, _ := isUserPod(event.Object)
+	return isUserPod
+}
+
+// Delete doesn't trigger reconcile
+func (PodIdlerPredicate) Delete(_ runtimeevent.DeleteEvent) bool {
+	return false
+}
+
+// Generic doesn't trigger reconcile
+func (p PodIdlerPredicate) Generic(_ runtimeevent.GenericEvent) bool {
+	return false
+}
+
+func isUserPod(object client.Object) (bool, *corev1.Pod) {
+	if pod, ok := object.(*corev1.Pod); ok { // this can be replaced by the typed-predicate in the next version of k8s
+		// all pods running in users' namespaces have the priorityClassName set, so trigger reconcile only
+		// if the pod contains the same class name to ensure that the pod runs in a user's namespace
+		// (we don't care about other pods)
+		return pod.Spec.PriorityClassName == mutatingwebhook.PriorityClassName, pod
+	}
+	return false, nil
+}

--- a/controllers/idler/predicate.go
+++ b/controllers/idler/predicate.go
@@ -25,7 +25,7 @@ func (p PodIdlerPredicate) Update(event runtimeevent.UpdateEvent) bool {
 	}
 	if oldPod, ok := event.ObjectOld.(*corev1.Pod); ok {
 		startTimeNewlySet := oldPod.Status.StartTime == nil && newPod.Status.StartTime != nil
-		return startTimeNewlySet || getHighestRestartCount(newPod.Status) > RestartThreshold
+		return startTimeNewlySet || getHighestRestartCount(newPod.Status) > restartThreshold
 	}
 	return false
 }

--- a/controllers/idler/predicate_test.go
+++ b/controllers/idler/predicate_test.go
@@ -1,0 +1,81 @@
+package idler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestPredicate(t *testing.T) {
+	// given
+	testData := map[string]struct {
+		pod            *corev1.Pod
+		expectedResult bool
+	}{
+		"pod with sandbox class": {
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				PriorityClassName: "sandbox-users-pods",
+			}},
+			expectedResult: true,
+		},
+		"pod without class": {
+			pod:            &corev1.Pod{Spec: corev1.PodSpec{}},
+			expectedResult: false,
+		},
+		"pod with other class": {
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				PriorityClassName: "some-class",
+			}},
+			expectedResult: false,
+		},
+	}
+	predicate := PodIdlerPredicate{}
+
+	for testName, data := range testData {
+		t.Run(testName, func(t *testing.T) {
+			// when & then
+			assert.Equal(t, data.expectedResult, predicate.Create(event.CreateEvent{Object: data.pod}))
+			assert.False(t, predicate.Generic(event.GenericEvent{Object: data.pod}))
+			assert.False(t, predicate.Delete(event.DeleteEvent{Object: data.pod}))
+
+			updateTestData := map[string]struct {
+				podStatus corev1.PodStatus
+				expected  bool
+			}{
+				"with container above threshold": {
+					podStatus: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+						{RestartCount: 51},
+						{RestartCount: 49},
+					}},
+					expected: true,
+				},
+				"with containers under threshold": {
+					podStatus: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+						{RestartCount: 0},
+						{RestartCount: 49},
+					}},
+					expected: false,
+				},
+				"without container statuses": {
+					podStatus: corev1.PodStatus{},
+					expected:  false,
+				},
+			}
+			t.Run("for update", func(t *testing.T) {
+				for updateTestName, updateData := range updateTestData {
+					t.Run(updateTestName, func(t *testing.T) {
+						// given
+						pod := data.pod.DeepCopy()
+						pod.Status = updateData.podStatus
+						expectedResult := data.expectedResult && updateData.expected
+
+						// when & then
+						assert.Equal(t, expectedResult, predicate.Update(event.UpdateEvent{ObjectNew: pod}))
+					})
+				}
+			})
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"os"
 	goruntime "runtime"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"time"
+
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/codeready-toolchain/member-operator/controllers/idler"
 	membercfgctrl "github.com/codeready-toolchain/member-operator/controllers/memberoperatorconfig"
@@ -248,7 +249,7 @@ func main() {
 		DynamicClient:       dynamicClient,
 		GetHostCluster:      cluster.GetHostCluster,
 		Namespace:           namespace,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, allNamespacesCluster); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Idler")
 		os.Exit(1)
 	}

--- a/pkg/webhook/mutatingwebhook/userpods_mutate.go
+++ b/pkg/webhook/mutatingwebhook/userpods_mutate.go
@@ -18,7 +18,7 @@ var (
 		{
 			"op":    "replace",
 			"path":  "/spec/priorityClassName",
-			"value": priorityClassName,
+			"value": PriorityClassName,
 		},
 		{
 			"op":    "replace",
@@ -32,7 +32,7 @@ var (
 
 const (
 	priority          = int32(-3)
-	priorityClassName = "sandbox-users-pods"
+	PriorityClassName = "sandbox-users-pods"
 )
 
 func init() {


### PR DESCRIPTION
Added watcher on pods with a predicate that should trigger the reconcile only if:
* pod exists in users namespace
* either the startTime was set in the pod's status, or it reached the restart threshold.

two fixes of scheduling the next requeue of the idler controller:
1. drops the `RequeueTimeThreshold` - the original value caused that the controller kept reconciling as crazy in instances with a high number of users 
2. take into account that VMs should live only one twelfth of the idler timeout - the next requeue should be scheduled accordingly.