### PR TITLE
check that startTime is not nil

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -181,8 +181,10 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 				StartTime: *pod.Status.StartTime,
 			})
 		}
-		killAfter := time.Until(pod.Status.StartTime.Add(time.Duration(timeoutSeconds+1) * time.Second))
-		requeueAfter = shorterDuration(requeueAfter, killAfter)
+		if pod.Status.StartTime != nil {
+			killAfter := time.Until(pod.Status.StartTime.Add(time.Duration(timeoutSeconds+1) * time.Second))
+			requeueAfter = shorterDuration(requeueAfter, killAfter)
+		}
 	}
 
 	return requeueAfter, r.updateStatusPods(ctx, idler, newStatusPods)


### PR DESCRIPTION
:man_facepalming: 
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x194e580]

goroutine 593 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x1d9d220?, 0x34e8b00?})
	/opt/hostedtoolcache/go/1.21.13/x64/src/runtime/panic.go:914 +0x21f
github.com/codeready-toolchain/member-operator/controllers/idler.(*Reconciler).ensureIdling(0xc00063aba0, {0x23e6d60, 0xc010c2af90}, 0xc010c00c80)
	/home/runner/work/member-operator/member-operator/controllers/idler/idler_controller.go:184 +0x740
github.com/codeready-toolchain/member-operator/controllers/idler.(*Reconciler).Reconcile(0xc00063aba0, {0x23e6d60, 0xc010c2af90}, {{{0x0?, 0x5?}, {0xc00d7c57f0?, 0xc0083b3d08?}}})
	/home/runner/work/member-operator/member-operator/controllers/idler/idler_controller.go:114 +0x43e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x23eac00?, {0x23e6d60?, 0xc010c2af90?}, {{{0x0?, 0xb?}, {0xc00d7c57f0?, 0x0?}}})
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000525220, {0x23e6d98, 0xc0001d9950}, {0x1e88760?, 0xc00be34f60?})
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:316 +0x3cc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000525220, {0x23e6d98, 0xc0001d9950})
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266 +0x1af
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 114
	/tmp/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:223 +0x565
```