### PR TITLE
Update the autoscaler-buffer image registry

### DIFF
--- a/deploy/autoscaler/member-operator-autoscaler.yaml
+++ b/deploy/autoscaler/member-operator-autoscaler.yaml
@@ -34,7 +34,7 @@ objects:
           terminationGracePeriodSeconds: 0
           containers:
             - name: autoscaling-buffer
-              image: gcr.io/google_containers/pause-amd64:3.2
+              image: registry.k8s.io/pause:3.9
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -225,7 +225,7 @@ func priorityClass() string {
 }
 
 func deployment(memory, cpu string, replicas int) string {
-	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"autoscaling-buffer","namespace":"%[1]s","labels":{"app":"autoscaling-buffer","toolchain.dev.openshift.com/provider":"codeready-toolchain"}},"spec":{"replicas":%[2]d,"selector":{"matchLabels":{"app":"autoscaling-buffer"}},"template":{"metadata":{"labels":{"app":"autoscaling-buffer"}},"spec":{"priorityClassName":"member-operator-autoscaling-buffer","terminationGracePeriodSeconds":0,"containers":[{"name":"autoscaling-buffer","image":"gcr.io/google_containers/pause-amd64:3.2","imagePullPolicy":"IfNotPresent","resources":{"requests":{"memory":"%[3]s","cpu":"%[4]s"}}}]}}}}`, test.MemberOperatorNs, replicas, memory, cpu)
+	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"autoscaling-buffer","namespace":"%[1]s","labels":{"app":"autoscaling-buffer","toolchain.dev.openshift.com/provider":"codeready-toolchain"}},"spec":{"replicas":%[2]d,"selector":{"matchLabels":{"app":"autoscaling-buffer"}},"template":{"metadata":{"labels":{"app":"autoscaling-buffer"}},"spec":{"priorityClassName":"member-operator-autoscaling-buffer","terminationGracePeriodSeconds":0,"containers":[{"name":"autoscaling-buffer","image":"registry.k8s.io/pause:3.9","imagePullPolicy":"IfNotPresent","resources":{"requests":{"memory":"%[3]s","cpu":"%[4]s"}}}]}}}}`, test.MemberOperatorNs, replicas, memory, cpu)
 }
 
 func bufferConfiguration(memory, cpu string, replicas int) BufferConfiguration {


### PR DESCRIPTION
gcr.io registry is gettig shutdown. The last day it will be available for pulls is March 20. See https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation
This PR is switching to the kube image registry instead.

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1136