### PR TITLE
idler: patch instead of update

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	notify "github.com/codeready-toolchain/toolchain-common/pkg/notification"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -385,46 +384,24 @@ func (r *Reconciler) scaleDeploymentToZero(ctx context.Context, namespace string
 		return "", "", false, err
 	}
 	zero := int32(0)
-
 	for _, deploymentOwner := range d.OwnerReferences {
 		if supportedScaleResource := getSupportedScaleResource(deploymentOwner); supportedScaleResource != nil {
-			// check for owner with scale sub resource
-			if scaleResource, err := r.ScalesClient.Scales(d.Namespace).Get(ctx, supportedScaleResource.GroupResource(), deploymentOwner.Name, metav1.GetOptions{}); err == nil {
-				scaleResource.Spec.Replicas = zero
-				_, err = r.ScalesClient.Scales(d.Namespace).Update(ctx, supportedScaleResource.GroupResource(), scaleResource, metav1.UpdateOptions{})
-
-				if err == nil {
-					logger.Info("Deployment scaled to zero using scale sub resource", "name", d.Name)
-					return owner.Kind, owner.Name, true, nil
+			patch := []byte(`{"spec":{"replicas":0}}`)
+			_, err := r.ScalesClient.Scales(d.Namespace).Patch(ctx, *supportedScaleResource, deploymentOwner.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					return "", "", false, err
 				}
-
-				return "", "", false, err
-			} else if errors.IsInternalError(err) { // Internal error indicates that the specReplicasPath is not set on the custom resource - just update the scale resource
-				scale := autoscalingv1.Scale{
-					ObjectMeta: ctrl.ObjectMeta{
-						Name:      deploymentOwner.Name,
-						Namespace: d.Namespace,
-					},
-					Spec: autoscalingv1.ScaleSpec{
-						Replicas: zero,
-					},
-				}
-				_, err = r.ScalesClient.Scales(d.Namespace).Update(ctx, supportedScaleResource.GroupResource(), &scale, metav1.UpdateOptions{})
-
-				if err == nil {
-					logger.Info("Deployment scaled to zero using scale sub resource", "name", d.Name)
-					return owner.Kind, owner.Name, true, nil
-				}
-
-				return "", "", false, err
-			} else if !errors.IsNotFound(err) {
-				return "", "", false, err
+			} else {
+				logger.Info("Deployment scaled to zero using scale sub resource", "name", d.Name)
+				return owner.Kind, owner.Name, true, nil
 			}
 		}
 	}
 
-	d.Spec.Replicas = &zero
-	if err := r.AllNamespacesClient.Update(ctx, d); err != nil {
+	patched := d.DeepCopy()
+	patched.Spec.Replicas = &zero
+	if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(d)); err != nil {
 		return "", "", false, err
 	}
 	logger.Info("Deployment scaled to zero", "name", d.Name)
@@ -463,8 +440,9 @@ func (r *Reconciler) scaleReplicaSetToZero(ctx context.Context, namespace string
 	if !deletedByController {
 		// There is no controller that owns the ReplicaSet. Scale the ReplicaSet to zero.
 		zero := int32(0)
-		rs.Spec.Replicas = &zero
-		if err := r.AllNamespacesClient.Update(ctx, rs); err != nil {
+		patched := rs.DeepCopy()
+		patched.Spec.Replicas = &zero
+		if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(rs)); err != nil {
 			return "", "", false, err
 		}
 		logger.Info("ReplicaSet scaled to zero", "name", rs.Name)
@@ -501,8 +479,9 @@ func (r *Reconciler) scaleStatefulSetToZero(ctx context.Context, namespace strin
 		return "", "", false, err
 	}
 	zero := int32(0)
-	s.Spec.Replicas = &zero
-	if err := r.AllNamespacesClient.Update(ctx, s); err != nil {
+	patched := s.DeepCopy()
+	patched.Spec.Replicas = &zero
+	if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(s)); err != nil {
 		return "", "", false, err
 	}
 	log.FromContext(ctx).Info("StatefulSet scaled to zero", "name", s.Name)
@@ -517,9 +496,10 @@ func (r *Reconciler) scaleDeploymentConfigToZero(ctx context.Context, namespace 
 		}
 		return "", "", false, err
 	}
-	dc.Spec.Replicas = 0
-	dc.Spec.Paused = false
-	if err := r.AllNamespacesClient.Update(ctx, dc); err != nil {
+	patched := dc.DeepCopy()
+	patched.Spec.Replicas = 0
+	patched.Spec.Paused = false
+	if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(dc)); err != nil {
 		return "", "", false, err
 	}
 	log.FromContext(ctx).Info("DeploymentConfig scaled to zero", "name", dc.Name)
@@ -541,8 +521,9 @@ func (r *Reconciler) scaleReplicationControllerToZero(ctx context.Context, names
 	if !deletedByController {
 		// There is no controller who owns the ReplicationController. Scale the ReplicationController to zero.
 		zero := int32(0)
-		rc.Spec.Replicas = &zero
-		if err := r.AllNamespacesClient.Update(ctx, rc); err != nil {
+		patched := rc.DeepCopy()
+		patched.Spec.Replicas = &zero
+		if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(rc)); err != nil {
 			return "", "", false, err
 		}
 		log.FromContext(ctx).Info("ReplicationController scaled to zero", "name", rc.Name)

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -632,11 +632,11 @@ func TestEnsureIdlingFailed(t *testing.T) {
 
 				update := allCl.MockUpdate
 				defer func() { allCl.MockUpdate = update }()
-				allCl.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+				allCl.MockPatch = func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					if reflect.TypeOf(obj) == reflect.TypeOf(inaccessible) {
 						return errors.New(errMsg)
 					}
-					return allCl.Client.Update(ctx, obj, opts...)
+					return allCl.Client.Patch(ctx, obj, patch, opts...)
 				}
 
 				// dynamic client for vms
@@ -1538,32 +1538,21 @@ func prepareReconcile(t *testing.T, name string, getHostClusterFunc func(fakeCli
 	dynamicClient := fakedynamic.NewSimpleDynamicClient(s)
 
 	scalesClient := fakescale.FakeScaleClient{}
-	scalesClient.AddReactor("update", "*", func(rawAction clienttest.Action) (bool, runtime.Object, error) {
-		action := rawAction.(clienttest.UpdateAction)    // nolint: forcetypeassert
-		obj := action.GetObject().(*autoscalingv1.Scale) // nolint: forcetypeassert
-		replicas := obj.Spec.Replicas
+	scalesClient.AddReactor("patch", "*", func(rawAction clienttest.Action) (bool, runtime.Object, error) {
+		action := rawAction.(clienttest.PatchAction) // nolint: forcetypeassert
 
 		// update owned deployment
 		d := &appsv1.Deployment{}
-		err := allNamespacesClient.Get(context.TODO(), types.NamespacedName{Name: obj.Name + "-deployment", Namespace: obj.Namespace}, d)
+		err := allNamespacesClient.Get(context.TODO(), types.NamespacedName{Name: action.GetName() + "-deployment", Namespace: action.GetNamespace()}, d)
 		if err != nil {
 			return false, nil, err
 		}
-		d.Spec.Replicas = &replicas
-		err = allNamespacesClient.Update(context.TODO(), d)
+		err = allNamespacesClient.Patch(context.TODO(), d, client.RawPatch(types.MergePatchType, action.GetPatch()))
 		if err != nil {
 			return false, nil, err
 		}
 
-		return true, &autoscalingv1.Scale{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      obj.Name,
-				Namespace: action.GetNamespace(),
-			},
-			Spec: autoscalingv1.ScaleSpec{
-				Replicas: replicas,
-			},
-		}, nil
+		return false, nil, nil
 	})
 
 	// Mock internal server error for Camel K integrations in order to replicate default behavior with missing spec.replicas field


### PR DESCRIPTION
use patch instead of update when scaling down controllers to avoid conflicts https://redhat-internal.slack.com/archives/C064SKK3C2E/p1742656300541629?thread_ts=1742645702.696489&cid=C064SKK3C2E