### PR TITLE
fix(idler): missing AAP permissions

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -91,6 +91,8 @@ type Reconciler struct {
 // based on the state of the existing object.
 //+kubebuilder:rbac:groups=subresources.kubevirt.io,resources=virtualmachines/stop,verbs=create;update
 
+//+kubebuilder:rbac:groups=aap.ansible.com,resources=ansibleautomationplatforms,verbs=get;list;watch;create;update;patch;delete
+
 // Reconcile reads that state of the cluster for an Idler object and makes changes based on the state read
 // and what is in the Idler.Spec
 // Note:


### PR DESCRIPTION
the member-operator is missing AAP permissions
```
ansibleautomationplatforms.aap.ansible.com is forbidden: User \"system:serviceaccount:toolchain-member-operator:member-operator-controller-manager\" cannot list resource \"ansibleautomationplatforms\" in API group \"aap.ansible.com\" in the namespace
```