### PR TITLE
idler: improve error handling

### DIFF
--- a/controllers/idler/aap_idler.go
+++ b/controllers/idler/aap_idler.go
@@ -2,13 +2,13 @@ package idler
 
 import (
 	"context"
-	errs "errors"
+	"errors"
 	"fmt"
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -133,7 +133,7 @@ func (i *aapIdler) ensureAnsiblePlatformIdling(ctx context.Context, idler *toolc
 	}
 
 	// there is at least one aap instance, schedule the next reconcile
-	return requeueAfter, errs.Join(idleErrors...)
+	return requeueAfter, errors.Join(idleErrors...)
 }
 
 // getRunningAAPs returns the list of all AAP CRs that are not idled from the namespace the idler was created for
@@ -214,7 +214,7 @@ func (i *aapIdler) getAAPOwner(ctx context.Context, obj metav1.Object) (metav1.O
 	// Get the owner object
 	ownerObject, err := i.dynamicClient.Resource(*gvr).Namespace(obj.GetNamespace()).Get(ctx, owner.Name, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			log.FromContext(ctx).Info("Owner not found", "kind", owner.Kind, "name", owner.Name)
 			return nil, nil
 		}

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -2,6 +2,7 @@ package idler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -26,12 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
-	errs "github.com/pkg/errors"
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// Fetch the Idler instance
 	idler := &toolchainv1alpha1.Idler{}
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: request.Name}, idler); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			logger.Info("no Idler found for namespace", "name", request.Name)
 			return reconcile.Result{}, nil
 		}
@@ -122,7 +122,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 	if idler.Spec.TimeoutSeconds < 0 {
 		// Make sure the timeout is bigger than 0
-		err := errs.New("timeoutSeconds should be bigger than 0")
+		err := errors.New("timeoutSeconds should be bigger than 0")
 		logger.Error(err, "failed to ensure idling")
 		return reconcile.Result{}, r.setStatusFailed(ctx, idler, err.Error())
 	}
@@ -168,6 +168,7 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 	}
 	requeueAfter := time.Duration(idler.Spec.TimeoutSeconds) * time.Second
 	newStatusPods := make([]toolchainv1alpha1.Pod, 0, 10)
+	var idleErrors []error
 	for _, pod := range podList.Items {
 		podLogger := log.FromContext(ctx).WithValues("pod_name", pod.Name, "pod_phase", pod.Status.Phase)
 		podCtx := log.IntoContext(ctx, podLogger)
@@ -185,7 +186,7 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				err := deletePodsAndCreateNotification(podCtx, pod, r, idler)
 				if err != nil {
-					return 0, err
+					idleErrors = append(idleErrors, err)
 				}
 				continue
 			}
@@ -195,7 +196,7 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				err := deletePodsAndCreateNotification(podCtx, pod, r, idler)
 				if err != nil {
-					return 0, err
+					idleErrors = append(idleErrors, err)
 				}
 				continue
 			}
@@ -218,8 +219,10 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 			requeueAfter = shorterDuration(requeueAfter, time.Duration(timeoutSeconds)*time.Second)
 		}
 	}
-
-	return requeueAfter, r.updateStatusPods(ctx, idler, newStatusPods)
+	if err := r.updateStatusPods(ctx, idler, newStatusPods); err != nil {
+		idleErrors = append(idleErrors, err)
+	}
+	return requeueAfter, errors.Join(idleErrors...)
 }
 
 func shorterDuration(first, second time.Duration) time.Duration {
@@ -307,7 +310,7 @@ func (r *Reconciler) createNotification(ctx context.Context, idler *toolchainv1a
 	notification := &toolchainv1alpha1.Notification{}
 	// Check if notification already exists in host
 	if err := hostCluster.Client.Get(ctx, types.NamespacedName{Name: notificationName, Namespace: hostCluster.OperatorNamespace}, notification); err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 
@@ -334,7 +337,7 @@ func (r *Reconciler) createNotification(ctx context.Context, idler *toolchainv1a
 				WithKeysAndValues(keysAndVals).
 				Create(ctx, userEmail)
 			if err != nil {
-				return errs.Wrapf(err, "unable to create Notification CR from Idler")
+				return fmt.Errorf("unable to create Notification CR from Idler: %w", err)
 			}
 		}
 	}
@@ -363,7 +366,7 @@ func (r *Reconciler) getUserEmailsFromMURs(ctx context.Context, hostCluster *clu
 			getMUR := &toolchainv1alpha1.MasterUserRecord{}
 			err := hostCluster.Client.Get(ctx, types.NamespacedName{Name: mur, Namespace: hostCluster.OperatorNamespace}, getMUR)
 			if err != nil {
-				return emails, errs.Wrapf(err, "could not get the MUR")
+				return emails, fmt.Errorf("could not get the MUR: %w", err)
 			}
 			if email := getMUR.Spec.PropagatedClaims.Email; email != "" {
 				emails = append(emails, getMUR.Spec.PropagatedClaims.Email)
@@ -412,7 +415,7 @@ func (r *Reconciler) scaleDeploymentToZero(ctx context.Context, namespace string
 	logger.Info("Scaling deployment to zero", "name", owner.Name)
 	d := &appsv1.Deployment{}
 	if err := r.AllNamespacesClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: owner.Name}, d); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			return owner.Kind, owner.Name, true, nil
 		}
 		return "", "", false, err
@@ -432,7 +435,7 @@ func (r *Reconciler) scaleDeploymentToZero(ctx context.Context, namespace string
 				}
 
 				return "", "", false, err
-			} else if errors.IsInternalError(err) { // Internal error indicates that the specReplicasPath is not set on the custom resource - just update the scale resource
+			} else if apierrors.IsInternalError(err) { // Internal error indicates that the specReplicasPath is not set on the custom resource - just update the scale resource
 				scale := autoscalingv1.Scale{
 					ObjectMeta: ctrl.ObjectMeta{
 						Name:      deploymentOwner.Name,
@@ -450,7 +453,7 @@ func (r *Reconciler) scaleDeploymentToZero(ctx context.Context, namespace string
 				}
 
 				return "", "", false, err
-			} else if !errors.IsNotFound(err) {
+			} else if !apierrors.IsNotFound(err) {
 				return "", "", false, err
 			}
 		}
@@ -481,7 +484,7 @@ func (r *Reconciler) scaleReplicaSetToZero(ctx context.Context, namespace string
 	logger.Info("Scaling replica set to zero", "name", owner.Name)
 	rs := &appsv1.ReplicaSet{}
 	if err := r.AllNamespacesClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: owner.Name}, rs); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			logger.Info("replica set is not found; ignoring: it might be already deleted")
 			return owner.Kind, owner.Name, true, nil
 		}
@@ -510,13 +513,13 @@ func (r *Reconciler) scaleReplicaSetToZero(ctx context.Context, namespace string
 func (r *Reconciler) deleteDaemonSet(ctx context.Context, namespace string, owner metav1.OwnerReference) (string, string, bool, error) {
 	ds := &appsv1.DaemonSet{}
 	if err := r.AllNamespacesClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: owner.Name}, ds); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			return owner.Kind, owner.Name, true, nil
 		}
 		return "", "", false, err
 	}
 	if err := r.AllNamespacesClient.Delete(ctx, ds); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			return owner.Kind, owner.Name, true, nil
 		}
 		return "", "", false, err
@@ -528,7 +531,7 @@ func (r *Reconciler) deleteDaemonSet(ctx context.Context, namespace string, owne
 func (r *Reconciler) scaleStatefulSetToZero(ctx context.Context, namespace string, owner metav1.OwnerReference) (string, string, bool, error) {
 	s := &appsv1.StatefulSet{}
 	if err := r.AllNamespacesClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: owner.Name}, s); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			return owner.Kind, owner.Name, true, nil
 		}
 		return "", "", false, err
@@ -545,7 +548,7 @@ func (r *Reconciler) scaleStatefulSetToZero(ctx context.Context, namespace strin
 func (r *Reconciler) scaleDeploymentConfigToZero(ctx context.Context, namespace string, owner metav1.OwnerReference) (string, string, bool, error) {
 	dc := &openshiftappsv1.DeploymentConfig{}
 	if err := r.AllNamespacesClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: owner.Name}, dc); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			return owner.Kind, owner.Name, true, nil
 		}
 		return "", "", false, err
@@ -562,7 +565,7 @@ func (r *Reconciler) scaleDeploymentConfigToZero(ctx context.Context, namespace 
 func (r *Reconciler) scaleReplicationControllerToZero(ctx context.Context, namespace string, owner metav1.OwnerReference) (string, string, bool, error) {
 	rc := &corev1.ReplicationController{}
 	if err := r.AllNamespacesClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: owner.Name}, rc); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			return owner.Kind, owner.Name, true, nil
 		}
 		return "", "", false, err
@@ -589,7 +592,7 @@ func (r *Reconciler) deleteJob(ctx context.Context, namespace string, owner meta
 	logger := log.FromContext(ctx)
 	j := &batchv1.Job{}
 	if err := r.AllNamespacesClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: owner.Name}, j); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			logger.Info("job not found")
 			return owner.Kind, owner.Name, true, nil
 		}
@@ -603,7 +606,7 @@ func (r *Reconciler) deleteJob(ctx context.Context, namespace string, owner meta
 	if err := r.AllNamespacesClient.Delete(ctx, j, &client.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	}); err != nil {
-		if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+		if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 			return owner.Kind, owner.Name, true, nil
 		}
 		return "", "", false, err
@@ -616,7 +619,7 @@ func (r *Reconciler) stopVirtualMachine(ctx context.Context, namespace string, o
 	logger := log.FromContext(ctx)
 	// get the virtualmachineinstance info from the owner reference
 	vmInstance, err := r.DynamicClient.Resource(vmInstanceGVR).Namespace(namespace).Get(ctx, owner.Name, metav1.GetOptions{})
-	if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+	if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 		logger.Info("VirtualMachineInstance not found", "name", owner.Name)
 		return owner.Kind, owner.Name, true, nil
 	}
@@ -640,7 +643,7 @@ func (r *Reconciler) stopVirtualMachine(ctx context.Context, namespace string, o
 
 	// get the virtualmachine resource
 	vm, err := r.DynamicClient.Resource(vmGVR).Namespace(namespace).Get(ctx, vmInstanceOwners[vmiOwnerIndex].Name, metav1.GetOptions{})
-	if errors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
+	if apierrors.IsNotFound(err) { // Ignore not found errors. Can happen if the parent controller has been deleted. The Garbage Collector should delete the pods shortly.
 		logger.Info("VirtualMachine not found")
 		return owner.Kind, owner.Name, true, nil
 	}
@@ -769,7 +772,7 @@ func (r *Reconciler) wrapErrorWithStatusUpdate(ctx context.Context, idler *toolc
 	if err := statusUpdater(ctx, idler, err.Error()); err != nil {
 		log.FromContext(ctx).Error(err, "status update failed")
 	}
-	return errs.Wrapf(err, format, args...)
+	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
 }
 
 func isOwnedByVM(meta metav1.ObjectMeta) bool {

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -185,20 +185,22 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 				podLogger.Info("Pod is restarting too often. Killing the pod", "restart_count", restartCount)
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				err := deletePodsAndCreateNotification(podCtx, pod, r, idler)
-				if err != nil {
-					idleErrors = append(idleErrors, err)
+				if err == nil {
+					continue
 				}
-				continue
+				idleErrors = append(idleErrors, err)
+				podLogger.Error(err, "failed to kill the pod")
 			}
 			// Already tracking this pod. Check the timeout.
 			if time.Now().After(trackedPod.StartTime.Add(time.Duration(timeoutSeconds) * time.Second)) {
 				podLogger.Info("Pod running for too long. Killing the pod.", "start_time", trackedPod.StartTime.Format("2006-01-02T15:04:05Z"), "timeout_seconds", timeoutSeconds)
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				err := deletePodsAndCreateNotification(podCtx, pod, r, idler)
-				if err != nil {
-					idleErrors = append(idleErrors, err)
+				if err == nil {
+					continue
 				}
-				continue
+				idleErrors = append(idleErrors, err)
+				podLogger.Error(err, "failed to kill the pod")
 			}
 			newStatusPods = append(newStatusPods, *trackedPod) // keep tracking
 

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -627,9 +627,10 @@ func TestEnsureIdlingFailed(t *testing.T) {
 				res, err := reconciler.Reconcile(context.TODO(), req)
 
 				// then
-				require.EqualError(t, err, fmt.Sprintf("failed to ensure idling 'alex-stage': %s", errMsg))
+				require.ErrorContains(t, err, fmt.Sprintf("failed to ensure idling 'alex-stage': %s", errMsg))
 				assert.Equal(t, reconcile.Result{}, res)
-				memberoperatortest.AssertThatIdler(t, idler.Name, cl).ContainsCondition(memberoperatortest.FailedToIdle(errMsg))
+				memberoperatortest.AssertThatIdler(t, idler.Name, cl).
+					ContainsCondition(memberoperatortest.FailedToIdle(strings.Split(err.Error(), ": ")[1]))
 			}
 
 			assertCanNotGetObject(&appsv1.Deployment{}, "can't get deployment")
@@ -731,9 +732,10 @@ func TestEnsureIdlingFailed(t *testing.T) {
 				res, err := reconciler.Reconcile(context.TODO(), req)
 
 				// then
-				require.EqualError(t, err, fmt.Sprintf("failed to ensure idling 'alex-stage': %s", errMsg))
+				require.ErrorContains(t, err, fmt.Sprintf("failed to ensure idling 'alex-stage': %s", errMsg))
 				assert.Equal(t, reconcile.Result{}, res)
-				memberoperatortest.AssertThatIdler(t, idler.Name, cl).ContainsCondition(memberoperatortest.FailedToIdle(errMsg))
+				memberoperatortest.AssertThatIdler(t, idler.Name, cl).
+					ContainsCondition(memberoperatortest.FailedToIdle(strings.Split(err.Error(), ": ")[1]))
 			}
 
 			assertCanNotUpdateObject(&appsv1.Deployment{}, "can't update deployment")
@@ -762,9 +764,10 @@ func TestEnsureIdlingFailed(t *testing.T) {
 				res, err := reconciler.Reconcile(context.TODO(), req)
 
 				// then
-				require.EqualError(t, err, fmt.Sprintf("failed to ensure idling 'alex-stage': %s", errMsg))
+				require.ErrorContains(t, err, fmt.Sprintf("failed to ensure idling 'alex-stage': %s", errMsg))
 				assert.Equal(t, reconcile.Result{}, res)
-				memberoperatortest.AssertThatIdler(t, idler.Name, cl).ContainsCondition(memberoperatortest.FailedToIdle(errMsg))
+				memberoperatortest.AssertThatIdler(t, idler.Name, cl).
+					ContainsCondition(memberoperatortest.FailedToIdle(strings.Split(err.Error(), ": ")[1]))
 			}
 
 			assertCanNotDeleteObject(&appsv1.DaemonSet{}, "can't delete daemonset")

--- a/test/idler_assertion.go
+++ b/test/idler_assertion.go
@@ -157,7 +157,7 @@ func (a *IdleablePayloadAssertion) DeploymentScaledDown(deployment *appsv1.Deplo
 	err := a.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, d)
 	require.NoError(a.t, err)
 	require.NotNil(a.t, d.Spec.Replicas)
-	assert.Equal(a.t, int32(0), *d.Spec.Replicas)
+	assert.Equal(a.t, int32(0), *d.Spec.Replicas, "namespace %s name %s", deployment.Namespace, deployment.Name)
 	return a
 }
 


### PR DESCRIPTION
* collect errors when trying to idle pods and do not return them immediately - try to idle (and track) the other pods
* align the import aliases
* drop `github.com/pkg/errors`

related to this https://redhat-internal.slack.com/archives/C064SKK3C2E/p1742656916819689?thread_ts=1742645702.696489&cid=C064SKK3C2E