### PR TITLE
Fix dynamic client for idler

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -433,7 +433,7 @@ func (r *Reconciler) scaleDeploymentToZero(ctx context.Context, namespace string
 
 	patched := d.DeepCopy()
 	patched.Spec.Replicas = &zero
-	if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(d)); err != nil {
+	if err := r.AllNamespacesClient.Patch(ctx, patched, runtimeclient.MergeFrom(d)); err != nil {
 		return "", "", false, err
 	}
 	logger.Info("Deployment scaled to zero", "name", d.Name)
@@ -474,7 +474,7 @@ func (r *Reconciler) scaleReplicaSetToZero(ctx context.Context, namespace string
 		zero := int32(0)
 		patched := rs.DeepCopy()
 		patched.Spec.Replicas = &zero
-		if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(rs)); err != nil {
+		if err := r.AllNamespacesClient.Patch(ctx, patched, runtimeclient.MergeFrom(rs)); err != nil {
 			return "", "", false, err
 		}
 		logger.Info("ReplicaSet scaled to zero", "name", rs.Name)
@@ -513,7 +513,7 @@ func (r *Reconciler) scaleStatefulSetToZero(ctx context.Context, namespace strin
 	zero := int32(0)
 	patched := s.DeepCopy()
 	patched.Spec.Replicas = &zero
-	if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(s)); err != nil {
+	if err := r.AllNamespacesClient.Patch(ctx, patched, runtimeclient.MergeFrom(s)); err != nil {
 		return "", "", false, err
 	}
 	log.FromContext(ctx).Info("StatefulSet scaled to zero", "name", s.Name)
@@ -531,7 +531,7 @@ func (r *Reconciler) scaleDeploymentConfigToZero(ctx context.Context, namespace 
 	patched := dc.DeepCopy()
 	patched.Spec.Replicas = 0
 	patched.Spec.Paused = false
-	if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(dc)); err != nil {
+	if err := r.AllNamespacesClient.Patch(ctx, patched, runtimeclient.MergeFrom(dc)); err != nil {
 		return "", "", false, err
 	}
 	log.FromContext(ctx).Info("DeploymentConfig scaled to zero", "name", dc.Name)
@@ -555,7 +555,7 @@ func (r *Reconciler) scaleReplicationControllerToZero(ctx context.Context, names
 		zero := int32(0)
 		patched := rc.DeepCopy()
 		patched.Spec.Replicas = &zero
-		if err := r.AllNamespacesClient.Patch(ctx, patched, client.MergeFrom(rc)); err != nil {
+		if err := r.AllNamespacesClient.Patch(ctx, patched, runtimeclient.MergeFrom(rc)); err != nil {
 			return "", "", false, err
 		}
 		log.FromContext(ctx).Info("ReplicationController scaled to zero", "name", rc.Name)

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"gopkg.in/h2non/gock.v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -1734,13 +1733,6 @@ func prepareReconcile(t *testing.T, name string, getHostClusterFunc func(fakeCli
 			},
 		}
 		return true, obj, nil
-	})
-
-	restClient, err := test.NewRESTClient("dummy-token", apiEndpoint)
-	require.NoError(t, err)
-	restClient.Client.Transport = gock.DefaultTransport
-	t.Cleanup(func() {
-		gock.OffAll()
 	})
 
 	r := &Reconciler{

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/redhat-cop/operator-utils v1.3.8
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.26.0
-	gopkg.in/h2non/gock.v1 v1.0.14
+	gopkg.in/h2non/gock.v1 v1.0.14 // indirect
 	k8s.io/api v0.30.1
 	k8s.io/client-go v0.30.1
 	k8s.io/klog v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/redhat-cop/operator-utils v1.3.8
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.26.0
-	gopkg.in/h2non/gock.v1 v1.0.14 // indirect
+	gopkg.in/h2non/gock.v1 v1.0.14
 	k8s.io/api v0.30.1
 	k8s.io/client-go v0.30.1
 	k8s.io/klog v1.0.0


### PR DESCRIPTION
- Resolves the issue with the DynamicClient and the VM stop subresource API that caused the error below
- Removes the rest client from the idler for simplification. We can just use and manage 1 client instead of 2
- The code comments include specific details about the fix.

The error that was preventing use of the DynamicClient with the VM stop API:

{"level":"error","ts":"2025-03-19T14:37:10.179Z","msg":"Reconciler error","controller":"idler","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"Idler","Idler":{"name":"user1-dev"},"namespace":"","name":"user1-dev","reconcileID":"b2be7e32-8c39-459d-9eeb-be94e2d49f80","error":"failed to ensure idling 'user1-dev': 406: Not Acceptable\n\nAvailable representations:","errorVerbose":"406: Not Acceptable\n\nAvailable representations:\nfailed to ensure idling 'user1-dev'\ngithub.com/codeready-toolchain/member-operator/controllers/idler.(*Reconciler).wrapErrorWithStatusUpdate\n\t/Users/rsenthil/go/src/github.com/codeready-toolchain/member-operator/controllers/idler/idler_controller.go:750\ngithub.com/codeready-toolchain/member-operator/controllers/idler.(*Reconciler).Reconcile\n\t/Users/rsenthil/go/src/github.com/codeready-toolchain/member-operator/controllers/idler/idler_controller.go:124
...
