### PR TITLE
chore(build): migrate to golangci-lint@v2 and golangci-lint-action@v7

### DIFF
--- a/.github/workflows/ci-golang-sbom.yml
+++ b/.github/workflows/ci-golang-sbom.yml
@@ -27,9 +27,9 @@ jobs:
         make generate-assets
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: v1.63.1
+        version: v2.0.2
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,32 +1,62 @@
-run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-  
+version: "2"
 linters:
   enable:
-    - megacheck
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - gocyclo
-    - gofmt
-    - revive
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
     - misspell
-  presets: # groups of linters. See https://golangci-lint.run/usage/linters/
-    - bugs
-    - unused
-  disable: 
-    - golint # deprecated, use 'revive'
-    - scopelint # deprecated, use 'exportloopref'
-    - contextcheck # too many false-positives
-    - noctx # not needed
-
-# all available settings of specific linters
-linters-settings:
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: true
-  revive:
-    rules:
-      - name: dot-imports
-        disabled: true # we allow for dot-imports
+    - musttag
+    - nilerr
+    - nilnesserr
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unparam
+    - zerologlint
+  disable:
+    - contextcheck
+    - noctx
+  settings:
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    unparam:
+      check-exported: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/controllers/idler/aap_idler_test.go
+++ b/controllers/idler/aap_idler_test.go
@@ -266,7 +266,7 @@ func TestAAPIdler(t *testing.T) {
 
 			t.Run("get deployment fails", func(t *testing.T) {
 				// given
-				dynamicCl.Fake.ReactionChain = originalReactions
+				dynamicCl.ReactionChain = originalReactions
 				dynamicCl.PrependReactor("get", "deployments", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("some get error")
 				})
@@ -284,7 +284,7 @@ func TestAAPIdler(t *testing.T) {
 
 			t.Run("list AAP fails", func(t *testing.T) {
 				// given
-				dynamicCl.Fake.ReactionChain = originalReactions
+				dynamicCl.ReactionChain = originalReactions
 				dynamicCl.PrependReactor("list", "ansibleautomationplatforms", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("some list error")
 				})
@@ -296,7 +296,7 @@ func TestAAPIdler(t *testing.T) {
 				require.EqualError(t, err, "some list error")
 				assert.Empty(t, requeueAfter)
 				interceptedNotify.assertThatCalled(t)
-				dynamicCl.Fake.ReactionChain = originalReactions
+				dynamicCl.ReactionChain = originalReactions
 				assertAAPsIdled(t, aapIdler, idler.Name, idledAAP.GetName())
 			})
 

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -614,7 +614,7 @@ func TestEnsureIdlingFailed(t *testing.T) {
 				originalReactions := make([]clienttest.Reactor, len(dynamicCl.ReactionChain))
 				copy(originalReactions, dynamicCl.ReactionChain)
 				defer func() {
-					dynamicCl.Fake.ReactionChain = originalReactions
+					dynamicCl.ReactionChain = originalReactions
 				}()
 				if reflect.TypeOf(inaccessible) == reflect.TypeOf(&unstructured.Unstructured{}) {
 					resource := strings.ToLower(inaccessible.(*unstructured.Unstructured).GetKind()) + "s"
@@ -663,7 +663,7 @@ func TestEnsureIdlingFailed(t *testing.T) {
 				originalReactions := make([]clienttest.Reactor, len(dynamicCl.ReactionChain))
 				copy(originalReactions, dynamicCl.ReactionChain)
 				defer func() {
-					dynamicCl.Fake.ReactionChain = originalReactions
+					dynamicCl.ReactionChain = originalReactions
 				}()
 				if reflect.TypeOf(inaccessible) == reflect.TypeOf(&unstructured.Unstructured{}) {
 					resource := strings.ToLower(inaccessible.(*unstructured.Unstructured).GetKind()) + "s"
@@ -718,7 +718,7 @@ func TestEnsureIdlingFailed(t *testing.T) {
 				originalReactions := make([]clienttest.Reactor, len(dynamicCl.ReactionChain))
 				copy(originalReactions, dynamicCl.ReactionChain)
 				defer func() {
-					dynamicCl.Fake.ReactionChain = originalReactions
+					dynamicCl.ReactionChain = originalReactions
 				}()
 				if reflect.TypeOf(inaccessible) == reflect.TypeOf(&unstructured.Unstructured{}) {
 					resource := strings.ToLower(inaccessible.(*unstructured.Unstructured).GetKind()) + "s"

--- a/controllers/memberstatus/memberstatus_controller_test.go
+++ b/controllers/memberstatus/memberstatus_controller_test.go
@@ -751,7 +751,7 @@ func forNode(name string, roles []string, allocatableMemory string, metricsModif
 			},
 		}
 		for _, role := range roles {
-			node.ObjectMeta.Labels["node-role.kubernetes.io/"+role] = ""
+			node.Labels["node-role.kubernetes.io/"+role] = ""
 		}
 		nodeMetrics := &v1beta1.NodeMetrics{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -451,5 +451,5 @@ func (r *namespacesManager) setProvisionedNamespaceList(ctx context.Context, nsT
 	if err != nil {
 		return err
 	}
-	return r.statusManager.updateStatusProvisionedNamespaces(ctx, nsTmplSet, userNamespaces)
+	return r.updateStatusProvisionedNamespaces(ctx, nsTmplSet, userNamespaces)
 }

--- a/controllers/nstemplateset/namespaces_test.go
+++ b/controllers/nstemplateset/namespaces_test.go
@@ -381,7 +381,7 @@ func TestGetNamespaceName(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		assert.Equal(t, "", nsName)
+		assert.Empty(t, nsName)
 	})
 
 }

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -379,9 +379,9 @@ func TestReconcileProvisionOK(t *testing.T) {
 		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
 		rb2Code := newRoleBinding(stageNS.Name, "crtadmin-view", spacename)
 		ro := newRole(devNS.Name, "exec-pods", spacename)
-		delete(ro.ObjectMeta.Labels, toolchainv1alpha1.SpaceLabelKey)
+		delete(ro.Labels, toolchainv1alpha1.SpaceLabelKey)
 		roCode := newRole(stageNS.Name, "exec-pods", spacename)
-		delete(roCode.ObjectMeta.Labels, toolchainv1alpha1.SpaceLabelKey)
+		delete(roCode.Labels, toolchainv1alpha1.SpaceLabelKey)
 		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rb, rb2, ro, roCode, rbCode, rb2Code)
 
 		// when
@@ -428,8 +428,8 @@ func TestReconcileProvisionOK(t *testing.T) {
 		stageNS := newNamespace("basic", spacename, "stage", withTemplateRefUsingRevision("abcde11"))
 		rbDev := newRoleBinding(devNS.Name, "crtadmin-pods", spacename)
 		rbCode := newRoleBinding(stageNS.Name, "crtadmin-pods", spacename)
-		delete(rbDev.ObjectMeta.Labels, toolchainv1alpha1.SpaceLabelKey)
-		delete(rbCode.ObjectMeta.Labels, toolchainv1alpha1.SpaceLabelKey)
+		delete(rbDev.Labels, toolchainv1alpha1.SpaceLabelKey)
+		delete(rbCode.Labels, toolchainv1alpha1.SpaceLabelKey)
 		r, req, fakeClient := prepareReconcile(t, namespaceName, spacename, nsTmplSet, devNS, stageNS, rbDev, rbCode)
 
 		// when

--- a/pkg/klog/writer.go
+++ b/pkg/klog/writer.go
@@ -23,15 +23,16 @@ func (kw Writer) Write(p []byte) (n int, err error) { // nolint:unparam
 		klogv2.InfoDepth(OutputCallDepth, string(p))
 		return len(p), nil
 	}
-	if p[0] == 'I' {
+	switch p[0] {
+	case 'I':
 		klogv2.InfoDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
-	} else if p[0] == 'W' {
+	case 'W':
 		klogv2.WarningDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
-	} else if p[0] == 'E' {
+	case 'E':
 		klogv2.ErrorDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
-	} else if p[0] == 'F' {
+	case 'F':
 		klogv2.FatalDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
-	} else {
+	default:
 		klogv2.InfoDepth(OutputCallDepth, string(p[DefaultPrefixLength:]))
 	}
 	return len(p), nil

--- a/pkg/webhook/mutatingwebhook/mutate_test.go
+++ b/pkg/webhook/mutatingwebhook/mutate_test.go
@@ -110,7 +110,7 @@ func fakeMutator(_ admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 }
 
 func assertPatchesEqual(t *testing.T, expected, actual []map[string]interface{}) {
-	assert.Equal(t, len(expected), len(actual))
+	assert.Len(t, actual, len(expected))
 	expectedPatchContent, err := json.Marshal(expected)
 	require.NoError(t, err)
 	actualPatchContent, err := json.Marshal(actual)

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -83,7 +83,7 @@ func (a *NSTemplateSetAssertion) HasProvisionedNamespaces(expected ...toolchainv
 func (a *NSTemplateSetAssertion) HasNoOwnerReferences() *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)
-	assert.Empty(a.t, a.nsTmplSet.ObjectMeta.OwnerReferences)
+	assert.Empty(a.t, a.nsTmplSet.OwnerReferences)
 	return a
 }
 


### PR DESCRIPTION
upgraded `.golangci.yml` with `golangci-lint migrate`

include fixes suggested by `golangci-lint run -c ./.golangci.yml`

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
