### PR TITLE
Revert "Fix dynamic client for idler (#655)"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -207,9 +207,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	dynamicClient, err := newDynamicClient(cfg)
+	restClient, err := newRestClient(cfg)
 	if err != nil {
-		setupLog.Error(err, "unable to create the dynamic client")
+		setupLog.Error(err, "unable to create the REST client")
+		os.Exit(1)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to create dynamic client")
 		os.Exit(1)
 	}
 
@@ -246,6 +252,7 @@ func main() {
 		ScalesClient:        scalesClient,
 		DynamicClient:       dynamicClient,
 		DiscoveryClient:     discoveryClient,
+		RestClient:          restClient,
 		GetHostCluster:      cluster.GetHostCluster,
 		Namespace:           namespace,
 	}).SetupWithManager(mgr, allNamespacesCluster); err != nil {
@@ -324,29 +331,13 @@ func main() {
 
 }
 
-func newDynamicClient(config *rest.Config) (*dynamic.DynamicClient, error) {
-	restCfg := rest.CopyConfig(config)
-	// Set AcceptContentTypes to "application/json, */*"" so that the client will accept non-JSON responses which is required for some APIs. See the comment regarding the VM stop API below.
-	restCfg.AcceptContentTypes = "application/json, */*"
-	httpClient, err := rest.HTTPClientFor(restCfg)
+func newRestClient(config *rest.Config) (*rest.RESTClient, error) {
+	httpClient, err := rest.HTTPClientFor(config)
 	if err != nil {
 		return nil, err
 	}
 
-	restClient, err := rest.RESTClientForConfigAndClient(restCfg, httpClient)
-	if err != nil {
-		return nil, err
-	}
-
-	// Avoid creating the DynamicClient via dynamic.NewForConfig(cfg) because it leads to the Accept header in the requests
-	// being set to "application/json" which leads to errors for some APIs like the VM stop API used by the idler.
-	//
-	// eg. the VM stop subresource API returns the error '406: Not Acceptable\n\nAvailable representations' when the Accept header is set to "application/json"
-	//
-	// Relevant code snippets:
-	// 1. https://github.com/kubernetes/client-go/blob/169f1af1bf07d58eef1246c3b55e465275b2feb9/dynamic/simple.go#L50-L51
-	// 2. https://github.com/kubernetes/client-go/blob/169f1af1bf07d58eef1246c3b55e465275b2feb9/rest/request.go#L210-L213
-	return dynamic.New(restClient), nil
+	return rest.RESTClientForConfigAndClient(config, httpClient)
 }
 
 func newScalesClient(config *rest.Config) (scale.ScalesGetter, error) {

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"gopkg.in/h2non/gock.v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -700,10 +701,9 @@ func TestEnsureIdlingFailed(t *testing.T) {
 			assertCanNotUpdateObject := func(inaccessible runtime.Object, errMsg string) {
 				// given
 				reconciler, req, cl, allCl, dynamicCl := prepareReconcileWithPodsRunningTooLong(t, idler)
+				gock.Off()
 				// mock stop call
-				dynamicCl.PrependReactor("update", "virtualmachines/stop", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
-					return true, nil, fmt.Errorf("can't update virtualmachine")
-				})
+				mockStopVMCalls(".*", ".*", http.StatusInternalServerError)
 
 				update := allCl.MockUpdate
 				defer func() { allCl.MockUpdate = update }()
@@ -741,7 +741,7 @@ func TestEnsureIdlingFailed(t *testing.T) {
 			assertCanNotUpdateObject(&appsv1.StatefulSet{}, "can't update statefulset")
 			assertCanNotUpdateObject(&openshiftappsv1.DeploymentConfig{}, "can't update deploymentconfig")
 			assertCanNotUpdateObject(&corev1.ReplicationController{}, "can't update replicationcontroller")
-			assertCanNotUpdateObject(vm, "can't update virtualmachine")
+			assertCanNotUpdateObject(vm, "an error on the server (\"\") has prevented the request from succeeding (put virtualmachines.authentication.k8s.io alex-stage-virtualmachine)")
 		})
 
 		t.Run("can't delete payloads", func(t *testing.T) {
@@ -1470,21 +1470,8 @@ func preparePayloadsWithCreateFunc(t *testing.T, clients clientSet, namespace, n
 	_, err = clients.dynamicClient.Resource(vmGVR).Namespace(namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// mock VM stop call
-	stopCallCounter := new(int)
-	clients.dynamicClient.(*fakedynamic.FakeDynamicClient).PrependReactor("update", "virtualmachines/stop", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
-		runtimeObj := action.(clienttest.UpdateAction).GetObject()
-		objMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(runtimeObj)
-		if err != nil {
-			return false, nil, err
-		}
-		unstructuredObj := unstructured.Unstructured{Object: objMap}
-		if action.GetNamespace() == namespace && unstructuredObj.GetName() == vm.GetName() {
-			*stopCallCounter++
-			return true, nil, nil // return true only if the stop counter is incremented, otherwise false should be returned so that the next reactors can check the request
-		}
-		return false, nil, nil
-	})
+	// mock stop call
+	stopCallCounter := mockStopVMCalls(namespace, vm.GetName(), http.StatusAccepted)
 
 	// VirtualMachineInstance
 	vmstartTime := metav1.NewTime(startTimes.vmStartTime)
@@ -1549,6 +1536,25 @@ func preparePayloadsWithCreateFunc(t *testing.T, clients clientSet, namespace, n
 		vmStopCallCounter:      stopCallCounter,
 		virtualmachineinstance: vmi,
 	}
+}
+
+func mockStopVMCalls(namespace, name string, reply int) *int {
+	expPath := fmt.Sprintf("/apis/subresources.kubevirt.io/v1/namespaces/%s/virtualmachines/%s/stop", namespace, name)
+	stopCallCounter := new(int)
+	gock.New(apiEndpoint).
+		Put(expPath).
+		Persist().
+		AddMatcher(func(request *http.Request, request2 *gock.Request) (bool, error) {
+			// the matcher function is called before checking the path,
+			// so we need to verify that it's really the same VM
+			if request.URL.Path == expPath {
+				*stopCallCounter++
+			}
+			return true, nil
+		}).
+		Reply(reply).
+		BodyString("")
+	return stopCallCounter
 }
 
 func preparePayloadsSinglePod(t *testing.T, r *Reconciler, namespace, namePrefix string, startTime time.Time, conditions ...corev1.PodCondition) payloads {
@@ -1724,11 +1730,19 @@ func prepareReconcile(t *testing.T, name string, getHostClusterFunc func(fakeCli
 		return true, obj, nil
 	})
 
+	restClient, err := test.NewRESTClient("dummy-token", apiEndpoint)
+	require.NoError(t, err)
+	restClient.Client.Transport = gock.DefaultTransport
+	t.Cleanup(func() {
+		gock.OffAll()
+	})
+
 	r := &Reconciler{
 		Client:              fakeClient,
 		AllNamespacesClient: allNamespacesClient,
 		DynamicClient:       dynamicClient,
 		DiscoveryClient:     fakeDiscovery,
+		RestClient:          restClient,
 		ScalesClient:        &scalesClient,
 		Scheme:              s,
 		GetHostCluster:      getHostClusterFunc(fakeClient),
@@ -1831,5 +1845,6 @@ var virtualmachineJSON = []byte(`{
 		"namespace": "another-namespace"
 	},
 	"spec": {
+		"running": true
 	}
 }`)


### PR DESCRIPTION
This reverts commit edd26db8a34ba159e336139014f22706e04f66d8.

Reverting the original PR instead and just keeping the REST client since the VM stop API doesn't seem to be made for the dynamic client

discussion thread https://redhat-internal.slack.com/archives/CHK0J6HT6/p1743092974483949