### PR TITLE
ignore errors when fething owners & improve tests

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -388,11 +388,11 @@ func (r *Reconciler) getUserEmailsFromMURs(ctx context.Context, hostCluster *clu
 // If any known controller owner is found, then it's scaled down (or deleted) and its kind and name is returned.
 // Otherwise, returns empty strings.
 func (r *Reconciler) scaleControllerToZero(ctx context.Context, meta metav1.Object, ownerFetcher *ownerFetcher) (kind string, name string, err error) {
-	log.FromContext(ctx).Info("Scaling controller to zero", "name", meta.GetName())
-	var owners []*objectWithGVR
-	owners, err = ownerFetcher.getOwners(ctx, meta)
+	logger := log.FromContext(ctx)
+	logger.Info("Scaling controller to zero", "name", meta.GetName())
+	owners, err := ownerFetcher.getOwners(ctx, meta)
 	if err != nil {
-		return
+		logger.Error(err, "failed to find all owners, try to idle the workload with information that is available")
 	}
 	for _, ownerWithGVR := range owners {
 		owner := ownerWithGVR.object

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -641,86 +641,47 @@ func TestEnsureIdlingFailed(t *testing.T) {
 		err = vmi.UnmarshalJSON(virtualmachineinstanceJSON)
 		require.NoError(t, err)
 
-		t.Run("can't get controllers because of general error", func(t *testing.T) {
-			assertCanNotGetObject := func(inaccessibleResource, errMsg string) {
-				// given
-				reconciler, req, cl, _, dynamicCl := prepareReconcileWithPodsRunningTooLong(t, idler)
-				dynamicCl.PrependReactor("get", inaccessibleResource, func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
-					return true, nil, errors.New(errMsg)
-				})
+		t.Run("error when getting owner deployment is ignored", func(t *testing.T) {
+			// given
+			reconciler, req, cl, allCl, dynamicClient := prepareReconcile(t, idler.Name, getHostCluster, &idler)
+			toKill := preparePayloads(t, reconciler, idler.Name, "", expiredStartTimes(idler.Spec.TimeoutSeconds))
+			//start tracking pods, so the Idler status is filled with the tracked pods
+			_, err := reconciler.Reconcile(context.TODO(), req)
+			require.NoError(t, err)
+			memberoperatortest.AssertThatIdler(t, idler.Name, cl).TracksPods(toKill.allPods)
+			dynamicClient.PrependReactor("get", "deployments", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, errors.New("can't get deployment")
+			})
 
-				//when
-				res, err := reconciler.Reconcile(context.TODO(), req)
+			//when
+			res, err := reconciler.Reconcile(context.TODO(), req)
 
-				// then
-				require.ErrorContains(t, err, fmt.Sprintf("failed to ensure idling 'alex-stage': %s", errMsg))
-				assert.Equal(t, reconcile.Result{}, res)
-				memberoperatortest.AssertThatIdler(t, idler.Name, cl).
-					ContainsCondition(memberoperatortest.FailedToIdle(strings.Split(err.Error(), ": ")[1]))
+			// then
+			require.NoError(t, err) // errors are ignored!
+			// it should idle the rest
+
+			payloadAssertion := memberoperatortest.AssertThatInIdleableCluster(t, allCl, dynamicClient).
+				// not idled
+				DeploymentScaledUp(toKill.deployment).
+				DeploymentScaledUp(toKill.integration).
+				DeploymentScaledUp(toKill.kameletBinding).
+				// idled
+				PodsDoNotExist(toKill.standalonePods).
+				ReplicaSetScaledDown(toKill.replicaSet).
+				DaemonSetDoesNotExist(toKill.daemonSet).
+				JobDoesNotExist(toKill.job).
+				DeploymentConfigScaledDown(toKill.deploymentConfig).
+				ReplicationControllerScaledDown(toKill.replicationController).
+				StatefulSetScaledDown(toKill.statefulSet).
+				VMStopped(toKill.vmStopCallCounter)
+			// replicaSets owned by the deployments
+			for _, rs := range toKill.replicaSetsWithDeployment {
+				payloadAssertion.ReplicaSetScaledDown(rs)
 			}
-
-			assertCanNotGetObject("deployments", "can't get deployment")
-			assertCanNotGetObject("replicasets", "can't get replicaset")
-			assertCanNotGetObject("daemonsets", "can't get daemonset")
-			assertCanNotGetObject("jobs", "can't get job")
-			assertCanNotGetObject("statefulsets", "can't get statefulset")
-			assertCanNotGetObject("deploymentconfigs", "can't get deploymentconfig")
-			assertCanNotGetObject("replicationcontrollers", "can't get replicationcontroller")
-			assertCanNotGetObject("virtualmachines", "can't get virtualmachine")
-			assertCanNotGetObject("virtualmachineinstances", "can't get virtualmachineinstance")
-		})
-
-		t.Run("can't get controllers because not found", func(t *testing.T) {
-			assertCanNotGetObject := func(inaccessible runtime.Object) {
-				// given
-				reconciler, req, cl, allCl, dynamicCl := prepareReconcileWithPodsRunningTooLong(t, idler)
-
-				get := allCl.MockGet
-				defer func() { allCl.MockGet = get }()
-				allCl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if reflect.TypeOf(obj) == reflect.TypeOf(inaccessible) {
-						return apierrors.NewNotFound(schema.GroupResource{
-							Group:    "",
-							Resource: reflect.TypeOf(obj).Name(),
-						}, key.Name)
-					}
-					return allCl.Client.Get(ctx, key, obj, opts...)
-				}
-
-				originalReactions := make([]clienttest.Reactor, len(dynamicCl.ReactionChain))
-				copy(originalReactions, dynamicCl.ReactionChain)
-				defer func() {
-					dynamicCl.ReactionChain = originalReactions
-				}()
-				if reflect.TypeOf(inaccessible) == reflect.TypeOf(&unstructured.Unstructured{}) {
-					resource := strings.ToLower(inaccessible.(*unstructured.Unstructured).GetKind()) + "s"
-					dynamicCl.PrependReactor("get", resource, func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
-						return true, nil, apierrors.NewNotFound(schema.GroupResource{
-							Group:    "",
-							Resource: resource,
-						}, inaccessible.(*unstructured.Unstructured).GetName())
-					})
-				}
-				//when
-				res, err := reconciler.Reconcile(context.TODO(), req)
-
-				// then
-				require.NoError(t, err) // 'NotFound' errors are ignored!
-				// no other pods being tracked
-				assert.True(t, res.Requeue)
-				assert.Equal(t, time.Duration(idler.Spec.TimeoutSeconds)*time.Second, res.RequeueAfter)
-				memberoperatortest.AssertThatIdler(t, idler.Name, cl).ContainsCondition(memberoperatortest.Running())
-			}
-
-			assertCanNotGetObject(&appsv1.Deployment{})
-			assertCanNotGetObject(&appsv1.ReplicaSet{})
-			assertCanNotGetObject(&appsv1.DaemonSet{})
-			assertCanNotGetObject(&batchv1.Job{})
-			assertCanNotGetObject(&appsv1.StatefulSet{})
-			assertCanNotGetObject(&openshiftappsv1.DeploymentConfig{})
-			assertCanNotGetObject(&corev1.ReplicationController{})
-			assertCanNotGetObject(vm)
-			assertCanNotGetObject(vmi)
+			// no other pods being tracked
+			assert.True(t, res.Requeue)
+			assert.Equal(t, time.Duration(idler.Spec.TimeoutSeconds)*time.Second, res.RequeueAfter)
+			memberoperatortest.AssertThatIdler(t, idler.Name, cl).ContainsCondition(memberoperatortest.Running())
 		})
 
 		t.Run("can't update controllers", func(t *testing.T) {
@@ -1309,18 +1270,19 @@ type payloads struct {
 	// standalonePods + controlledPods
 	allPods []*corev1.Pod
 
-	deployment             *appsv1.Deployment
-	integration            *appsv1.Deployment
-	kameletBinding         *appsv1.Deployment
-	replicaSet             *appsv1.ReplicaSet
-	daemonSet              *appsv1.DaemonSet
-	statefulSet            *appsv1.StatefulSet
-	deploymentConfig       *openshiftappsv1.DeploymentConfig
-	replicationController  *corev1.ReplicationController
-	job                    *batchv1.Job
-	virtualmachine         *unstructured.Unstructured
-	vmStopCallCounter      *int
-	virtualmachineinstance *unstructured.Unstructured
+	deployment                *appsv1.Deployment
+	integration               *appsv1.Deployment
+	kameletBinding            *appsv1.Deployment
+	replicaSet                *appsv1.ReplicaSet
+	replicaSetsWithDeployment []*appsv1.ReplicaSet
+	daemonSet                 *appsv1.DaemonSet
+	statefulSet               *appsv1.StatefulSet
+	deploymentConfig          *openshiftappsv1.DeploymentConfig
+	replicationController     *corev1.ReplicationController
+	job                       *batchv1.Job
+	virtualmachine            *unstructured.Unstructured
+	vmStopCallCounter         *int
+	virtualmachineinstance    *unstructured.Unstructured
 }
 
 type payloadStartTimes struct {
@@ -1366,6 +1328,7 @@ func preparePayloadsWithCreateFunc(t *testing.T, clients clientSet, namespace, n
 	}
 	err := clients.createOwnerObjects(context.TODO(), d)
 	require.NoError(t, err)
+	var replicaSetsWithDeployment []*appsv1.ReplicaSet
 	rs := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-replicaset", d.Name), Namespace: namespace},
 		Spec:       appsv1.ReplicaSetSpec{Replicas: &replicas},
@@ -1374,6 +1337,7 @@ func preparePayloadsWithCreateFunc(t *testing.T, clients clientSet, namespace, n
 	require.NoError(t, err)
 	err = clients.createOwnerObjects(context.TODO(), rs)
 	require.NoError(t, err)
+	replicaSetsWithDeployment = append(replicaSetsWithDeployment, rs)
 	controlledPods := createPods(t, clients.allNamespacesClient, rs, sTime, make([]*corev1.Pod, 0, 3), noRestart(), conditions...)
 
 	// Deployment with Camel K integration as an owner reference and a scale sub resource
@@ -1401,6 +1365,7 @@ func preparePayloadsWithCreateFunc(t *testing.T, clients clientSet, namespace, n
 	require.NoError(t, err)
 	err = clients.createOwnerObjects(context.TODO(), integrationRS)
 	require.NoError(t, err)
+	replicaSetsWithDeployment = append(replicaSetsWithDeployment, integrationRS)
 	controlledPods = createPods(t, clients.allNamespacesClient, integrationRS, sTime, controlledPods, noRestart())
 
 	// Deployment with Camel K integration as an owner reference and a scale sub resource
@@ -1428,6 +1393,7 @@ func preparePayloadsWithCreateFunc(t *testing.T, clients clientSet, namespace, n
 	require.NoError(t, err)
 	err = clients.createOwnerObjects(context.TODO(), bindingRS)
 	require.NoError(t, err)
+	replicaSetsWithDeployment = append(replicaSetsWithDeployment, bindingRS)
 	controlledPods = createPods(t, clients.allNamespacesClient, bindingRS, sTime, controlledPods, noRestart())
 
 	// Standalone ReplicaSet
@@ -1553,21 +1519,22 @@ func preparePayloadsWithCreateFunc(t *testing.T, clients clientSet, namespace, n
 	}
 
 	return payloads{
-		standalonePods:         standalonePods,
-		controlledPods:         controlledPods,
-		allPods:                append(standalonePods, controlledPods...),
-		deployment:             d,
-		integration:            integration,
-		kameletBinding:         binding,
-		replicaSet:             standaloneRs,
-		daemonSet:              ds,
-		statefulSet:            sts,
-		deploymentConfig:       dc,
-		replicationController:  standaloneRC,
-		job:                    job,
-		virtualmachine:         vm,
-		vmStopCallCounter:      stopCallCounter,
-		virtualmachineinstance: vmi,
+		standalonePods:            standalonePods,
+		controlledPods:            controlledPods,
+		allPods:                   append(standalonePods, controlledPods...),
+		deployment:                d,
+		integration:               integration,
+		kameletBinding:            binding,
+		replicaSet:                standaloneRs,
+		replicaSetsWithDeployment: replicaSetsWithDeployment,
+		daemonSet:                 ds,
+		statefulSet:               sts,
+		deploymentConfig:          dc,
+		replicationController:     standaloneRC,
+		job:                       job,
+		virtualmachine:            vm,
+		vmStopCallCounter:         stopCallCounter,
+		virtualmachineinstance:    vmi,
 	}
 }
 

--- a/controllers/idler/owners_test.go
+++ b/controllers/idler/owners_test.go
@@ -2,15 +2,20 @@ package idler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
 
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	apiv1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -20,6 +25,7 @@ import (
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	clienttest "k8s.io/client-go/testing"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -99,6 +105,9 @@ func TestGetOwners(t *testing.T) {
 	testCases := map[string]struct {
 		expectedOwners []client.Object
 	}{
+		"no owner": {
+			expectedOwners: []client.Object{},
+		},
 		"with replica as owner": {
 			expectedOwners: []client.Object{replica},
 		},
@@ -158,7 +167,14 @@ func TestGetOwnersFailures(t *testing.T) {
 	// given
 	givenPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "test-namespace"}}
 	replica := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "test-replica", Namespace: "test-namespace"}}
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: "test-namespace"}}
+	daemon := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset", Namespace: "test-namespace"}}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "test-namespace"}}
+	statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset", Namespace: "test-namespace"}}
+	dc := &apiv1.DeploymentConfig{ObjectMeta: metav1.ObjectMeta{Name: "test-deploymentconfig", Namespace: "test-namespace"}}
+	rc := &corev1.ReplicationController{ObjectMeta: metav1.ObjectMeta{Name: "test-rc", Namespace: "test-namespace"}}
 	aap := newAAP(t, false, "test-aap", "test-namespace")
+	vm, vmi := newVMResources(t, "test-vm", "test-namespace")
 
 	t.Run("api not available", func(t *testing.T) {
 		// given
@@ -178,22 +194,93 @@ func TestGetOwnersFailures(t *testing.T) {
 		require.Nil(t, owners)
 	})
 
-	t.Run("replica not found", func(t *testing.T) {
-		// given
-		pod := givenPod.DeepCopy()
-		err := controllerruntime.SetControllerReference(replica, pod, scheme.Scheme)
-		require.NoError(t, err)
-		dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme.Scheme, pod)
+	t.Run("can't get owner controller", func(t *testing.T) {
+		assertCanNotGetObject := func(t *testing.T, inaccessibleResource string, ownerObject client.Object, isNotFound bool) {
+			t.Run(inaccessibleResource, func(t *testing.T) {
+				// given
+				fakeDiscovery := newFakeDiscoveryClient(withAAPResourceList(t)...)
 
-		fakeDiscovery := newFakeDiscoveryClient(withAAPResourceList(t)...)
-		fetcher := newOwnerFetcher(fakeDiscovery, dynamicClient)
+				t.Run("with one owner", func(t *testing.T) {
 
-		// when
-		owners, err := fetcher.getOwners(context.TODO(), pod)
+					pod := givenPod.DeepCopy()
+					require.NoError(t, controllerruntime.SetControllerReference(ownerObject, pod, scheme.Scheme))
+					// when it's supposed to be "not found" then do not include it in the client
+					dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme.Scheme, pod)
+					// otherwise, configure general error for the client
+					if !isNotFound {
+						dynamicClient = fakedynamic.NewSimpleDynamicClient(scheme.Scheme, pod, ownerObject)
+						dynamicClient.PrependReactor("get", inaccessibleResource, func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
+							return true, nil, errors.New("some error")
+						})
+					}
+					fetcher := newOwnerFetcher(fakeDiscovery, dynamicClient)
 
-		// then
-		require.EqualError(t, err, "replicasets.apps \"test-replica\" not found")
-		require.Nil(t, owners)
+					// when
+					owners, err := fetcher.getOwners(context.TODO(), pod)
+
+					// then
+					if isNotFound {
+						require.ErrorContains(t, err, inaccessibleResource)
+						assert.True(t, apierrors.IsNotFound(err))
+					} else {
+						require.EqualError(t, err, "some error")
+					}
+					require.Nil(t, owners)
+				})
+
+				t.Run("intermediate owner is returned", func(t *testing.T) {
+					// given
+					pod := givenPod.DeepCopy()
+					idler := &v1alpha1.Idler{ObjectMeta: metav1.ObjectMeta{Name: "test-rc", Namespace: "test-namespace"}}
+					require.NoError(t, controllerruntime.SetControllerReference(idler, pod, scheme.Scheme))
+					require.NoError(t, controllerruntime.SetControllerReference(ownerObject, idler, scheme.Scheme))
+					// when it's supposed to be "not found" then do not include it in the client
+					dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme.Scheme, pod, idler)
+					// otherwise, configure general error for the client
+					if !isNotFound {
+						dynamicClient = fakedynamic.NewSimpleDynamicClient(scheme.Scheme, pod, idler, ownerObject)
+						dynamicClient.PrependReactor("get", inaccessibleResource, func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
+							return true, nil, errors.New("some error")
+						})
+					}
+					fetcher := newOwnerFetcher(fakeDiscovery, dynamicClient)
+
+					// when
+					owners, err := fetcher.getOwners(context.TODO(), pod)
+
+					// then
+					if isNotFound {
+						require.ErrorContains(t, err, inaccessibleResource)
+						assert.True(t, apierrors.IsNotFound(err))
+					} else {
+						require.EqualError(t, err, "some error")
+					}
+					require.Len(t, owners, 1)
+				})
+			})
+		}
+
+		testCases := map[string]client.Object{
+			"deployments":             deployment,
+			"replicasets":             replica,
+			"daemonsets":              daemon,
+			"jobs":                    job,
+			"statefulsets":            statefulSet,
+			"deploymentconfigs":       dc,
+			"replicationcontrollers":  rc,
+			"virtualmachines":         vm,
+			"virtualmachineinstances": vmi,
+		}
+		for inaccessibleResource, inaccessibleObject := range testCases {
+			t.Run(inaccessibleResource, func(t *testing.T) {
+				t.Run("general error", func(t *testing.T) {
+					assertCanNotGetObject(t, inaccessibleResource, inaccessibleObject, false)
+				})
+				t.Run("general error", func(t *testing.T) {
+					assertCanNotGetObject(t, inaccessibleResource, inaccessibleObject, true)
+				})
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
a follow-up of https://redhat-internal.slack.com/archives/C064SKK3C2E/p1747301942697849 

two changes introduced:
1. ignores when there is an error returned when fetching the owners
2. moves & improves failure tests to owners_test.go file