### PR TITLE
replace TierTemplate cache with cached host cluster client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	goruntime "runtime"
 	"time"
 
+	"github.com/codeready-toolchain/member-operator/pkg/host"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/codeready-toolchain/member-operator/controllers/idler"
@@ -219,6 +220,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	hostClientInitializer := host.NewCachedHostClientInitializer(scheme, cluster.GetHostCluster)
+
 	// Setup all Controllers
 	if err = (&toolchainclusterresources.Reconciler{
 		Client:    mgr.GetClient(),
@@ -271,10 +274,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (nstemplateset.NewReconciler(&nstemplateset.APIClient{
-		Client:              mgr.GetClient(),
-		AllNamespacesClient: allNamespacesCluster.GetClient(),
-		Scheme:              mgr.GetScheme(),
-		GetHostCluster:      cluster.GetHostCluster,
+		Client:               mgr.GetClient(),
+		AllNamespacesClient:  allNamespacesCluster.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		GetHostClusterClient: hostClientInitializer.GetHostClient,
 	})).SetupWithManager(mgr, allNamespacesCluster, discoveryClient); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NSTemplateSet")
 		os.Exit(1)

--- a/controllers/nstemplateset/client.go
+++ b/controllers/nstemplateset/client.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/member-operator/pkg/host"
 	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,11 +16,11 @@ import (
 )
 
 type APIClient struct {
-	AllNamespacesClient runtimeclient.Client
-	Client              runtimeclient.Client
-	Scheme              *runtime.Scheme
-	GetHostCluster      cluster.GetHostClusterFunc
-	AvailableAPIGroups  []metav1.APIGroup
+	AllNamespacesClient  runtimeclient.Client
+	Client               runtimeclient.Client
+	Scheme               *runtime.Scheme
+	GetHostClusterClient host.ClientGetter
+	AvailableAPIGroups   []metav1.APIGroup
 }
 
 // ApplyToolchainObjects applies the given ToolchainObjects with the given labels.

--- a/controllers/nstemplateset/client_test.go
+++ b/controllers/nstemplateset/client_test.go
@@ -338,7 +338,6 @@ func prepareAPIClient(t *testing.T, initObjs ...runtimeclient.Object) (*APIClien
 	tierTemplates, err := prepareTemplateTiers(decoder)
 	require.NoError(t, err)
 	fakeClient := test.NewFakeClient(t, append(initObjs, tierTemplates...)...)
-	resetCache()
 
 	// objects created from OpenShift templates are `*unstructured.Unstructured`,
 	// which causes troubles when calling the `List` method on the fake client,
@@ -366,10 +365,10 @@ func prepareAPIClient(t *testing.T, initObjs ...runtimeclient.Object) (*APIClien
 		return nil
 	}
 	return &APIClient{
-		AllNamespacesClient: fakeClient,
-		Client:              fakeClient,
-		Scheme:              s,
-		GetHostCluster:      NewGetHostCluster(fakeClient, true, corev1.ConditionTrue),
+		AllNamespacesClient:  fakeClient,
+		Client:               fakeClient,
+		Scheme:               s,
+		GetHostClusterClient: NewHostClientGetter(fakeClient, nil),
 		AvailableAPIGroups: newAPIGroups(
 			newAPIGroup("quota.openshift.io", "v1"),
 			newAPIGroup("rbac.authorization.k8s.io", "v1"),

--- a/controllers/nstemplateset/cluster_resources.go
+++ b/controllers/nstemplateset/cluster_resources.go
@@ -114,7 +114,7 @@ func (r *clusterResourcesManager) ensure(ctx context.Context, nsTmplSet *toolcha
 	var tierTemplate *tierTemplate
 	var err error
 	if nsTmplSet.Spec.ClusterResources != nil {
-		tierTemplate, err = getTierTemplate(ctx, r.GetHostCluster, nsTmplSet.Spec.ClusterResources.TemplateRef)
+		tierTemplate, err = getTierTemplate(ctx, r.GetHostClusterClient, nsTmplSet.Spec.ClusterResources.TemplateRef)
 		if err != nil {
 			return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(userTierCtx, nsTmplSet, err,
 				"failed to retrieve TierTemplate for the cluster resources with the name '%s'", nsTmplSet.Spec.ClusterResources.TemplateRef)

--- a/controllers/nstemplateset/namespaces.go
+++ b/controllers/nstemplateset/namespaces.go
@@ -194,7 +194,7 @@ func (r *namespacesManager) ensureInnerNamespaceResources(ctx context.Context, n
 		if err := r.setStatusUpdatingIfNotProvisioning(ctx, nsTmplSet); err != nil {
 			return err
 		}
-		currentTierTemplate, err := getTierTemplate(ctx, r.GetHostCluster, currentRef)
+		currentTierTemplate, err := getTierTemplate(ctx, r.GetHostClusterClient, currentRef)
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(ctx, nsTmplSet, r.setStatusUpdateFailed, err, "failed to retrieve current TierTemplate with name '%s'", currentRef)
 		}
@@ -271,7 +271,7 @@ func (r *namespacesManager) ensureDeleted(ctx context.Context, nsTmplSet *toolch
 func (r *namespacesManager) getTierTemplatesForAllNamespaces(ctx context.Context, nsTmplSet *toolchainv1alpha1.NSTemplateSet) ([]*tierTemplate, error) {
 	var tmpls []*tierTemplate
 	for _, ns := range nsTmplSet.Spec.Namespaces {
-		nsTmpl, err := getTierTemplate(ctx, r.GetHostCluster, ns.TemplateRef)
+		nsTmpl, err := getTierTemplate(ctx, r.GetHostClusterClient, ns.TemplateRef)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/nstemplateset/namespaces_test.go
+++ b/controllers/nstemplateset/namespaces_test.go
@@ -1264,7 +1264,7 @@ func TestIsUpToDateAndProvisioned(t *testing.T) {
 			Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 		}
 
-		tierTmpl, err := getTierTemplate(ctx, manager.GetHostCluster, "basic-dev-abcde11")
+		tierTmpl, err := getTierTemplate(ctx, manager.GetHostClusterClient, "basic-dev-abcde11")
 		require.NoError(t, err)
 		// when
 		isProvisioned, err := manager.isUpToDateAndProvisioned(ctx, &devNS, tierTmpl)
@@ -1290,7 +1290,7 @@ func TestIsUpToDateAndProvisioned(t *testing.T) {
 		rb := newRoleBinding(devNS.Name, "crtadmin-pods", "johnsmith")
 		rb2 := newRoleBinding(devNS.Name, "crtadmin-view", "johnsmith")
 		manager, _ := prepareNamespacesManager(t, nsTmplSet, rb, rb2)
-		tierTmpl, err := getTierTemplate(ctx, manager.GetHostCluster, "advanced-dev-abcde11")
+		tierTmpl, err := getTierTemplate(ctx, manager.GetHostClusterClient, "advanced-dev-abcde11")
 		require.NoError(t, err)
 		//when
 		isProvisioned, err := manager.isUpToDateAndProvisioned(ctx, &devNS, tierTmpl)
@@ -1305,7 +1305,7 @@ func TestIsUpToDateAndProvisioned(t *testing.T) {
 		rb := newRoleBinding(devNS.Name, "crtadmin-pods", "johnsmith")
 		role := newRole(devNS.Name, "exec-pods", "johnsmith")
 		manager, _ := prepareNamespacesManager(t, nsTmplSet, rb, role)
-		tierTmpl, err := getTierTemplate(ctx, manager.GetHostCluster, "advanced-dev-abcde11")
+		tierTmpl, err := getTierTemplate(ctx, manager.GetHostClusterClient, "advanced-dev-abcde11")
 		require.NoError(t, err)
 		//when
 		isProvisioned, err := manager.isUpToDateAndProvisioned(ctx, devNS, tierTmpl)
@@ -1329,7 +1329,7 @@ func TestIsUpToDateAndProvisioned(t *testing.T) {
 			},
 		}
 		manager, _ := prepareNamespacesManager(t, nsTmplSet, rb, rb2, role)
-		tierTmpl, err := getTierTemplate(ctx, manager.GetHostCluster, "advanced-dev-abcde11")
+		tierTmpl, err := getTierTemplate(ctx, manager.GetHostClusterClient, "advanced-dev-abcde11")
 		require.NoError(t, err)
 		//when
 		isProvisioned, err := manager.isUpToDateAndProvisioned(ctx, devNS, tierTmpl)
@@ -1351,7 +1351,7 @@ func TestIsUpToDateAndProvisioned(t *testing.T) {
 			},
 		}
 		manager, _ := prepareNamespacesManager(t, nsTmplSet, rb)
-		tierTmpl, err := getTierTemplate(ctx, manager.GetHostCluster, "basic-dev-abcde11")
+		tierTmpl, err := getTierTemplate(ctx, manager.GetHostClusterClient, "basic-dev-abcde11")
 		require.NoError(t, err)
 		//when
 		isProvisioned, err := manager.isUpToDateAndProvisioned(ctx, devNS, tierTmpl)
@@ -1365,7 +1365,7 @@ func TestIsUpToDateAndProvisioned(t *testing.T) {
 		devNS := newNamespace("basic", "johnsmith", "dev", withTemplateRefUsingRevision("abcde11"))
 		delete(devNS.Labels, toolchainv1alpha1.SpaceLabelKey)
 		manager, _ := prepareNamespacesManager(t, nsTmplSet)
-		tierTmpl, err := getTierTemplate(ctx, manager.GetHostCluster, "basic-dev-abcde11")
+		tierTmpl, err := getTierTemplate(ctx, manager.GetHostClusterClient, "basic-dev-abcde11")
 		require.NoError(t, err)
 		//when
 		isProvisioned, err := manager.isUpToDateAndProvisioned(ctx, devNS, tierTmpl)

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -710,9 +710,6 @@ func TestProvisionTwoUsers(t *testing.T) {
 						HasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue)
 
 					t.Run("provision john's inner resources of dev namespace", func(t *testing.T) {
-						// given - when host cluster is not ready, then it should use the cache
-						r.GetHostCluster = NewGetHostCluster(fakeClient, true, corev1.ConditionFalse)
-
 						// when
 						res, err := r.Reconcile(context.TODO(), req)
 
@@ -826,10 +823,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 											HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
 											HasResource(joeUsername+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 
-										t.Run("provision inner resources of joe's dev namespace (using cached TierTemplate)", func(t *testing.T) {
-											// given - when host cluster is not ready, then it should use the cache
-											r.GetHostCluster = NewGetHostCluster(fakeClient, true, corev1.ConditionFalse)
-
+										t.Run("provision inner resources of joe's dev namespace", func(t *testing.T) {
 											// when
 											res, err := r.Reconcile(context.TODO(), joeReq)
 
@@ -1016,9 +1010,6 @@ func TestReconcilePromotion(t *testing.T) {
 								HasResource("crtadmin-view", &rbacv1.RoleBinding{})
 
 							t.Run("when nothing to upgrade, then it should be provisioned", func(t *testing.T) {
-								// given - when host cluster is not ready, then it should use the cache (for both TierTemplates)
-								r.GetHostCluster = NewGetHostCluster(fakeClient, true, corev1.ConditionFalse)
-
 								// when - should check if everything is OK and set status to provisioned
 								_, err = r.Reconcile(context.TODO(), req)
 
@@ -1307,9 +1298,6 @@ func TestReconcileUpdate(t *testing.T) {
 								HasResource(spacename+"-space-viewer", &rbacv1.RoleBinding{})
 
 							t.Run("when nothing to update, then it should be provisioned", func(t *testing.T) {
-								// given - when host cluster is not ready, then it should use the cache (for both TierTemplates)
-								r.GetHostCluster = NewGetHostCluster(fakeClient, true, corev1.ConditionFalse)
-
 								// when - should check if everything is OK and set status to provisioned
 								_, err = r.Reconcile(context.TODO(), req)
 
@@ -1507,9 +1495,6 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 						HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}) // resource was deleted
 
 					t.Run("reconcile after cluster resource quota deletion triggers removal of the finalizer and thus successful deletion", func(t *testing.T) {
-						// given - when host cluster is not ready, then it should use the cache
-						r.GetHostCluster = NewGetHostCluster(r.Client, true, corev1.ConditionFalse)
-
 						// when a last reconcile loop is triggered (when the NSTemplateSet resource is marked for deletion and there's a finalizer)
 						_, err := r.Reconcile(context.TODO(), req)
 

--- a/controllers/nstemplateset/nstemplatetier.go
+++ b/controllers/nstemplateset/nstemplatetier.go
@@ -3,12 +3,11 @@ package nstemplateset
 import (
 	"context"
 	"fmt"
-	"sync"
 
+	"github.com/codeready-toolchain/member-operator/pkg/host"
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/pkg/errors"
@@ -18,25 +17,20 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var tierTemplatesCache = newTierTemplateCache()
-
 // getTierTemplate retrieves the TierTemplateRevision resource with the given name from the host cluster,
 // if not found then falls back to the current logic of retrieving the TierTemplate
 // and returns an instance of the tierTemplate type for it whose template content can be parsable.
 // The returned tierTemplate contains all data from TierTemplate including its name.
-func getTierTemplate(ctx context.Context, hostClusterFunc cluster.GetHostClusterFunc, templateRef string) (*tierTemplate, error) {
+func getTierTemplate(ctx context.Context, getHostClient host.ClientGetter, templateRef string) (*tierTemplate, error) {
 	var tierTmpl *tierTemplate
 	if templateRef == "" {
 		return nil, fmt.Errorf("templateRef is not provided - it's not possible to fetch related TierTemplate/TierTemplateRevision resource")
 	}
 
-	if tierTmpl, ok := tierTemplatesCache.get(templateRef); ok && tierTmpl != nil {
-		return tierTmpl, nil
-	}
-	ttr, err := getTierTemplateRevision(ctx, hostClusterFunc, templateRef)
+	ttr, err := getTierTemplateRevision(ctx, getHostClient, templateRef)
 	if err != nil {
 		if errs.IsNotFound(err) {
-			tmpl, err := getToolchainTierTemplate(ctx, hostClusterFunc, templateRef)
+			tmpl, err := getToolchainTierTemplate(ctx, getHostClient, templateRef)
 			if err != nil {
 				return nil, err
 			}
@@ -50,7 +44,7 @@ func getTierTemplate(ctx context.Context, hostClusterFunc cluster.GetHostCluster
 			return nil, err
 		}
 	} else {
-		ttrTmpl, err := getToolchainTierTemplate(ctx, hostClusterFunc, ttr.GetLabels()[toolchainv1alpha1.TemplateRefLabelKey])
+		ttrTmpl, err := getToolchainTierTemplate(ctx, getHostClient, ttr.GetLabels()[toolchainv1alpha1.TemplateRefLabelKey])
 		if err != nil {
 			return nil, err
 		}
@@ -62,23 +56,20 @@ func getTierTemplate(ctx context.Context, hostClusterFunc cluster.GetHostCluster
 		}
 	}
 
-	tierTemplatesCache.add(tierTmpl)
 	return tierTmpl, nil
 }
 
 // getToolchainTierTemplate gets the TierTemplate resource from the host cluster.
-func getToolchainTierTemplate(ctx context.Context, hostClusterFunc cluster.GetHostClusterFunc, templateRef string) (*toolchainv1alpha1.TierTemplate, error) {
-	// retrieve the ToolchainCluster instance representing the host cluster
-	host, ok := hostClusterFunc()
-	if !ok {
-		return nil, fmt.Errorf("unable to connect to the host cluster: unknown cluster")
+func getToolchainTierTemplate(ctx context.Context, getHostClient host.ClientGetter, templateRef string) (*toolchainv1alpha1.TierTemplate, error) {
+	// get the host client
+	hostClient, err := getHostClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to the host cluster: %w", err)
 	}
-	if !cluster.IsReady(host.ClusterStatus) {
-		return nil, fmt.Errorf("the host cluster is not ready")
-	}
+
 	tierTemplate := &toolchainv1alpha1.TierTemplate{}
-	err := host.Client.Get(ctx, types.NamespacedName{
-		Namespace: host.OperatorNamespace,
+	err = hostClient.Get(ctx, types.NamespacedName{
+		Namespace: hostClient.Namespace,
 		Name:      templateRef,
 	}, tierTemplate)
 	if err != nil {
@@ -113,29 +104,4 @@ func (t *tierTemplate) process(scheme *runtime.Scheme, params map[string]string,
 	tmplProcessor := template.NewProcessor(scheme)
 	params[MemberOperatorNS] = ns // add (or enforce)
 	return tmplProcessor.Process(t.template.DeepCopy(), params, filters...)
-}
-
-type tierTemplateCache struct {
-	sync.RWMutex
-	// tierTemplatesByTemplateRef contains tierTemplatesByTemplateRef mapped by TemplateRef key
-	tierTemplatesByTemplateRef map[string]*tierTemplate
-}
-
-func newTierTemplateCache() *tierTemplateCache {
-	return &tierTemplateCache{
-		tierTemplatesByTemplateRef: map[string]*tierTemplate{},
-	}
-}
-
-func (c *tierTemplateCache) get(templateRef string) (*tierTemplate, bool) {
-	c.RLock()
-	defer c.RUnlock()
-	tierTemplate, ok := c.tierTemplatesByTemplateRef[templateRef]
-	return tierTemplate, ok
-}
-
-func (c *tierTemplateCache) add(tierTemplate *tierTemplate) {
-	c.Lock()
-	defer c.Unlock()
-	c.tierTemplatesByTemplateRef[tierTemplate.templateRef] = tierTemplate
 }

--- a/controllers/nstemplateset/space_roles.go
+++ b/controllers/nstemplateset/space_roles.go
@@ -100,7 +100,7 @@ func (r *spaceRolesManager) getSpaceRolesObjects(ctx context.Context, ns *corev1
 	// store by kind and name
 	spaceRoleObjects := []runtimeclient.Object{}
 	for _, spaceRole := range spaceRoles {
-		tierTemplate, err := getTierTemplate(ctx, r.GetHostCluster, spaceRole.TemplateRef)
+		tierTemplate, err := getTierTemplate(ctx, r.GetHostClusterClient, spaceRole.TemplateRef)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/nstemplateset/tier_template_revision.go
+++ b/controllers/nstemplateset/tier_template_revision.go
@@ -5,26 +5,22 @@ import (
 	"fmt"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-
+	"github.com/codeready-toolchain/member-operator/pkg/host"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 // getTierTemplateRevision gets the TierTemplateRevision resource from the host cluster.
-func getTierTemplateRevision(ctx context.Context, hostClusterFunc cluster.GetHostClusterFunc, templateRef string) (*toolchainv1alpha1.TierTemplateRevision, error) {
-	// retrieve the ToolchainCluster instance representing the host cluster
-	host, ok := hostClusterFunc()
-	if !ok {
-		return nil, fmt.Errorf("unable to connect to the host cluster: unknown cluster")
-	}
-	if !cluster.IsReady(host.ClusterStatus) {
-		return nil, fmt.Errorf("the host cluster is not ready")
+func getTierTemplateRevision(ctx context.Context, getHostClient host.ClientGetter, templateRef string) (*toolchainv1alpha1.TierTemplateRevision, error) {
+	// get the host client
+	hostClient, err := getHostClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to the host cluster: %w", err)
 	}
 
 	tierTemplateRevision := &toolchainv1alpha1.TierTemplateRevision{}
-	err := host.Client.Get(ctx, types.NamespacedName{
-		Namespace: host.OperatorNamespace,
+	err = hostClient.Get(ctx, types.NamespacedName{
+		Namespace: hostClient.Namespace,
 		Name:      templateRef,
 	}, tierTemplateRevision)
 	if err != nil {

--- a/pkg/host/client.go
+++ b/pkg/host/client.go
@@ -1,0 +1,110 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimecluster "sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// CachedHostClientInit takes care of initializing a cached host cluster client
+type CachedHostClientInit struct {
+	getLock                 sync.Mutex
+	initLock                sync.RWMutex
+	scheme                  *runtime.Scheme
+	cachedHostClusterClient *NamespacedClient
+	getHostCluster          cluster.GetHostClusterFunc
+	initCachedClient        func(ctx context.Context, scheme *runtime.Scheme, cachedHostCluster *cluster.CachedToolchainCluster, hostNamespace string) (client.Client, error)
+}
+
+func NewCachedHostClientInitializer(scheme *runtime.Scheme, getHostCluster cluster.GetHostClusterFunc) *CachedHostClientInit {
+	return &CachedHostClientInit{
+		scheme:           scheme,
+		initCachedClient: initCachedClient,
+		getHostCluster:   getHostCluster,
+	}
+}
+
+func NewNamespacedClient(client client.Client, namespace string) *NamespacedClient {
+	return &NamespacedClient{Client: client, Namespace: namespace}
+}
+
+// NamespacedClient holds the client and the operator namespace
+type NamespacedClient struct {
+	client.Client
+	Namespace string
+}
+
+type ClientGetter func(ctx context.Context) (*NamespacedClient, error)
+
+// GetHostClient returns NamespacedClient backed by cached client for host operator namespace.
+func (c *CachedHostClientInit) GetHostClient(ctx context.Context) (*NamespacedClient, error) {
+	c.getLock.Lock()
+	defer c.getLock.Unlock()
+	if c.cachedHostClusterClient == nil {
+		return c.init(ctx)
+	}
+	return c.cachedHostClusterClient, nil
+}
+
+func (c *CachedHostClientInit) init(ctx context.Context) (*NamespacedClient, error) {
+	c.initLock.Lock()
+	defer c.initLock.Unlock()
+	logger := log.FromContext(ctx)
+	logger.Info("Initializing cached host client")
+	cachedHostCluster, found := c.getHostCluster()
+	if !found {
+		return nil, fmt.Errorf("host cluster not found")
+	}
+	hostNamespace := cachedHostCluster.OperatorNamespace
+	cachedClient, err := c.initCachedClient(ctx, c.scheme, cachedHostCluster, hostNamespace)
+	if err != nil {
+		return nil, err
+	}
+	// populate the cache backed by shared informers that are initialized lazily on the first call
+	// for the given GVK with all resources we are interested in from the host-operator namespace
+	objectsToList := map[string]client.ObjectList{
+		"TierTemplate":         &toolchainv1alpha1.TierTemplateList{},
+		"TierTemplateRevision": &toolchainv1alpha1.TierTemplateRevisionList{},
+	}
+
+	for resourceName := range objectsToList {
+		logger.Info("Syncing informer cache with resources", "resourceName", resourceName)
+		if err := cachedClient.List(ctx, objectsToList[resourceName], client.InNamespace(hostNamespace)); err != nil {
+			return nil, fmt.Errorf("informer cache sync failed for resource %s: %w", resourceName, err)
+		}
+	}
+
+	logger.Info("Host cluster client initialized")
+	c.cachedHostClusterClient = NewNamespacedClient(cachedClient, hostNamespace)
+	return c.cachedHostClusterClient, nil
+}
+
+func initCachedClient(ctx context.Context, scheme *runtime.Scheme, cachedHostCluster *cluster.CachedToolchainCluster, hostNamespace string) (client.Client, error) {
+
+	hostCluster, err := runtimecluster.New(cachedHostCluster.RestConfig, func(options *runtimecluster.Options) {
+		options.Scheme = scheme
+		// cache only in the host-operator namespace
+		options.Cache.DefaultNamespaces = map[string]cache.Config{hostNamespace: {}}
+	})
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		if err := hostCluster.Start(ctx); err != nil {
+			panic(fmt.Errorf("failed to create cached client: %w", err))
+		}
+	}()
+
+	if !hostCluster.GetCache().WaitForCacheSync(ctx) {
+		return nil, fmt.Errorf("unable to sync the cache of the client")
+	}
+	return hostCluster.GetClient(), nil
+}

--- a/pkg/host/client_test.go
+++ b/pkg/host/client_test.go
@@ -122,10 +122,10 @@ func TestNewCachedHostClientInitializer(t *testing.T) {
 					hostClient, err := initializer.GetHostClient(context.TODO())
 
 					// then
-					require.NoError(t, err)
-					require.NotNil(t, hostClient)
-					require.NotNil(t, hostClient.Client)
-					require.Equal(t, testcommon.HostOperatorNs, hostClient.Namespace)
+					assert.NoError(t, err)
+					assert.NotNil(t, hostClient)
+					assert.NotNil(t, hostClient.Client)
+					assert.Equal(t, testcommon.HostOperatorNs, hostClient.Namespace)
 				}()
 			}
 

--- a/pkg/host/client_test.go
+++ b/pkg/host/client_test.go
@@ -1,0 +1,155 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	testcommon "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestNewCachedHostClientInitializer(t *testing.T) {
+	// given
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	t.Run("success", func(t *testing.T) {
+		initializer := NewCachedHostClientInitializer(s, NewGetHostCluster(true))
+		initializer.initCachedClient = func(_ context.Context, _ *runtime.Scheme, _ *cluster.CachedToolchainCluster, _ string) (client.Client, error) {
+			return testcommon.NewFakeClient(t), nil
+		}
+
+		// when
+		hostClient, err := initializer.GetHostClient(context.TODO())
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, hostClient)
+		require.NotNil(t, hostClient.Client)
+		require.Equal(t, testcommon.HostOperatorNs, hostClient.Namespace)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		t.Run("host cluster not found", func(t *testing.T) {
+			initializer := NewCachedHostClientInitializer(s, NewGetHostCluster(false))
+
+			// when
+			hostClient, err := initializer.GetHostClient(context.TODO())
+
+			// then
+			require.EqualError(t, err, "host cluster not found")
+			require.Nil(t, hostClient)
+		})
+
+		t.Run("init client fails", func(t *testing.T) {
+			initializer := NewCachedHostClientInitializer(s, NewGetHostCluster(true))
+			initializer.initCachedClient = func(_ context.Context, _ *runtime.Scheme, _ *cluster.CachedToolchainCluster, _ string) (client.Client, error) {
+				return nil, errors.New("some error")
+			}
+
+			// when
+			hostClient, err := initializer.GetHostClient(context.TODO())
+
+			// then
+			require.EqualError(t, err, "some error")
+			require.Nil(t, hostClient)
+		})
+
+		t.Run("list fails", func(t *testing.T) {
+			initializer := NewCachedHostClientInitializer(s, NewGetHostCluster(true))
+			cl := testcommon.NewFakeClient(t)
+			cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				return errors.New("some list error")
+			}
+			initializer.initCachedClient = func(_ context.Context, _ *runtime.Scheme, _ *cluster.CachedToolchainCluster, _ string) (client.Client, error) {
+				return cl, nil
+			}
+
+			// when
+			hostClient, err := initializer.GetHostClient(context.TODO())
+
+			// then
+			require.ErrorContains(t, err, "informer cache sync failed for resource")
+			require.ErrorContains(t, err, "some list error")
+			require.Nil(t, hostClient)
+		})
+	})
+
+	t.Run("cache", func(t *testing.T) {
+		t.Run("once initialized, then it doesn't try again", func(t *testing.T) {
+			// given
+			initializer := NewCachedHostClientInitializer(s, NewGetHostCluster(false))
+			cachedClient := NewNamespacedClient(testcommon.NewFakeClient(t), testcommon.HostOperatorNs)
+			initializer.cachedHostClusterClient = cachedClient
+			initializer.initCachedClient = func(_ context.Context, _ *runtime.Scheme, _ *cluster.CachedToolchainCluster, _ string) (client.Client, error) {
+				return nil, errors.New("shouldn't be called")
+			}
+
+			// when
+			hostClient, err := initializer.GetHostClient(context.TODO())
+
+			// then
+			require.NoError(t, err)
+			assert.Same(t, cachedClient, hostClient)
+		})
+
+		t.Run("test multiple calls in parallel", func(t *testing.T) {
+			// given
+			var gate sync.WaitGroup
+			gate.Add(1)
+			var waitForFinished sync.WaitGroup
+			initializer := NewCachedHostClientInitializer(s, NewGetHostCluster(true))
+			initializer.initCachedClient = func(_ context.Context, _ *runtime.Scheme, _ *cluster.CachedToolchainCluster, _ string) (client.Client, error) {
+				return testcommon.NewFakeClient(t), nil
+			}
+
+			for i := 0; i < 1000; i++ {
+				waitForFinished.Add(1)
+				go func() {
+					// given
+					defer waitForFinished.Done()
+					gate.Wait()
+
+					// when
+					hostClient, err := initializer.GetHostClient(context.TODO())
+
+					// then
+					require.NoError(t, err)
+					require.NotNil(t, hostClient)
+					require.NotNil(t, hostClient.Client)
+					require.Equal(t, testcommon.HostOperatorNs, hostClient.Namespace)
+				}()
+			}
+
+			// when
+			gate.Done()
+
+			// then
+			waitForFinished.Wait()
+		})
+	})
+}
+
+func NewGetHostCluster(ok bool) cluster.GetHostClusterFunc {
+	if !ok {
+		return func() (*cluster.CachedToolchainCluster, bool) {
+			return nil, false
+		}
+	}
+
+	return func() (toolchainCluster *cluster.CachedToolchainCluster, b bool) {
+		return &cluster.CachedToolchainCluster{
+			Config: &cluster.Config{
+				OperatorNamespace: testcommon.HostOperatorNs,
+			},
+		}, true
+	}
+}

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -1,7 +1,10 @@
 package test
 
 import (
+	"context"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/member-operator/pkg/host"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
@@ -10,6 +13,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// NewHostClientGetter returns the host.ClientGetter function that returns the same given values
+func NewHostClientGetter(cl client.Client, err error) host.ClientGetter {
+	return func(_ context.Context) (*host.NamespacedClient, error) {
+		return host.NewNamespacedClient(cl, test.HostOperatorNs), err
+	}
+}
 
 // NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.CachedToolchainCluster
 // that is returned by the function then contains the given client and the given status.

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -100,7 +100,7 @@ func (a *NSTemplateSetAssertion) HasStatusSpaceRolesRevisionsSet() *NSTemplateSe
 func (a *NSTemplateSetAssertion) HasStatusSpaceRolesRevisionsValue(expectedSpaceRoles []toolchainv1alpha1.NSTemplateSetSpaceRole) *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)
-	assert.Equal(a.t, expectedSpaceRoles, a.nsTmplSet.Status.SpaceRoles, "expected space roles to match")
+	assert.ElementsMatch(a.t, expectedSpaceRoles, a.nsTmplSet.Status.SpaceRoles, "expected space roles to match")
 	return a
 }
 


### PR DESCRIPTION
After the latest changes introduced in this PR: https://github.com/codeready-toolchain/member-operator/pull/666 the code always tries to get TTR first
https://github.com/codeready-toolchain/member-operator/blob/7a97fe7eb68d072f4af61a9eaaadb66ff289270a/controllers/nstemplateset/nstemplatetier.go#L36
but none TTR CR is currently present in the prod cluster, which means that the TierTemplate cache doesn't have any impact on the number of request made for TTRs. 
Since the call uses a client without a cache, then it always makes a request to the public api of the host cluster which may increase networking load on both sides (host & member).

This PR:
* introduced cached host cluster client that uses controller-runtime client backed by informer cache
* drops the TierTemplate cache

additional notes:
* there are some similarities with the reg-service implementation - we can extract the common code into toolchain-common in a separate PR
* The PR uses the cached client only in the NSTemplateSet controller, we can start using it in other controllers in the following PRs