### PR TITLE
monitoring: service to access '/healthz' endpoint

### DIFF
--- a/config/manager/health_service.yaml
+++ b/config/manager/health_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: health-service
+  namespace: system
+spec:
+  ports:
+  - name: health
+    port: 8081
+    protocol: TCP
+    targetPort: health
+  selector:
+    control-plane: controller-manager

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- health_service.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,9 @@ spec:
           - "--health-probe-bind-address=:8081"
           - "--metrics-bind-address=127.0.0.1:8080"
           - "--leader-elect"
+        ports:
+          - name: health
+            containerPort: 8081
         image: REPLACE_IMAGE
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
for probing via Blackbox Exporter

see also https://github.com/codeready-toolchain/host-operator/pull/1178

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
