### PR TITLE
KUBESAW-282: Remove CODE-OWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @MatousJobanek @xcoulon @alexeykazakov @rajivnathan @mfrancisc @rsoaresd @fbm3307 @metlos @jrosental


### PR DESCRIPTION
This PR removes the CODE-OWNERS file.

Similar PRs
- api : https://github.com/codeready-toolchain/api/pull/479
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/483
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1179
- registration-service: https://github.com/codeready-toolchain/registration-service/pull/533
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1153
- ksctl: https://github.com/kubesaw/ksctl/pull/118
- toolchain-cicd: https://github.com/codeready-toolchain/toolchain-cicd/pull/141
- workload-analyzer: https://github.com/codeready-toolchain/workload-analyzer/pull/216
- sandboxctl: https://github.com/codeready-toolchain/sandboxctl/pull/41
- sandbox-sre: https://github.com/codeready-toolchain/sandbox-sre/pull/2464
- kubesaw.github.io: https://github.com/kubesaw/kubesaw.github.io/pull/14