### PR TITLE
move owner idling to owners.go

### DIFF
--- a/controllers/idler/owners.go
+++ b/controllers/idler/owners.go
@@ -4,12 +4,198 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/scale"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+type ownerIdler struct {
+	ownerFetcher  *ownerFetcher
+	dynamicClient dynamic.Interface
+	scalesClient  scale.ScalesGetter
+	restClient    rest.Interface
+}
+
+func newOwnerIdler(discoveryClient discovery.ServerResourcesInterface, dynamicClient dynamic.Interface, scalesClient scale.ScalesGetter, restClient rest.Interface) *ownerIdler {
+	return &ownerIdler{
+		ownerFetcher:  newOwnerFetcher(discoveryClient, dynamicClient),
+		dynamicClient: dynamicClient,
+		scalesClient:  scalesClient,
+		restClient:    restClient,
+	}
+}
+
+// scaleOwnerToZero fetches the whole tree of the controller owners from the provided object (Deployment, ReplicaSet, etc).
+// If any known controller owner is found, then it's scaled down (or deleted) and its kind and name is returned.
+// Otherwise, returns empty strings.
+func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, meta metav1.Object) (kind string, name string, err error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Scaling owner to zero", "name", meta.GetName())
+
+	owners, err := i.ownerFetcher.getOwners(ctx, meta)
+	if err != nil {
+		logger.Error(err, "failed to find all owners, try to idle the workload with information that is available")
+	}
+	for _, ownerWithGVR := range owners {
+		owner := ownerWithGVR.object
+		kind = owner.GetObjectKind().GroupVersionKind().Kind
+		name = owner.GetName()
+		switch kind {
+		case "Deployment":
+			err = i.scaleDeploymentToZero(ctx, ownerWithGVR)
+			return
+		case "ReplicaSet":
+			err = i.scaleToZero(ctx, ownerWithGVR)
+			return
+		case "DaemonSet":
+			err = i.deleteResource(ctx, ownerWithGVR) // Nothing to scale down. Delete instead.
+			return
+		case "StatefulSet":
+			err = i.scaleToZero(ctx, ownerWithGVR)
+			return
+		case "DeploymentConfig":
+			err = i.scaleDeploymentConfigToZero(ctx, ownerWithGVR)
+			return
+		case "ReplicationController":
+			err = i.scaleToZero(ctx, ownerWithGVR)
+			return
+		case "Job":
+			err = i.deleteResource(ctx, ownerWithGVR) // Nothing to scale down. Delete instead.
+			return
+		case "VirtualMachine":
+			err = i.stopVirtualMachine(ctx, ownerWithGVR) // Nothing to scale down. Stop instead.
+			return
+		}
+	}
+	return "", "", nil
+}
+
+func (i *ownerIdler) scaleDeploymentToZero(ctx context.Context, objectWithGVR *objectWithGVR) error {
+	logger := log.FromContext(ctx)
+	object := objectWithGVR.object
+	logger.Info("Scaling deployment to zero", "name", object.GetName())
+	patch := []byte(`{"spec":{"replicas":0}}`)
+	for _, deploymentOwner := range object.GetOwnerReferences() {
+		if supportedScaleResource := getSupportedScaleResource(deploymentOwner); supportedScaleResource != nil {
+			_, err := i.scalesClient.Scales(object.GetNamespace()).Patch(ctx, *supportedScaleResource, deploymentOwner.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+			} else {
+				logger.Info("Deployment scaled to zero using scale sub resource", "name", object.GetName())
+				return nil
+			}
+		}
+	}
+	_, err := i.dynamicClient.
+		Resource(*objectWithGVR.gvr).
+		Namespace(object.GetNamespace()).
+		Patch(ctx, object.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	logger.Info("Deployment scaled to zero", "name", object.GetName())
+	return nil
+}
+
+func getSupportedScaleResource(ownerReference metav1.OwnerReference) *schema.GroupVersionResource {
+	if ownerGVK, err := schema.ParseGroupVersion(ownerReference.APIVersion); err == nil {
+		for groupVersionKind, groupVersionResource := range SupportedScaleResources {
+			if groupVersionKind.String() == ownerGVK.WithKind(ownerReference.Kind).String() {
+				return &groupVersionResource
+			}
+		}
+	}
+
+	return nil
+}
+
+func (i *ownerIdler) scaleToZero(ctx context.Context, objectWithGVR *objectWithGVR) error {
+	logger := log.FromContext(ctx)
+	object := objectWithGVR.object
+	logger.Info("Scaling controller owner to zero",
+		"kind", object.GetObjectKind().GroupVersionKind().Kind, "name", object.GetName())
+
+	patch := []byte(`{"spec":{"replicas":0}}`)
+	_, err := i.dynamicClient.
+		Resource(*objectWithGVR.gvr).
+		Namespace(object.GetNamespace()).
+		Patch(ctx, object.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Controller owner scaled to zero",
+		"kind", object.GetObjectKind().GroupVersionKind().Kind, "name", object.GetName())
+	return nil
+}
+
+func (i *ownerIdler) deleteResource(ctx context.Context, objectWithGVR *objectWithGVR) error {
+	logger := log.FromContext(ctx)
+	object := objectWithGVR.object
+	logger.Info("Deleting controller owner",
+		"kind", object.GetObjectKind().GroupVersionKind().Kind, "name", object.GetName())
+	// see https://github.com/kubernetes/kubernetes/issues/20902#issuecomment-321484735
+	// also, this may be needed for the e2e tests if the call to `client.Delete` comes too quickly after creating the job,
+	// which may leave the job's pod running but orphan, hence causing a test failure (and making the test flaky)
+	propagationPolicy := metav1.DeletePropagationBackground
+
+	err := i.dynamicClient.
+		Resource(*objectWithGVR.gvr).
+		Namespace(object.GetNamespace()).
+		Delete(ctx, object.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Controller owner deleted",
+		"kind", object.GetObjectKind().GroupVersionKind().Kind, "name", object.GetName())
+	return nil
+}
+
+func (i *ownerIdler) scaleDeploymentConfigToZero(ctx context.Context, objectWithGVR *objectWithGVR) error {
+	logger := log.FromContext(ctx)
+	object := objectWithGVR.object
+	logger.Info("Scaling DeploymentConfig to zero", "name", object.GetName())
+	patch := []byte(`{"spec":{"replicas":0,"paused":false}}`)
+	_, err := i.dynamicClient.
+		Resource(*objectWithGVR.gvr).
+		Namespace(object.GetNamespace()).
+		Patch(ctx, object.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	log.FromContext(ctx).Info("DeploymentConfig scaled to zero", "name", object.GetName())
+	return nil
+}
+
+func (i *ownerIdler) stopVirtualMachine(ctx context.Context, objectWithGVR *objectWithGVR) error {
+	logger := log.FromContext(ctx)
+	object := objectWithGVR.object
+	logger.Info("Stopping VirtualMachine", "name", object.GetName())
+	err := i.restClient.Put().
+		AbsPath(fmt.Sprintf(vmSubresourceURLFmt, "v1")).
+		Namespace(object.GetNamespace()).
+		Resource("virtualmachines").
+		Name(object.GetName()).
+		SubResource("stop").
+		Do(ctx).
+		Error()
+	if err != nil {
+		return err
+	}
+
+	logger.Info("VirtualMachine stopped", "name", object.GetName())
+	return nil
+}
 
 type ownerFetcher struct {
 	resourceLists   []*metav1.APIResourceList // All available API in the cluster

--- a/controllers/idler/owners_test.go
+++ b/controllers/idler/owners_test.go
@@ -4,14 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/apis"
+	"github.com/codeready-toolchain/member-operator/test"
+	testcommon "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	apiv1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,11 +30,254 @@ import (
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	fakescale "k8s.io/client-go/scale/fake"
 	clienttest "k8s.io/client-go/testing"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+func preparePayloadsForDynamicClient(t *testing.T, dynamicClient *fakedynamic.FakeDynamicClient) payloads {
+	return preparePayloadsWithCreateFunc(t, clientSet{
+		allNamespacesClient: testcommon.NewFakeClient(t),
+		dynamicClient:       dynamicClient,
+		createOwnerObjects: func(ctx context.Context, object client.Object) error {
+			return createObjectWithDynamicClient(t, dynamicClient, object, nil)
+		}}, "alex-stage", "", freshStartTimes(60))
+}
+
+type payloadTestConfig struct {
+	podOwnerName    string
+	expectedAppName string
+	ownerScaledUp   func(*test.IdleablePayloadAssertion)
+	ownerScaledDown func(*test.IdleablePayloadAssertion)
+}
+
+type createTestConfigFunc func(payloads) payloadTestConfig
+
+var testConfigs = map[string]createTestConfigFunc{
+	"Deployment": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			// We are testing the case with a nested controllers (Deployment -> ReplicaSet -> Pod) here,
+			// so we the pod's owner is ReplicaSet but the expected scaled app is the parent Deployment.
+			podOwnerName:    fmt.Sprintf("%s-replicaset", plds.deployment.Name),
+			expectedAppName: plds.deployment.Name,
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.DeploymentScaledUp(plds.deployment)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.DeploymentScaledDown(plds.deployment)
+			},
+		}
+	},
+	"ReplicaSet": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			podOwnerName:    plds.replicaSet.Name,
+			expectedAppName: plds.replicaSet.Name,
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.ReplicaSetScaledUp(plds.replicaSet)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.ReplicaSetScaledDown(plds.replicaSet)
+			},
+		}
+	},
+	"DaemonSet": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			podOwnerName:    plds.daemonSet.Name,
+			expectedAppName: plds.daemonSet.Name,
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.DaemonSetExists(plds.daemonSet)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.DaemonSetDoesNotExist(plds.daemonSet)
+			},
+		}
+	},
+	"StatefulSet": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			podOwnerName:    plds.statefulSet.Name,
+			expectedAppName: plds.statefulSet.Name,
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.StatefulSetScaledUp(plds.statefulSet)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.StatefulSetScaledDown(plds.statefulSet)
+			},
+		}
+	},
+	"DeploymentConfig": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			// We are testing the case with a nested controllers (DeploymentConfig -> ReplicationController -> Pod) here,
+			// so we the pod's owner is ReplicaSet but the expected scaled app is the parent Deployment.
+			podOwnerName:    fmt.Sprintf("%s-replicationcontroller", plds.deploymentConfig.Name),
+			expectedAppName: plds.deploymentConfig.Name,
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.DeploymentConfigScaledUp(plds.deploymentConfig)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.DeploymentConfigScaledDown(plds.deploymentConfig)
+			},
+		}
+	},
+	"ReplicationController": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			podOwnerName:    plds.replicationController.Name,
+			expectedAppName: plds.replicationController.Name,
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.ReplicationControllerScaledUp(plds.replicationController)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.ReplicationControllerScaledDown(plds.replicationController)
+			},
+		}
+	},
+	"Job": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			podOwnerName:    plds.job.Name,
+			expectedAppName: plds.job.Name,
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.JobExists(plds.job)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.JobDoesNotExist(plds.job)
+			},
+		}
+	},
+	"VirtualMachine": func(plds payloads) payloadTestConfig {
+		return payloadTestConfig{
+			podOwnerName:    plds.virtualmachineinstance.GetName(),
+			expectedAppName: plds.virtualmachine.GetName(),
+			ownerScaledUp: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.VMRunning(plds.vmStopCallCounter)
+			},
+			ownerScaledDown: func(assertion *test.IdleablePayloadAssertion) {
+				assertion.VMStopped(plds.vmStopCallCounter)
+			},
+		}
+	},
+}
+
+func TestAppNameTypeForControllers(t *testing.T) {
+	setup := func(t *testing.T, createTestConfig createTestConfigFunc) (*ownerIdler, *fakedynamic.FakeDynamicClient, payloadTestConfig, payloads, *corev1.Pod) {
+		dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme.Scheme)
+		fakeDiscovery := newFakeDiscoveryClient(withAAPResourceList(t)...)
+		scalesClient := &fakescale.FakeScaleClient{}
+		restClient, err := testcommon.NewRESTClient("dummy-token", apiEndpoint)
+		require.NoError(t, err)
+		restClient.Client.Transport = gock.DefaultTransport
+		t.Cleanup(func() {
+			gock.OffAll()
+		})
+
+		ownerIdler := newOwnerIdler(fakeDiscovery, dynamicClient, scalesClient, restClient)
+
+		plds := preparePayloadsForDynamicClient(t, dynamicClient)
+		tc := createTestConfig(plds)
+
+		p := func() *corev1.Pod {
+			for _, pod := range plds.controlledPods {
+				for _, owner := range pod.OwnerReferences {
+					if owner.Name == tc.podOwnerName {
+						return pod
+					}
+				}
+			}
+			return nil
+		}()
+		return ownerIdler, dynamicClient, tc, plds, p
+	}
+
+	t.Run("success", func(t *testing.T) {
+
+		for kind, createTestConfig := range testConfigs {
+			t.Run(kind, func(t *testing.T) {
+				//given
+				ownerIdler, dynamicClient, testConfig, plds, pod := setup(t, createTestConfig)
+
+				//when
+				appType, appName, err := ownerIdler.scaleOwnerToZero(context.TODO(), pod)
+
+				//then
+				require.NoError(t, err)
+				require.Equal(t, kind, appType)
+				require.Equal(t, testConfig.expectedAppName, appName)
+				assertion := test.AssertThatInIdleableCluster(t, testcommon.NewFakeClient(t), dynamicClient)
+				testConfig.ownerScaledDown(assertion)
+				for otherKind, othersTCFunc := range testConfigs {
+					if kind != otherKind {
+						othersTCFunc(plds).ownerScaledUp(assertion)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("failure when patching/deleting", func(t *testing.T) {
+		for kind, createTestConfig := range testConfigs {
+			t.Run(kind, func(t *testing.T) {
+				//given
+				ownerIdler, dynamicClient, testConfig, plds, pod := setup(t, createTestConfig)
+				gock.OffAll()
+				// mock stop call
+				mockStopVMCalls(".*", ".*", http.StatusInternalServerError)
+
+				errMsg := "can't update/delete " + kind
+				dynamicClient.PrependReactor("patch", strings.ToLower(kind)+"s", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New(errMsg)
+				})
+				dynamicClient.PrependReactor("delete", strings.ToLower(kind)+"s", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New(errMsg)
+				})
+
+				//when
+				appType, appName, err := ownerIdler.scaleOwnerToZero(context.TODO(), pod)
+
+				//then
+				assertion := test.AssertThatInIdleableCluster(t, testcommon.NewFakeClient(t), dynamicClient)
+				if kind != "VirtualMachine" {
+					require.EqualError(t, err, errMsg)
+					testConfig.ownerScaledUp(assertion)
+				} else {
+					require.EqualError(t, err, "an error on the server (\"\") has prevented the request from succeeding (put virtualmachines.authentication.k8s.io alex-stage-virtualmachine)")
+				}
+
+				require.Equal(t, kind, appType)
+				require.Equal(t, testConfig.expectedAppName, appName)
+				for otherKind, othersTCFunc := range testConfigs {
+					if kind != otherKind {
+						othersTCFunc(plds).ownerScaledUp(assertion)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("error when getting owner deployment is ignored", func(t *testing.T) {
+		// given
+		ownerIdler, dynamicClient, testConfig, plds, pod := setup(t, testConfigs["Deployment"])
+		reactionChain := dynamicClient.ReactionChain
+		dynamicClient.PrependReactor("get", "deployments", func(action clienttest.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("can't get deployment")
+		})
+
+		//when
+		appType, appName, err := ownerIdler.scaleOwnerToZero(context.TODO(), pod)
+
+		// then
+		require.NoError(t, err) // errors are ignored!
+		dynamicClient.ReactionChain = reactionChain
+		payloadAssertion := test.AssertThatInIdleableCluster(t, testcommon.NewFakeClient(t), dynamicClient).
+			DeploymentScaledUp(plds.deployment) // deployment is not idled
+		for _, rs := range plds.replicaSetsWithDeployment {
+			if rs.Name == testConfig.podOwnerName {
+				payloadAssertion.ReplicaSetScaledDown(rs) // but the ReplicaSet is
+			}
+		}
+		require.Equal(t, "ReplicaSet", appType)
+		require.Equal(t, testConfig.podOwnerName, appName)
+	})
+}
 
 func TestGetAPIResourceList(t *testing.T) {
 	// given

--- a/test/idler_assertion.go
+++ b/test/idler_assertion.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -136,8 +139,8 @@ func (a *IdleablePayloadAssertion) PodsExist(pods []*corev1.Pod) *IdleablePayloa
 
 func (a *IdleablePayloadAssertion) DeploymentScaledDown(deployment *appsv1.Deployment) *IdleablePayloadAssertion {
 	d := &appsv1.Deployment{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, d)
-	require.NoError(a.t, err)
+	gvr := appsv1.SchemeGroupVersion.WithResource("deployments")
+	a.getResourceFromDynamicClient(gvr, deployment.Namespace, deployment.Name, d)
 	require.NotNil(a.t, d.Spec.Replicas)
 	assert.Equal(a.t, int32(0), *d.Spec.Replicas, "namespace %s name %s", deployment.Namespace, deployment.Name)
 	return a
@@ -145,8 +148,8 @@ func (a *IdleablePayloadAssertion) DeploymentScaledDown(deployment *appsv1.Deplo
 
 func (a *IdleablePayloadAssertion) DeploymentScaledUp(deployment *appsv1.Deployment) *IdleablePayloadAssertion {
 	d := &appsv1.Deployment{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, d)
-	require.NoError(a.t, err)
+	gvr := appsv1.SchemeGroupVersion.WithResource("deployments")
+	a.getResourceFromDynamicClient(gvr, deployment.Namespace, deployment.Name, d)
 	require.NotNil(a.t, d.Spec.Replicas)
 	assert.Equal(a.t, int32(3), *d.Spec.Replicas)
 	return a
@@ -154,17 +157,28 @@ func (a *IdleablePayloadAssertion) DeploymentScaledUp(deployment *appsv1.Deploym
 
 func (a *IdleablePayloadAssertion) ReplicaSetScaledDown(replicaSet *appsv1.ReplicaSet) *IdleablePayloadAssertion {
 	r := &appsv1.ReplicaSet{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: replicaSet.Name, Namespace: replicaSet.Namespace}, r)
-	require.NoError(a.t, err)
+	gvr := appsv1.SchemeGroupVersion.WithResource("replicasets")
+	a.getResourceFromDynamicClient(gvr, replicaSet.Namespace, replicaSet.Name, r)
 	require.NotNil(a.t, r.Spec.Replicas)
 	assert.Equal(a.t, int32(0), *r.Spec.Replicas)
 	return a
 }
 
+func (a *IdleablePayloadAssertion) getResourceFromDynamicClient(gvr schema.GroupVersionResource, namespace, name string, object runtime.Object) {
+	unstructured, err := a.dynamicClient.
+		Resource(gvr).
+		Namespace(namespace).
+		Get(context.TODO(), name, metav1.GetOptions{})
+	require.NoError(a.t, err)
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.Object, object)
+	require.NoError(a.t, err)
+}
+
 func (a *IdleablePayloadAssertion) ReplicaSetScaledUp(replicaSet *appsv1.ReplicaSet) *IdleablePayloadAssertion {
 	r := &appsv1.ReplicaSet{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: replicaSet.Name, Namespace: replicaSet.Namespace}, r)
-	require.NoError(a.t, err)
+	gvr := appsv1.SchemeGroupVersion.WithResource("replicasets")
+	a.getResourceFromDynamicClient(gvr, replicaSet.Namespace, replicaSet.Name, r)
 	require.NotNil(a.t, r.Spec.Replicas)
 	assert.Equal(a.t, int32(3), *r.Spec.Replicas)
 	return a
@@ -172,8 +186,8 @@ func (a *IdleablePayloadAssertion) ReplicaSetScaledUp(replicaSet *appsv1.Replica
 
 func (a *IdleablePayloadAssertion) DeploymentConfigScaledDown(deployment *openshiftappsv1.DeploymentConfig) *IdleablePayloadAssertion {
 	d := &openshiftappsv1.DeploymentConfig{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, d)
-	require.NoError(a.t, err)
+	gvr := openshiftappsv1.SchemeGroupVersion.WithResource("deploymentconfigs")
+	a.getResourceFromDynamicClient(gvr, deployment.Namespace, deployment.Name, d)
 	assert.Equal(a.t, int32(0), d.Spec.Replicas)
 	assert.False(a.t, d.Spec.Paused) // DeploymentConfig should be unpaused when scaling down so that the replicas update can be rolled out
 	return a
@@ -181,16 +195,16 @@ func (a *IdleablePayloadAssertion) DeploymentConfigScaledDown(deployment *opensh
 
 func (a *IdleablePayloadAssertion) DeploymentConfigScaledUp(deployment *openshiftappsv1.DeploymentConfig) *IdleablePayloadAssertion {
 	d := &openshiftappsv1.DeploymentConfig{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, d)
-	require.NoError(a.t, err)
+	gvr := openshiftappsv1.SchemeGroupVersion.WithResource("deploymentconfigs")
+	a.getResourceFromDynamicClient(gvr, deployment.Namespace, deployment.Name, d)
 	assert.Equal(a.t, int32(3), d.Spec.Replicas)
 	return a
 }
 
 func (a *IdleablePayloadAssertion) ReplicationControllerScaledDown(rc *corev1.ReplicationController) *IdleablePayloadAssertion {
 	r := &corev1.ReplicationController{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: rc.Name, Namespace: rc.Namespace}, r)
-	require.NoError(a.t, err)
+	gvr := corev1.SchemeGroupVersion.WithResource("replicationcontrollers")
+	a.getResourceFromDynamicClient(gvr, rc.Namespace, rc.Name, r)
 	require.NotNil(a.t, r.Spec.Replicas)
 	assert.Equal(a.t, int32(0), *r.Spec.Replicas)
 	return a
@@ -198,47 +212,59 @@ func (a *IdleablePayloadAssertion) ReplicationControllerScaledDown(rc *corev1.Re
 
 func (a *IdleablePayloadAssertion) ReplicationControllerScaledUp(rc *corev1.ReplicationController) *IdleablePayloadAssertion {
 	r := &corev1.ReplicationController{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: rc.Name, Namespace: rc.Namespace}, r)
-	require.NoError(a.t, err)
+	gvr := corev1.SchemeGroupVersion.WithResource("replicationcontrollers")
+	a.getResourceFromDynamicClient(gvr, rc.Namespace, rc.Name, r)
 	require.NotNil(a.t, r.Spec.Replicas)
 	assert.Equal(a.t, int32(3), *r.Spec.Replicas)
 	return a
 }
 
 func (a *IdleablePayloadAssertion) DaemonSetExists(daemonSet *appsv1.DaemonSet) *IdleablePayloadAssertion {
-	d := &appsv1.DaemonSet{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: daemonSet.Name, Namespace: daemonSet.Namespace}, d)
+	gvr := appsv1.SchemeGroupVersion.WithResource("daemonsets")
+	_, err := a.dynamicClient.
+		Resource(gvr).
+		Namespace(daemonSet.Namespace).
+		Get(context.TODO(), daemonSet.Name, metav1.GetOptions{})
 	require.NoError(a.t, err)
 	return a
 }
 
 func (a *IdleablePayloadAssertion) DaemonSetDoesNotExist(daemonSet *appsv1.DaemonSet) *IdleablePayloadAssertion {
-	d := &appsv1.DaemonSet{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: daemonSet.Name, Namespace: daemonSet.Namespace}, d)
-	require.Error(a.t, err, "daemonSet %s still exists", d.Name)
+	gvr := appsv1.SchemeGroupVersion.WithResource("daemonsets")
+	_, err := a.dynamicClient.
+		Resource(gvr).
+		Namespace(daemonSet.Namespace).
+		Get(context.TODO(), daemonSet.Name, metav1.GetOptions{})
+	require.Error(a.t, err, "daemonSet %s still exists", daemonSet.Name)
 	assert.True(a.t, apierrors.IsNotFound(err))
 	return a
 }
 
 func (a *IdleablePayloadAssertion) JobExists(job *batchv1.Job) *IdleablePayloadAssertion {
-	j := &batchv1.Job{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, j)
+	gvr := batchv1.SchemeGroupVersion.WithResource("jobs")
+	_, err := a.dynamicClient.
+		Resource(gvr).
+		Namespace(job.Namespace).
+		Get(context.TODO(), job.Name, metav1.GetOptions{})
 	require.NoError(a.t, err)
 	return a
 }
 
 func (a *IdleablePayloadAssertion) JobDoesNotExist(job *batchv1.Job) *IdleablePayloadAssertion {
-	j := &batchv1.Job{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, j)
-	require.Error(a.t, err, "job %s still exists", j.Name)
+	gvr := batchv1.SchemeGroupVersion.WithResource("jobs")
+	_, err := a.dynamicClient.
+		Resource(gvr).
+		Namespace(job.Namespace).
+		Get(context.TODO(), job.Name, metav1.GetOptions{})
+	require.Error(a.t, err, "job %s still exists", job.Name)
 	assert.True(a.t, apierrors.IsNotFound(err))
 	return a
 }
 
 func (a *IdleablePayloadAssertion) StatefulSetScaledDown(statefulSet *appsv1.StatefulSet) *IdleablePayloadAssertion {
 	s := &appsv1.StatefulSet{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: statefulSet.Name, Namespace: statefulSet.Namespace}, s)
-	require.NoError(a.t, err)
+	gvr := appsv1.SchemeGroupVersion.WithResource("statefulsets")
+	a.getResourceFromDynamicClient(gvr, statefulSet.Namespace, statefulSet.Name, s)
 	require.NotNil(a.t, s.Spec.Replicas)
 	assert.Equal(a.t, int32(0), *s.Spec.Replicas)
 	return a
@@ -246,8 +272,8 @@ func (a *IdleablePayloadAssertion) StatefulSetScaledDown(statefulSet *appsv1.Sta
 
 func (a *IdleablePayloadAssertion) StatefulSetScaledUp(statefulSet *appsv1.StatefulSet) *IdleablePayloadAssertion {
 	s := &appsv1.StatefulSet{}
-	err := a.client.Get(context.TODO(), types.NamespacedName{Name: statefulSet.Name, Namespace: statefulSet.Namespace}, s)
-	require.NoError(a.t, err)
+	gvr := appsv1.SchemeGroupVersion.WithResource("statefulsets")
+	a.getResourceFromDynamicClient(gvr, statefulSet.Namespace, statefulSet.Name, s)
 	require.NotNil(a.t, s.Spec.Replicas)
 	assert.Equal(a.t, int32(3), *s.Spec.Replicas)
 	return a


### PR DESCRIPTION
a few refactoring changes:
* stop using all-namespaces client for owners - use DynamicClient only to support generic approach
* move controller/owner idling logic to owners.go to spread the code and decrease the size of the idler_controller.go file (the same applies to the tests)
* replace the duplicated scaling/deleting logic with generic functions `scaleToZero` and `deleteResource`.