### PR TITLE
Idle Notebooks in controller

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -75,6 +75,7 @@ type Reconciler struct {
 //+kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines;virtualmachineinstances,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kubeflow.org,resources=notebooks,verbs=get;list;watch;create;update;patch;delete
 
 // needed to stop the VMs - we need to make a PUT request for the "stop" subresource. Kubernetes internally classifies these as either create or update
 // based on the state of the existing object.


### PR DESCRIPTION
Moves the CronJob part of idling Notebooks into the idler controller https://github.com/codeready-toolchain/sandbox-sre/blob/b4705f3b43b16d3cdb9f0614a2ff024ce6635b3f/components/rhoai/base/nb-culler.yaml#L72-L82

paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1170

Assisted-by: Cursor