### PR TITLE
idler second known owner if idling the first one didn't work

### DIFF
--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -173,6 +173,7 @@ func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.
 				// Check if it belongs to a controller (Deployment, DeploymentConfig, etc) and scale it down to zero.
 				err := r.deletePodsAndCreateNotification(podCtx, pod, idler, ownerIdler)
 				if err == nil {
+					requeueAfter = shorterDuration(requeueAfter, time.Duration(float32(timeoutSeconds)*0.05)*time.Second)
 					continue
 				}
 				idleErrors = append(idleErrors, err)

--- a/controllers/idler/idler_controller.go
+++ b/controllers/idler/idler_controller.go
@@ -130,24 +130,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	return result, r.setStatusReady(ctx, idler)
 }
 
+func getTimeout(idler *toolchainv1alpha1.Idler, pod corev1.Pod) int32 {
+	timeoutSeconds := idler.Spec.TimeoutSeconds
+	if isOwnedByVM(pod.ObjectMeta) {
+		// use 1/12th of the timeout for VMs to have more aggressive idling to decrease
+		// the infra costs because VMs consume much more resources
+		timeoutSeconds = timeoutSeconds / 12
+	}
+	return timeoutSeconds
+}
+
 func (r *Reconciler) ensureIdling(ctx context.Context, idler *toolchainv1alpha1.Idler) (time.Duration, error) {
 	// Get all pods running in the namespace
 	podList := &corev1.PodList{}
 	if err := r.AllNamespacesClient.List(ctx, podList, client.InNamespace(idler.Name)); err != nil {
 		return 0, err
 	}
-	ownerIdler := newOwnerIdler(r.DiscoveryClient, r.DynamicClient, r.ScalesClient, r.RestClient)
+	ownerIdler := newOwnerIdler(idler, r)
 	requeueAfter := time.Duration(idler.Spec.TimeoutSeconds) * time.Second
 	var idleErrors []error
 	for _, pod := range podList.Items {
 		podLogger := log.FromContext(ctx).WithValues("pod_name", pod.Name, "pod_phase", pod.Status.Phase)
 		podCtx := log.IntoContext(ctx, podLogger)
-		timeoutSeconds := idler.Spec.TimeoutSeconds
-		if isOwnedByVM(pod.ObjectMeta) {
-			// use 1/12th of the timeout for VMs to have more aggressive idling to decrease
-			// the infra costs because VMs consume much more resources
-			timeoutSeconds = timeoutSeconds / 12
-		}
+
+		timeoutSeconds := getTimeout(idler, pod)
 		if pod.Status.StartTime != nil {
 			// check the restart count for the pod
 			restartCount := getHighestRestartCount(pod.Status)

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -606,7 +606,7 @@ func TestNotificationAppNameTypeForPods(t *testing.T) {
 	for pt, tcs := range testpod {
 		t.Run(pt, func(t *testing.T) {
 			reconciler, _, fakeClients := prepareReconcile(t, idler.Name, getHostCluster, idler, nsTmplSet, mur)
-			ownerIdler := newOwnerIdler(reconciler.DiscoveryClient, reconciler.DynamicClient, reconciler.ScalesClient, reconciler.RestClient)
+			ownerIdler := newOwnerIdler(idler, reconciler)
 			pod, appName := tcs.preparePayload(fakeClients)
 
 			// when

--- a/controllers/idler/idler_controller_test.go
+++ b/controllers/idler/idler_controller_test.go
@@ -234,7 +234,8 @@ func TestEnsureIdling(t *testing.T) {
 				HasConditions(memberoperatortest.Running(), memberoperatortest.IdlerNotificationCreated())
 
 			assert.True(t, res.Requeue)
-			assertRequeueTimeInDelta(t, res.RequeueAfter, idler.Spec.TimeoutSeconds/24)
+			// something was idled, expect the next reconcile in 5% of the timeout
+			assertRequeueTimeInDelta(t, res.RequeueAfter, int32(float32(idler.Spec.TimeoutSeconds)*0.05/12))
 
 			t.Run("No pods. requeue after idler timeout.", func(t *testing.T) {
 				//given
@@ -362,7 +363,8 @@ func TestEnsureIdling(t *testing.T) {
 		//then
 		require.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.Equal(t, time.Duration(idler.Spec.TimeoutSeconds)*time.Second, res.RequeueAfter)
+		// something was idled, expect the next reconcile in 5% of the timeout
+		assert.Equal(t, time.Duration(int32(float32(idler.Spec.TimeoutSeconds)*0.05/12))*time.Second, res.RequeueAfter)
 		memberoperatortest.AssertThatIdler(t, idler.Name, fakeClients).
 			HasConditions(memberoperatortest.Running(), memberoperatortest.IdlerNotificationCreated())
 		//check the notification is actually created
@@ -384,7 +386,8 @@ func TestEnsureIdling(t *testing.T) {
 			//then
 			require.NoError(t, err)
 			assert.True(t, res.Requeue)
-			assert.Equal(t, time.Duration(idler.Spec.TimeoutSeconds)*time.Second, res.RequeueAfter)
+			// pods (exceeding the timeout) are still running, expect the next reconcile in 5% of the timeout
+			assert.Equal(t, time.Duration(int32(float32(idler.Spec.TimeoutSeconds)*0.05/12))*time.Second, res.RequeueAfter)
 			memberoperatortest.AssertThatIdler(t, idler.Name, fakeClients).
 				HasConditions(memberoperatortest.Running(), memberoperatortest.IdlerNotificationCreated())
 

--- a/controllers/idler/owners.go
+++ b/controllers/idler/owners.go
@@ -40,6 +40,7 @@ func newOwnerIdler(idler *toolchainv1alpha1.Idler, reconciler *Reconciler) *owne
 // scaleOwnerToZero fetches the whole tree of the controller owners from the provided pod.
 // If any known controller owner is found, then it's scaled down (or deleted) and its kind and name is returned.
 // If the pod has been running for longer than 105% of the idler timeout, it will also idle the second known owner.
+// This is a workaround for cases when the top owner controller fails to idle the workload. For example the AAP controller sometimes fails to scale down StatefulSets for postgres pods owned by the top AAP CR. Scaling down the StatefulSet (AAP -> StatefulSet -> Pods) mitigates that AAP controller bug.
 // Otherwise, returns empty strings.
 func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, pod *corev1.Pod) (string, string, error) {
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
a generic workaround for the broken AAP-internal idler: https://redhat-internal.slack.com/archives/C07UWTB1BPB/p1751090482552999
if idling of the top known owner either fails or the pod is running longer than 105% of the idler timeout (which means that the first idling didn't have any effect), then idle the second known owner.
Also, if there is a running pod that exceeded the timeout (which means that the idler tried to idle it) it schedules the next reconcile in the 5% of the timeout.

Assisted-by: Cursor (but this time it wasn't really helpful) 