### PR TITLE
[SANDBOX-1395] Don't listen to changes in the known types of cluster-scoped resources

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -331,7 +331,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }
 
 func newRestClient(config *rest.Config) (*rest.RESTClient, error) {

--- a/controllers/nstemplateset/cluster_resources.go
+++ b/controllers/nstemplateset/cluster_resources.go
@@ -180,7 +180,7 @@ func (r *clusterResourcesManager) ensure(ctx context.Context, nsTmplSet *toolcha
 // apply creates or updates the given object with the set of toolchain labels. If the apply operation was successful, then it returns 'true, nil',
 // but if there was an error then it returns 'false, error'.
 func (r *clusterResourcesManager) apply(ctx context.Context, nsTmplSet *toolchainv1alpha1.NSTemplateSet, tierTemplate *tierTemplate, object runtimeclient.Object) (bool, error) {
-	var labels = map[string]string{
+	labels := map[string]string{
 		toolchainv1alpha1.SpaceLabelKey:       nsTmplSet.GetName(),
 		toolchainv1alpha1.TypeLabelKey:        toolchainv1alpha1.ClusterResourcesTemplateType,
 		toolchainv1alpha1.TemplateRefLabelKey: tierTemplate.templateRef,

--- a/controllers/nstemplateset/nstemplateset_controller.go
+++ b/controllers/nstemplateset/nstemplateset_controller.go
@@ -62,8 +62,8 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager, allNamespaceCluster r
 		// we're watching the roles and role bindings explicitly so that the users that accidentally lose access to their namespaces
 		// can get it restored as quickly as possible.
 		//
-		// We watch no other resource kinds that are created from the templates. Instead we rely on the periodic reconcile of nstemplatesets that is automatically
-		// triggered by the controller runtime roughly once a day.
+		// We intentionally do not watch any other resources potentially created by the templates (including cluster-scoped resources).
+		// Instead, we rely on controller-runtime's/ periodic resync/reconcile of NSTemplateSets as configured via manager.Options.Cache.SyncPeriod.
 		WatchesRawSource(source.Kind[runtimeclient.Object](allNamespaceCluster.GetCache(), &rbac.Role{}, mapToOwnerByLabel, commonpredicates.LabelsAndGenerationPredicate{})).
 		WatchesRawSource(source.Kind[runtimeclient.Object](allNamespaceCluster.GetCache(), &rbac.RoleBinding{}, mapToOwnerByLabel, commonpredicates.LabelsAndGenerationPredicate{}))
 
@@ -126,7 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// we proceed with the cluster-scoped resources template, then all namespaces and finally space roles
-	// as we want ot be sure that cluster scoped resources such as quotas are set
+	// as we want ot be sure that cluster-scoped resources such as quotas are set
 	// even before the namespaces exist
 	if createdOrUpdated, err := r.clusterResources.ensure(ctx, nsTmplSet); err != nil {
 		logger.Error(err, "failed to either provision or update cluster resources")

--- a/controllers/nstemplateset/nstemplateset_controller.go
+++ b/controllers/nstemplateset/nstemplateset_controller.go
@@ -64,6 +64,11 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager, allNamespaceCluster r
 		//
 		// We intentionally do not watch any other resources potentially created by the templates (including cluster-scoped resources).
 		// Instead, we rely on controller-runtime's/ periodic resync/reconcile of NSTemplateSets as configured via manager.Options.Cache.SyncPeriod.
+		//
+		// This is a reasonable thing to do because the users either don't have the write access to the resources that are part of the template at all (i.e.
+		// the users don't have write access to any cluster-scoped resources) or there is the assumption that there is not much potential harm
+		// when the users modify the (namespaced) resources from the template. As mentioned above, the notable exception are roles and bindings that can
+		// cause the user to lose the access to the namespace and therefore we DO watch those to reapply the template and restore the access as soon as possible.
 		WatchesRawSource(source.Kind[runtimeclient.Object](allNamespaceCluster.GetCache(), &rbac.Role{}, mapToOwnerByLabel, commonpredicates.LabelsAndGenerationPredicate{})).
 		WatchesRawSource(source.Kind[runtimeclient.Object](allNamespaceCluster.GetCache(), &rbac.RoleBinding{}, mapToOwnerByLabel, commonpredicates.LabelsAndGenerationPredicate{}))
 

--- a/controllers/nstemplateset/nstemplateset_controller.go
+++ b/controllers/nstemplateset/nstemplateset_controller.go
@@ -131,7 +131,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// we proceed with the cluster-scoped resources template, then all namespaces and finally space roles
-	// as we want ot be sure that cluster-scoped resources such as quotas are set
+	// as we want to be sure that cluster-scoped resources such as quotas are set
 	// even before the namespaces exist
 	if createdOrUpdated, err := r.clusterResources.ensure(ctx, nsTmplSet); err != nil {
 		logger.Error(err, "failed to either provision or update cluster resources")

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,7 +32,6 @@ import (
 )
 
 func TestReconcileAddFinalizer(t *testing.T) {
-
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
 	spacename := "johnsmith"
@@ -73,11 +73,9 @@ func TestReconcileAddFinalizer(t *testing.T) {
 				DoesNotHaveFinalizer()
 		})
 	})
-
 }
 
 func TestReconcileProvisionOK(t *testing.T) {
-
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
 	spacename := "johnsmith"
@@ -445,7 +443,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 			HasResource("exec-pods", &rbacv1.Role{})
 
-		//second reconcile adds owner label to role in stage namespace
+		// second reconcile adds owner label to role in stage namespace
 		res, err = r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
@@ -489,7 +487,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
 
-		//second reconcile adds owner label to rolebinding in stage namespace
+		// second reconcile adds owner label to rolebinding in stage namespace
 		res, err = r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
@@ -527,7 +525,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 		AssertThatNamespace(t, spacename+"-stage", fakeClient).
 			HasResource("crtadmin-pods", &rbacv1.RoleBinding{})
 
-		//second reconcile adds owner label to rolebinding in stage namespace
+		// second reconcile adds owner label to rolebinding in stage namespace
 		res, err = r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
@@ -573,7 +571,7 @@ func TestReconcileProvisionOK(t *testing.T) {
 			HasResource("crtadmin-view", &rbacv1.RoleBinding{}).
 			HasResource("exec-pods", &rbacv1.Role{})
 
-		//second reconcile adds owner label to role in stage namespace
+		// second reconcile adds owner label to role in stage namespace
 		res, err = r.Reconcile(context.TODO(), req)
 		// then
 		require.NoError(t, err)
@@ -606,7 +604,6 @@ func TestReconcileProvisionOK(t *testing.T) {
 }
 
 func TestProvisionTwoUsers(t *testing.T) {
-
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
 	spacename := "john"
@@ -625,7 +622,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, res)
+		assert.Equal(t, reconcile.Result{Requeue: true}, res)
 		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev").
@@ -642,7 +639,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, res)
+			assert.Equal(t, reconcile.Result{Requeue: true}, res)
 			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 				HasFinalizer().
 				HasSpecNamespaces("dev").
@@ -659,7 +656,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				assert.Equal(t, reconcile.Result{}, res)
+				assert.Equal(t, reconcile.Result{Requeue: true}, res)
 				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasFinalizer().
 					HasSpecNamespaces("dev").
@@ -676,7 +673,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				assert.Equal(t, reconcile.Result{}, res)
+				assert.Equal(t, reconcile.Result{Requeue: true}, res)
 				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 					HasConditions(Provisioning())
 				AssertThatCluster(t, fakeClient).
@@ -744,7 +741,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 							// then
 							require.NoError(t, err)
-							assert.Equal(t, reconcile.Result{}, res)
+							assert.Equal(t, reconcile.Result{Requeue: true}, res)
 							AssertThatNSTemplateSet(t, namespaceName, joeUsername, fakeClient).
 								HasFinalizer().
 								HasSpecNamespaces("dev").
@@ -761,7 +758,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 								// then
 								require.NoError(t, err)
-								assert.Equal(t, reconcile.Result{}, res)
+								assert.Equal(t, reconcile.Result{Requeue: true}, res)
 								AssertThatNSTemplateSet(t, namespaceName, joeUsername, fakeClient).
 									HasFinalizer().
 									HasSpecNamespaces("dev").
@@ -778,7 +775,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 									// then
 									require.NoError(t, err)
-									assert.Equal(t, reconcile.Result{}, res)
+									assert.Equal(t, reconcile.Result{Requeue: true}, res)
 									AssertThatNSTemplateSet(t, namespaceName, joeUsername, fakeClient).
 										HasFinalizer().
 										HasSpecNamespaces("dev").
@@ -794,7 +791,7 @@ func TestProvisionTwoUsers(t *testing.T) {
 
 									// then
 									require.NoError(t, err)
-									assert.Equal(t, reconcile.Result{}, res)
+									assert.Equal(t, reconcile.Result{Requeue: true}, res)
 									AssertThatNSTemplateSet(t, namespaceName, joeUsername, fakeClient).
 										HasConditions(Provisioning())
 									AssertThatCluster(t, fakeClient).
@@ -857,7 +854,6 @@ func TestProvisionTwoUsers(t *testing.T) {
 }
 
 func TestReconcilePromotion(t *testing.T) {
-
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
 	spacename := "johnsmith"
@@ -867,7 +863,6 @@ func TestReconcilePromotion(t *testing.T) {
 	t.Cleanup(restore)
 
 	t.Run("upgrade from basic to advanced tier", func(t *testing.T) {
-
 		t.Run("create ClusterResourceQuota", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
@@ -959,7 +954,6 @@ func TestReconcilePromotion(t *testing.T) {
 							WithLabel(toolchainv1alpha1.TierLabelKey, "advanced")) // created
 
 					t.Run("delete redundant namespace", func(t *testing.T) {
-
 						// when - should delete the -stage namespace
 						_, err := r.Reconcile(context.TODO(), req)
 
@@ -1040,7 +1034,6 @@ func TestReconcilePromotion(t *testing.T) {
 }
 
 func TestReconcileUpdate(t *testing.T) {
-
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	// given
 	spacename := "johnsmith"
@@ -1050,7 +1043,6 @@ func TestReconcileUpdate(t *testing.T) {
 	t.Cleanup(restore)
 
 	t.Run("upgrade from abcde11 to abcde12 as part of the advanced tier", func(t *testing.T) {
-
 		t.Run("update ClusterResourceQuota", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced",
@@ -1173,7 +1165,6 @@ func TestReconcileUpdate(t *testing.T) {
 				}
 
 				t.Run("delete redundant namespace", func(t *testing.T) {
-
 					// when - should delete the -stage namespace
 					_, err := r.Reconcile(context.TODO(), req)
 
@@ -1529,7 +1520,7 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		result, err := r.Reconcile(context.TODO(), req)
 		// then
 		require.EqualError(t, err, "failed to delete cluster resource 'for-johnsmith': mock error")
-		require.Empty(t, result)
+		require.Equal(t, controllerruntime.Result{Requeue: true}, result)
 	})
 
 	t.Run("NSTemplateSet deletion errors when namespace is not deleted in 1 min", func(t *testing.T) {
@@ -1560,29 +1551,26 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		// first reconcile, deletion is triggered
 		result, err := r.Reconcile(context.TODO(), req)
 		require.NoError(t, err)
-		require.True(t, result.Requeue)
 		require.Equal(t, time.Second, result.RequeueAfter)
-		//then second reconcile to check if namespace has actually been deleted
+		// then second reconcile to check if namespace has actually been deleted
 		result, err = r.Reconcile(context.TODO(), req)
 		require.NoError(t, err)
-		require.True(t, result.Requeue)
 		require.Equal(t, time.Second, result.RequeueAfter)
 
 		firstNSName := fmt.Sprintf("%s-dev", spacename)
 		secondNSName := fmt.Sprintf("%s-stage", spacename)
 		// get the first namespace and check that it has deletion timestamp
 		AssertThatNamespace(t, firstNSName, r.Client).HasDeletionTimestamp()
-		//second NS is not affected
+		// second NS is not affected
 		AssertThatNamespace(t, secondNSName, r.Client).HasNoDeletionTimestamp()
 		// get the NSTemplateSet resource again, check it is not deleted and its status
 		AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 			HasFinalizer().
 			HasConditions(Terminating())
 
-		//reconcile to check there is no change, ns still exists
+		// reconcile to check there is no change, ns still exists
 		result, err = r.Reconcile(context.TODO(), req)
 		require.NoError(t, err)
-		require.True(t, result.Requeue)
 		require.Equal(t, time.Second, result.RequeueAfter)
 
 		AssertThatNamespace(t, firstNSName, r.Client).HasDeletionTimestamp()
@@ -1603,7 +1591,6 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		// deletion of firstNS would trigger another reconcile deleting secondNS
 		result, err = r.Reconcile(context.TODO(), req)
 		require.NoError(t, err)
-		require.True(t, result.Requeue)
 		require.Equal(t, time.Second, result.RequeueAfter)
 
 		// get the first namespace and check it IS deleted
@@ -1622,7 +1609,6 @@ func TestDeleteNSTemplateSet(t *testing.T) {
 		// Check that nsTemplateSet is gone as well
 		AssertThatNSTemplateSet(t, namespaceName, spacename, r.Client).
 			DoesNotExist()
-
 	})
 }
 


### PR DESCRIPTION
Instead just rely on periodic 'whole-world' reconciles run by the controller runtime.

This is done in preparation for simplifying and unifying the way we handle namespace-scoped and cluster-wide resources.

Jira issue: https://issues.redhat.com/browse/SANDBOX-1395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Faster restoration of user namespace access after RBAC changes; role and rolebinding updates are applied before continuation.

- Performance Improvements
  - Reduced background watches to only RBAC resources, lowering cluster load.

- Reliability
  - Improved reconcile and retry behavior with short delays and explicit requeues to ensure cluster resources are applied and cleaned up.

- Tests
  - Reconciler tests updated to expect asynchronous requeue behavior.

- Chores
  - Minor formatting and non-functional code cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->