### PR TITLE
postpone silence-until of go 1.22 vulnerabilities to 2025-10-01

### DIFF
--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -4,16 +4,16 @@ ignored-vulnerabilities:
   # Fixed in Fixed in: net/http/internal@go1.23.8
   - id: GO-2025-3563
     info: https://pkg.go.dev/vuln/GO-2025-3563
-    silence-until: 2025-08-01
+    silence-until: 2025-10-01
   # Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in syscall
   # Found in Found in: os@go1.22.12
   # Fixed in Fixed in: os@go1.23.10
   - id: GO-2025-3750
     info: https://pkg.go.dev/vuln/GO-2025-3750
-    silence-until: 2025-08-01
+    silence-until: 2025-10-01
   # Sensitive headers not cleared on cross-origin redirect in net/http
   # Found in Found in: net/http@go1.22.12
   # Fixed in Fixed in: net/http@go1.23.10
   - id: GO-2025-3751
     info: https://pkg.go.dev/vuln/GO-2025-3751
-    silence-until: 2025-08-01
+    silence-until: 2025-10-01


### PR DESCRIPTION
still waiting for the update of go version to 1.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to extend temporary ignores for select advisories through 2025-10-01.
  * No impact to app behavior, performance, or user-facing features.
  * Build, runtime, and APIs remain unchanged; CI security checks continue to run as before.
  * Helps keep vulnerability reports focused on actionable issues while upstream fixes stabilize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->