### PR TITLE
drop 'Install Go' step from govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,11 +13,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v5
 
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
-
     - name: Run govulncheck
       uses: codeready-toolchain/toolchain-cicd/govulncheck-action@master
       with:


### PR DESCRIPTION
drop 'Install Go' step from govulncheck workflow because it's done in the GHA composite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the vulnerability scanning workflow to reduce redundancy and improve reliability in continuous integration.
  * Consolidated setup steps to simplify maintenance and speed up security checks.
  * No changes to product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->