### PR TITLE
apply all cluster resources at once and read the prior state from the nstemplateset status instead of labels

### DIFF
--- a/controllers/nstemplateset/cluster_resources.go
+++ b/controllers/nstemplateset/cluster_resources.go
@@ -2,19 +2,14 @@ package nstemplateset
 
 import (
 	"context"
+	"fmt"
+	"slices"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
-	"github.com/codeready-toolchain/toolchain-common/pkg/template"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	quotav1 "github.com/openshift/api/quota/v1"
 	errs "github.com/pkg/errors"
 	"github.com/redhat-cop/operator-utils/pkg/util"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -24,157 +19,131 @@ type clusterResourcesManager struct {
 	*statusManager
 }
 
-// listExistingResourcesIfAvailable returns a list of comparable Objects representing existing resources in the cluster
-type listExistingResources func(ctx context.Context, cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error)
-
-// listExistingResourcesIfAvailable checks if the API group is available in the cluster and returns a list of comparable Objects representing existing resources in the cluster
-type listExistingResourcesIfAvailable func(ctx context.Context, cl runtimeclient.Client, spacename string, availableAPIGroups []metav1.APIGroup) ([]runtimeclient.Object, error)
-
-// toolchainObjectKind represents a resource kind that should be present in templates containing cluster resources.
-// Such a kind should be watched by NSTempalateSet controller which means that every change of the
-// resources of that kind triggers a new reconcile.
-// It is expected that the template contains only the kinds that are being watched and there is an instance of
-// toolchainObjectKind type created in clusterResourceKinds list
-type toolchainObjectKind struct {
-	gvk                              schema.GroupVersionKind
-	object                           runtimeclient.Object
-	listExistingResourcesIfAvailable listExistingResourcesIfAvailable
-}
-
-func newToolchainObjectKind(gvk schema.GroupVersionKind, emptyObject runtimeclient.Object, listExistingResources listExistingResources) toolchainObjectKind {
-	return toolchainObjectKind{
-		gvk:    gvk,
-		object: emptyObject,
-		listExistingResourcesIfAvailable: func(ctx context.Context, cl runtimeclient.Client, spacename string, availableAPIGroups []metav1.APIGroup) (objects []runtimeclient.Object, e error) {
-			if !apiGroupIsPresent(availableAPIGroups, gvk) {
-				return []runtimeclient.Object{}, nil
-			}
-			return listExistingResources(ctx, cl, spacename)
-		},
-	}
-}
-
-// clusterResourceKinds is a list that contains definitions for all cluster-scoped toolchainObjectKinds
-var clusterResourceKinds = []toolchainObjectKind{
-	newToolchainObjectKind(
-		quotav1.GroupVersion.WithKind("ClusterResourceQuota"),
-		&quotav1.ClusterResourceQuota{},
-		func(ctx context.Context, cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error) {
-			itemList := &quotav1.ClusterResourceQuotaList{}
-			if err := cl.List(ctx, itemList, listBySpaceLabel(spacename)); err != nil {
-				return nil, err
-			}
-			list := make([]runtimeclient.Object, len(itemList.Items))
-			for index := range itemList.Items {
-				list[index] = &itemList.Items[index]
-			}
-			return applycl.SortObjectsByName(list), nil
-		}),
-
-	newToolchainObjectKind(
-		rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"),
-		&rbacv1.ClusterRoleBinding{},
-		func(ctx context.Context, cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error) {
-			itemList := &rbacv1.ClusterRoleBindingList{}
-			if err := cl.List(ctx, itemList, listBySpaceLabel(spacename)); err != nil {
-				return nil, err
-			}
-			list := make([]runtimeclient.Object, len(itemList.Items))
-			for index := range itemList.Items {
-				list[index] = &itemList.Items[index]
-			}
-			return applycl.SortObjectsByName(list), nil
-		}),
-
-	newToolchainObjectKind(
-		toolchainv1alpha1.GroupVersion.WithKind("Idler"),
-		&toolchainv1alpha1.Idler{},
-		func(ctx context.Context, cl runtimeclient.Client, spacename string) ([]runtimeclient.Object, error) {
-			itemList := &toolchainv1alpha1.IdlerList{}
-			if err := cl.List(ctx, itemList, listBySpaceLabel(spacename)); err != nil {
-				return nil, err
-			}
-			list := make([]runtimeclient.Object, len(itemList.Items))
-			for index := range itemList.Items {
-				list[index] = &itemList.Items[index]
-			}
-			return applycl.SortObjectsByName(list), nil
-		}),
-}
-
 // ensure ensures that the cluster resources exist.
 // Returns `true, nil` if something was changed, `false, nil` if nothing changed, `false, err` if an error occurred
-func (r *clusterResourcesManager) ensure(ctx context.Context, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
+//
+// NOTE: This method makes 1 important assumption: all the cluster-scoped resources of the NSTemplateSet are uniquely
+// associated with it. I.e. the logic doesn't work correctly if 2 NSTemplateSets declare the very same cluster-scoped
+// resource. It is assumed that if a cluster-scoped resource should be common to more than 1 nstemplateset, it should
+// be deployed externally from Devsandbox, e.g. using ArgoCD.
+func (r *clusterResourcesManager) ensure(ctx context.Context, nsTmplSet *toolchainv1alpha1.NSTemplateSet) error {
 	logger := log.FromContext(ctx)
 	userTierLogger := logger.WithValues("spacename", nsTmplSet.GetName(), "tier", nsTmplSet.Spec.TierName)
 	userTierCtx := log.IntoContext(ctx, userTierLogger)
 	userTierLogger.Info("ensuring cluster resources")
 
 	spacename := nsTmplSet.GetName()
-	var tierTemplate *tierTemplate
-	var err error
+
+	var oldTemplateRef, newTemplateRef string
 	if nsTmplSet.Spec.ClusterResources != nil {
-		tierTemplate, err = getTierTemplate(ctx, r.GetHostClusterClient, nsTmplSet.Spec.ClusterResources.TemplateRef)
+		newTemplateRef = nsTmplSet.Spec.ClusterResources.TemplateRef
+	}
+	if nsTmplSet.Status.ClusterResources != nil {
+		oldTemplateRef = nsTmplSet.Status.ClusterResources.TemplateRef
+	}
+
+	if oldTemplateRef == newTemplateRef {
+		return nil
+	}
+
+	var newTierTemplate *tierTemplate
+	var oldTierTemplate *tierTemplate
+	var err error
+	if newTemplateRef != "" {
+		newTierTemplate, err = getTierTemplate(ctx, r.GetHostClusterClient, newTemplateRef)
 		if err != nil {
-			return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(userTierCtx, nsTmplSet, err,
-				"failed to retrieve TierTemplate for the cluster resources with the name '%s'", nsTmplSet.Spec.ClusterResources.TemplateRef)
+			return r.wrapErrorWithStatusUpdateForClusterResourceFailure(userTierCtx, nsTmplSet, err,
+				"failed to retrieve the TierTemplate for the to-be-applied cluster resources with the name '%s'", newTemplateRef)
 		}
 	}
-	// go through all cluster resource kinds
-	for _, clusterResourceKind := range clusterResourceKinds {
-		gvkLogger := userTierLogger.WithValues("gvk", clusterResourceKind.gvk)
-		gvkCtx := log.IntoContext(ctx, gvkLogger)
-
-		gvkLogger.Info("ensuring cluster resources")
-		newObjs := make([]runtimeclient.Object, 0)
-
-		// get all objects of the resource kind from the template (if the template is specified)
-		if tierTemplate != nil {
-			newObjs, err = tierTemplate.process(r.Scheme, map[string]string{
-				SpaceName: spacename,
-			}, retainObjectsOfSameGVK(clusterResourceKind.gvk))
-			if err != nil {
-				return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(gvkCtx, nsTmplSet, err,
-					"failed to process template for the cluster resources with the name '%s'", nsTmplSet.Spec.ClusterResources.TemplateRef)
-			}
-		}
-
-		// list all existing objects of the cluster resource kind
-		currentObjects, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, r.Client, spacename, r.AvailableAPIGroups)
+	if oldTemplateRef != "" {
+		oldTierTemplate, err = getTierTemplate(ctx, r.GetHostClusterClient, oldTemplateRef)
 		if err != nil {
-			return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(gvkCtx, nsTmplSet, err,
-				"failed to list existing cluster resources of GVK '%v'", clusterResourceKind.gvk)
-		}
-
-		// if there are more than one existing, then check if there is any that should be updated or deleted
-		if len(currentObjects) > 0 {
-			updatedOrDeleted, err := r.updateOrDeleteRedundant(gvkCtx, currentObjects, newObjs, tierTemplate, nsTmplSet)
-			if err != nil {
-				return false, r.wrapErrorWithStatusUpdate(gvkCtx, nsTmplSet, r.setStatusUpdateFailed,
-					err, "failed to update/delete existing cluster resources of GVK '%v'", clusterResourceKind.gvk)
-			}
-			if updatedOrDeleted {
-				return true, err
-			}
-		}
-		// if none was found to be either updated or deleted or if there is no existing object available,
-		// then check if there is any object to be created
-		if len(newObjs) > 0 {
-			anyCreated, err := r.createMissing(gvkCtx, currentObjects, newObjs, tierTemplate, nsTmplSet)
-			if err != nil {
-				return false, r.wrapErrorWithStatusUpdate(gvkCtx, nsTmplSet, r.setStatusClusterResourcesProvisionFailed,
-					err, "failed to create missing cluster resource of GVK '%v'", clusterResourceKind.gvk)
-			}
-			if anyCreated {
-				return true, nil
-			}
-		} else {
-			gvkLogger.Info("no new cluster resources to create")
+			return r.wrapErrorWithStatusUpdateForClusterResourceFailure(userTierCtx, nsTmplSet, err,
+				"failed to retrieve TierTemplate for the last-applied cluster resources with the name '%s'", oldTemplateRef)
 		}
 	}
 
-	userTierLogger.Info("cluster resources already provisioned")
-	return false, nil
+	var newObjs, currentObjects []runtimeclient.Object
+	if newTierTemplate != nil {
+		newObjs, err = newTierTemplate.process(r.Scheme, map[string]string{SpaceName: spacename})
+		if err != nil {
+			return r.wrapErrorWithStatusUpdateForClusterResourceFailure(ctx, nsTmplSet, err,
+				"failed to process template for the to-be-applied cluster resources with the name '%s'", newTemplateRef)
+		}
+	}
+	if oldTierTemplate != nil {
+		currentObjects, err = oldTierTemplate.process(r.Scheme, map[string]string{SpaceName: spacename})
+		if err != nil {
+			return r.wrapErrorWithStatusUpdateForClusterResourceFailure(ctx, nsTmplSet, err,
+				"failed to process template for the last-applied cluster resources with the name '%s'", oldTemplateRef)
+		}
+	}
+
+	statusChanged := false
+	firstDeployment := nsTmplSet.Status.ClusterResources == nil || nsTmplSet.Status.ClusterResources.TemplateRef == ""
+	var failureStatusReason statusUpdater
+	if firstDeployment {
+		failureStatusReason = r.setStatusClusterResourcesProvisionFailed
+	} else {
+		failureStatusReason = r.setStatusUpdateFailed
+	}
+
+	changeStatusIfNeeded := func() error {
+		if !statusChanged {
+			if firstDeployment {
+				err = r.setStatusProvisioningIfNotUpdating(ctx, nsTmplSet)
+			} else {
+				err = r.setStatusUpdatingIfNotProvisioning(ctx, nsTmplSet)
+			}
+			if err != nil {
+				return err
+			}
+			statusChanged = true
+		}
+		return nil
+	}
+
+	for _, newObj := range newObjs {
+		if !shouldCreate(newObj, nsTmplSet) {
+			continue
+		}
+
+		// by removing the new objects from the current objects, we are going to be left with the objects
+		// that should be removed from the cluster after we're done with this loop
+		for oldIdx, curObj := range currentObjects {
+			if curObj.GetName() == newObj.GetName() && curObj.GetNamespace() == newObj.GetNamespace() && curObj.GetObjectKind().GroupVersionKind() == newObj.GetObjectKind().GroupVersionKind() {
+				currentObjects = slices.Delete(currentObjects, oldIdx, oldIdx+1)
+				break
+			}
+		}
+
+		if err := changeStatusIfNeeded(); err != nil {
+			return err
+		}
+
+		// create or update the resource
+		if _, err = r.apply(ctx, nsTmplSet, newTierTemplate, newObj); err != nil {
+			err := fmt.Errorf("failed to apply changes to the cluster resource %s, %s: %w", newObj.GetName(), newObj.GetObjectKind().GroupVersionKind().String(), err)
+			return r.wrapErrorWithStatusUpdate(ctx, nsTmplSet, failureStatusReason, err, "failure while syncing cluster resources")
+		}
+	}
+
+	// what we're left with here is the list of currently existing objects that are no longer present in the template.
+	// we need to delete them
+	for _, obj := range currentObjects {
+		if err := changeStatusIfNeeded(); err != nil {
+			return err
+		}
+		if err := r.Client.Delete(ctx, obj); err != nil {
+			if !errors.IsNotFound(err) {
+				err := fmt.Errorf("failed to delete the cluster resource %s, %s: %w", obj.GetName(), obj.GetObjectKind().GroupVersionKind().String(), err)
+				return r.wrapErrorWithStatusUpdate(ctx, nsTmplSet, failureStatusReason, err, "failure while syncing cluster resources")
+			}
+		}
+	}
+
+	return nil
 }
 
 // apply creates or updates the given object with the set of toolchain labels. If the apply operation was successful, then it returns 'true, nil',
@@ -195,161 +164,46 @@ func (r *clusterResourcesManager) apply(ctx context.Context, nsTmplSet *toolchai
 	log.FromContext(ctx).Info("applying cluster resource", "object_name", object.GetObjectKind().GroupVersionKind().Kind+"/"+object.GetName())
 	createdOrModified, err := r.ApplyToolchainObjects(ctx, []runtimeclient.Object{object}, labels)
 	if err != nil {
-		return false, errs.Wrapf(err, "failed to apply cluster resource of type '%v'", object.GetObjectKind().GroupVersionKind())
+		return false, errs.Wrapf(err, "failed to apply cluster resource")
 	}
 	return createdOrModified, nil
 }
 
-// updateOrDeleteRedundant takes the given currentObjs and newObjs and compares them.
-//
-// If there is any existing redundant resource (exist in the currentObjs, but not in the newObjs), then it deletes the resource and returns 'true, nil'.
-//
-// If there is any resource that is outdated (exists in both currentObjs and newObjs but its templateref is not matching),
-// then it updates the resource and returns 'true, nil'
-//
-// If no resource to be updated or deleted was found then it returns 'false, nil'. In case of any errors 'false, error'
-func (r *clusterResourcesManager) updateOrDeleteRedundant(ctx context.Context, currentObjs []runtimeclient.Object, newObjs []runtimeclient.Object, tierTemplate *tierTemplate, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
-	// go through all current objects, so we can compare then with the set of the requested and thus update the obsolete ones or delete redundant ones
-	logger := log.FromContext(ctx)
-	logger.Info("updating or deleting cluster resources")
-CurrentObjects:
-	for _, currentObject := range currentObjs {
-
-		// if the template is not specified, then delete all cluster resources one by one
-		if nsTmplSet.Spec.ClusterResources == nil || tierTemplate == nil {
-			return r.deleteClusterResource(ctx, nsTmplSet, currentObject)
-		}
-
-		// check if the object should still exist and should be updated
-		for _, newObject := range newObjs {
-			if newObject.GetName() == currentObject.GetName() {
-				// is found then let's check if the object represents a feature and if yes then the feature is still enabled
-				if !shouldCreate(newObject, nsTmplSet) {
-					break // proceed to deleting the object
-				}
-				// Either it's not a featured object or the feature is still enabled
-				// Do we need to update it?
-				if !isUpToDate(currentObject, newObject, tierTemplate) {
-					logger.Info("updating cluster resource")
-					// let's update it
-					if err := r.setStatusUpdatingIfNotProvisioning(ctx, nsTmplSet); err != nil {
-						return false, err
-					}
-					return r.apply(ctx, nsTmplSet, tierTemplate, newObject)
-				}
-				continue CurrentObjects
-			}
-		}
-		// is not found then let's delete it
-		return r.deleteClusterResource(ctx, nsTmplSet, currentObject)
+// delete deletes all cluster-scoped resources referenced by the nstemplateset.
+func (r *clusterResourcesManager) delete(ctx context.Context, nsTmplSet *toolchainv1alpha1.NSTemplateSet) error {
+	if nsTmplSet.Status.ClusterResources == nil {
+		return nil
 	}
-	return false, nil
-}
 
-// deleteClusterResource sets status to updating, deletes the given resource and returns 'true, nil'. In case of any errors 'false, error'.
-func (r *clusterResourcesManager) deleteClusterResource(ctx context.Context, nsTmplSet *toolchainv1alpha1.NSTemplateSet, toDelete runtimeclient.Object) (bool, error) {
-	log.FromContext(ctx).Info("deleting cluster resource")
-	if err := r.setStatusUpdatingIfNotProvisioning(ctx, nsTmplSet); err != nil {
-		return false, err
+	currentTierTemplate, err := getTierTemplate(ctx, r.GetHostClusterClient, nsTmplSet.Status.ClusterResources.TemplateRef)
+	if err != nil {
+		return r.wrapErrorWithStatusUpdateForClusterResourceFailure(ctx, nsTmplSet, err,
+			"failed to read the existing cluster resources")
 	}
-	if err := r.Client.Delete(ctx, toDelete); err != nil {
-		return false, errs.Wrapf(err, "failed to delete an existing redundant cluster resource of name '%s' and gvk '%v'",
-			toDelete.GetName(), toDelete.GetObjectKind().GroupVersionKind())
+	currentObjects, err := currentTierTemplate.process(r.Scheme, map[string]string{SpaceName: nsTmplSet.Name})
+	if err != nil {
+		return r.wrapErrorWithStatusUpdateForClusterResourceFailure(ctx, nsTmplSet, err,
+			"failed to list existing cluster resources")
 	}
-	return true, nil
-}
 
-// createMissing takes the given currentObjs and newObjs and compares them if there is any that should be created.
-// If such a object is found, then it creates it and returns 'true, nil'. If no missing resource was found then returns 'false, nil'.
-// In case of any error 'false, error'
-func (r *clusterResourcesManager) createMissing(ctx context.Context, currentObjs []runtimeclient.Object, newObjs []runtimeclient.Object, tierTemplate *tierTemplate, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
-	// go through all new (expected) objects to check if all of them already exist or not
-NewObjects:
-	for _, newObject := range newObjs {
-		// Check if the new object is associated with a feature toggle.
-		// If yes then ignore this object if it represents a feature which is not enabled for this NSTemplateSet
-		if !shouldCreate(newObject, nsTmplSet) {
-			continue NewObjects
+	for _, toDelete := range currentObjects {
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: toDelete.GetName()}, toDelete); err != nil && !errors.IsNotFound(err) {
+			return r.wrapErrorWithStatusUpdate(ctx, nsTmplSet, r.setStatusTerminatingFailed, err,
+				"failed to get the cluster resource '%s' (GVK '%s') while deleting cluster resources", toDelete.GetName(), toDelete.GetObjectKind().GroupVersionKind())
+		}
+		// ignore cluster resource that are already flagged for deletion
+		if errors.IsNotFound(err) || util.IsBeingDeleted(toDelete) {
+			continue
 		}
 
-		// go through current objects to check if is one of the new (expected)
-		for _, currentObject := range currentObjs {
-			// if the name is the same, then it means that it already exist so just continue with the next new object
-			if newObject.GetName() == currentObject.GetName() {
-				continue NewObjects
-			}
-		}
-		// if there was no existing object found that would match with the new one, then set the status appropriately
-		namespaces, err := fetchNamespacesByOwner(ctx, r.Client, nsTmplSet.Name)
-		if err != nil {
-			return false, errs.Wrapf(err, "unable to fetch user's namespaces")
-		}
-		// if there is any existing namespace, then set the status to updating
-		if len(namespaces) == 0 {
-			if err := r.setStatusProvisioningIfNotUpdating(ctx, nsTmplSet); err != nil {
-				return false, err
-			}
-		} else {
-			// otherwise, to provisioning
-			if err := r.setStatusUpdatingIfNotProvisioning(ctx, nsTmplSet); err != nil {
-				return false, err
-			}
-		}
-		// and create the object
-		return r.apply(ctx, nsTmplSet, tierTemplate, newObject)
-	}
-	return false, nil
-}
-
-// delete deletes one cluster scoped resource owned by the user and returns 'true, nil'. If no cluster-scoped resource owned
-// by the user is found, then it returns 'false, nil'. In case of any errors 'false, error'
-func (r *clusterResourcesManager) delete(ctx context.Context, nsTmplSet *toolchainv1alpha1.NSTemplateSet) (bool, error) {
-	if nsTmplSet.Spec.ClusterResources == nil {
-		return false, nil
-	}
-	for _, clusterResourceKind := range clusterResourceKinds {
-		// list all existing objects of the cluster resource kind
-		currentObjects, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, r.Client, nsTmplSet.Name, r.AvailableAPIGroups)
-		if err != nil {
-			return false, r.wrapErrorWithStatusUpdateForClusterResourceFailure(ctx, nsTmplSet, err,
-				"failed to list existing cluster resources of GVK '%v'", clusterResourceKind.gvk)
-		}
-
-		for _, toDelete := range currentObjects {
-			if err := r.Client.Get(ctx, types.NamespacedName{Name: toDelete.GetName()}, toDelete); err != nil && !errors.IsNotFound(err) {
-				return false, r.wrapErrorWithStatusUpdate(ctx, nsTmplSet, r.setStatusTerminatingFailed, err,
-					"failed to get current object '%s' while deleting cluster resource of GVK '%s'", toDelete.GetName(), toDelete.GetObjectKind().GroupVersionKind())
-			}
-			// ignore cluster resource that are already flagged for deletion
-			if errors.IsNotFound(err) || util.IsBeingDeleted(toDelete) {
-				continue
-			}
-
-			log.FromContext(ctx).Info("deleting cluster resource", "name", toDelete.GetName(), "kind", toDelete.GetObjectKind().GroupVersionKind().Kind)
-			if err := r.Client.Delete(ctx, toDelete); err != nil && errors.IsNotFound(err) {
-				// ignore case where the resource did not exist anymore, move to the next one to delete
-				continue
-			} else if err != nil {
-				// report an error only if the resource could not be deleted (but ignore if the resource did not exist anymore)
-				return false, r.wrapErrorWithStatusUpdate(ctx, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to delete cluster resource '%s'", toDelete.GetName())
-			}
-			// stop there for now. Will reconcile again for the next cluster resource (if any exists)
-			return true, nil
+		log.FromContext(ctx).Info("deleting cluster resource", "name", toDelete.GetName(), "kind", toDelete.GetObjectKind().GroupVersionKind().Kind)
+		if err := r.Client.Delete(ctx, toDelete); err != nil && errors.IsNotFound(err) {
+			// ignore case where the resource did not exist anymore, move to the next one to delete
+			continue
+		} else if err != nil {
+			// report an error only if the resource could not be deleted (but ignore if the resource did not exist anymore)
+			return r.wrapErrorWithStatusUpdate(ctx, nsTmplSet, r.setStatusTerminatingFailed, err, "failed to delete cluster resource '%s'", toDelete.GetName())
 		}
 	}
-	return false, nil
-}
-
-// isUpToDate returns true if the currentObject uses the corresponding templateRef and tier labels
-func isUpToDate(currentObject, _ runtimeclient.Object, tierTemplate *tierTemplate) bool {
-	return currentObject.GetLabels() != nil &&
-		currentObject.GetLabels()[toolchainv1alpha1.TemplateRefLabelKey] == tierTemplate.templateRef &&
-		currentObject.GetLabels()[toolchainv1alpha1.TierLabelKey] == tierTemplate.tierName
-	// && currentObject.IsSame(newObject)  <-- TODO Uncomment when IsSame is implemented for all ToolchainObjects!
-}
-
-func retainObjectsOfSameGVK(gvk schema.GroupVersionKind) template.FilterFunc {
-	return func(obj runtime.RawExtension) bool {
-		return obj.Object.GetObjectKind().GroupVersionKind() == gvk
-	}
+	return nil
 }

--- a/controllers/nstemplateset/cluster_resources_test.go
+++ b/controllers/nstemplateset/cluster_resources_test.go
@@ -2,15 +2,15 @@ package nstemplateset
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"k8s.io/utils/strings/slices"
 	"strings"
 	"testing"
 	"time"
 
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/strings/slices"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/member-operator/pkg/apis"
 	. "github.com/codeready-toolchain/member-operator/test"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -21,152 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
-
-func TestClusterResourceKinds(t *testing.T) {
-	// given
-	s := scheme.Scheme
-	err := apis.AddToScheme(s)
-	require.NoError(t, err)
-	ctx := context.TODO()
-
-	for _, clusterResourceKind := range clusterResourceKinds {
-		johnyRuntimeObject := clusterResourceKind.object.DeepCopyObject()
-		johnyObject, ok := johnyRuntimeObject.(client.Object)
-		require.True(t, ok)
-		johnyObjectLabels := map[string]string{toolchainv1alpha1.SpaceLabelKey: "johny"}
-		johnyObject.SetLabels(johnyObjectLabels)
-		johnyObject.SetName("johny-object")
-
-		johnyRuntimeObject2 := clusterResourceKind.object.DeepCopyObject()
-		johnyObject2, ok := johnyRuntimeObject2.(client.Object)
-		require.True(t, ok)
-		johnyObject2.SetLabels(johnyObjectLabels)
-		johnyObject2.SetName("johny-object-2")
-
-		anotherRuntimeObject := clusterResourceKind.object.DeepCopyObject()
-		anotherObject, ok := anotherRuntimeObject.(client.Object)
-		require.True(t, ok)
-		anotherObject.SetLabels(map[string]string{toolchainv1alpha1.SpaceLabelKey: "another"})
-		anotherObject.SetName("another-object")
-		namespace := newNamespace("basic", "johny", "code")
-
-		apiGroups := newAPIGroups(newAPIGroup("apps", "v1"), newAPIGroup("", "v1"), newAPIGroup(clusterResourceKind.gvk.Group, clusterResourceKind.gvk.Version))
-
-		t.Run("listExistingResourcesIfAvailable should return one resource of gvk "+clusterResourceKind.gvk.String(), func(t *testing.T) {
-			// given
-			fakeClient := test.NewFakeClient(t, anotherObject, johnyObject, namespace)
-
-			// when
-			existingResources, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, fakeClient, "johny", apiGroups)
-
-			// then
-			require.NoError(t, err)
-			require.Len(t, existingResources, 1)
-			assert.Equal(t, johnyObject, existingResources[0])
-		})
-
-		t.Run("listExistingResourcesIfAvailable should return two resources of gvk "+clusterResourceKind.gvk.String(), func(t *testing.T) {
-			// given
-			fakeClient := test.NewFakeClient(t, anotherObject, johnyObject, johnyObject2, namespace)
-
-			// when
-			existingResources, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, fakeClient, "johny", apiGroups)
-
-			// then
-			require.NoError(t, err)
-			require.Len(t, existingResources, 2)
-			assert.Equal(t, johnyObject, existingResources[0])
-			assert.Equal(t, johnyObject2, existingResources[1])
-		})
-
-		t.Run("listExistingResourcesIfAvailable should return not return any resource of gvk "+clusterResourceKind.gvk.String(), func(t *testing.T) {
-			// given
-			fakeClient := test.NewFakeClient(t, anotherObject, namespace)
-
-			// when
-			existingResources, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, fakeClient, "johny", apiGroups)
-
-			// then
-			require.NoError(t, err)
-			assert.Empty(t, existingResources)
-		})
-
-		t.Run("listExistingResourcesIfAvailable should return an error when listing resources of gvk "+clusterResourceKind.gvk.String(), func(t *testing.T) {
-			// given
-			fakeClient := test.NewFakeClient(t, anotherObject, johnyObject)
-			fakeClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-				return fmt.Errorf("some error")
-			}
-
-			// when
-			existingResources, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, fakeClient, "johny", apiGroups)
-
-			// then
-			require.Error(t, err)
-			assert.Empty(t, existingResources)
-		})
-
-		t.Run("listExistingResourcesIfAvailable should not return any resource when APIGroup is missing for gvk "+clusterResourceKind.gvk.String(), func(t *testing.T) {
-			// given
-			fakeClient := test.NewFakeClient(t, anotherObject, johnyObject, johnyObject2, namespace)
-
-			// when
-			existingResources, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, fakeClient, "johny",
-				newAPIGroups(newAPIGroup("apps", "v1"), newAPIGroup("", "v1")))
-
-			// then
-			require.NoError(t, err)
-			assert.Empty(t, existingResources)
-		})
-
-		t.Run("listExistingResourcesIfAvailable should not return any resource when APIGroup is present but is missing the version "+clusterResourceKind.gvk.String(), func(t *testing.T) {
-			// given
-			fakeClient := test.NewFakeClient(t, anotherObject, johnyObject, johnyObject2, namespace)
-
-			// when
-			existingResources, err := clusterResourceKind.listExistingResourcesIfAvailable(ctx, fakeClient, "johny",
-				newAPIGroups(newAPIGroup("apps", "v1"), newAPIGroup("", "v1"), newAPIGroup(clusterResourceKind.gvk.Group, "old")))
-
-			// then
-			require.NoError(t, err)
-			assert.Empty(t, existingResources)
-		})
-	}
-
-	t.Run("verify ClusterResourceQuota is in clusterResourceKinds", func(t *testing.T) {
-		// given
-		clusterResource := clusterResourceKinds[0]
-
-		// then
-		assert.Equal(t, &quotav1.ClusterResourceQuota{}, clusterResource.object)
-		assert.Equal(t, quotav1.GroupVersion.WithKind("ClusterResourceQuota"), clusterResource.gvk)
-	})
-
-	t.Run("verify ClusterRoleBinding is in clusterResourceKinds", func(t *testing.T) {
-		// given
-		clusterResource := clusterResourceKinds[1]
-
-		// then
-		assert.Equal(t, &rbacv1.ClusterRoleBinding{}, clusterResource.object)
-		assert.Equal(t, rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"), clusterResource.gvk)
-	})
-
-	t.Run("verify Idler is in clusterResourceKinds", func(t *testing.T) {
-		// given
-		clusterResource := clusterResourceKinds[2]
-
-		// then
-		assert.Equal(t, &toolchainv1alpha1.Idler{}, clusterResource.object)
-		assert.Equal(t, toolchainv1alpha1.GroupVersion.WithKind("Idler"), clusterResource.gvk)
-	})
-}
 
 func TestEnsureClusterResourcesOK(t *testing.T) {
 	// given
@@ -179,6 +37,23 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
 	t.Cleanup(restore)
+
+	t.Run("should set status to provisioning", func(t *testing.T) {
+		// given
+		manager, failingClient := prepareClusterResourcesManager(t, nsTmplSet)
+
+		err := manager.ensure(ctx, nsTmplSet)
+
+		require.NoError(t, err)
+		AssertThatNSTemplateSet(t, namespaceName, spacename, failingClient).
+			HasFinalizer().
+			HasConditions(Provisioning())
+		AssertThatCluster(t, failingClient).
+			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+			HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+			HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
+			HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{})
+	})
 
 	t.Run("should create only CRQs and set status to provisioning", func(t *testing.T) {
 		tests := []struct {
@@ -225,69 +100,31 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 				}
 				manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
 
-				t.Run("first iteration - create first resource with no feature", func(t *testing.T) {
-					// when
+				// when
+				err := manager.ensure(ctx, nsTmplSet)
 
-					// Each iteration of ensure() applies a single object only (if any) and exists after that.
-					// Assuming that the controller would watch the created resources and would trigger another reconcile/ensure()
-					// to apply all the objects one by one.
-					// So the first iteration always creates the first ClusterResourceQuota with no feature only.
-					// Even if the features are enabled.
-					createdOrUpdated, err := manager.ensure(ctx, nsTmplSet)
+				// then
+				require.NoError(t, err)
+				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
+					HasFinalizer().
+					HasConditions(Provisioning())
 
-					// then
-					require.NoError(t, err)
-					assert.True(t, createdOrUpdated)
-					AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
-						HasFinalizer().
-						HasConditions(Provisioning())
-					AssertThatCluster(t, fakeClient).
-						HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-						HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
-						HasNoResource("feature-1-for-"+spacename, &quotav1.ClusterResourceQuota{}).
-						HasNoResource("feature-2-for-"+spacename, &quotav1.ClusterResourceQuota{}).
-						HasNoResource("feature-3-for-"+spacename, &quotav1.ClusterResourceQuota{})
+				// check that the resources not guarded by a feature gate are there
+				clusterAssertion := AssertThatCluster(t, fakeClient).
+					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+					HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
+					HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{})
 
-					// Now, do another iteration and make sure the corresponding objects are created for each enabled feature
-					enabledFeatures := strings.Split(testRun.enabledFeatures, ",")
-					expectedFeatureToBeAlreadyCreated := make([]string, 0)
-					for _, feature := range enabledFeatures {
-						expectedFeatureToBeAlreadyCreated = append(expectedFeatureToBeAlreadyCreated, feature)
-						t.Run(fmt.Sprintf("next iteration - create resource for feature %s if enabled", feature), func(t *testing.T) {
-							// when
-							createdOrUpdated, err := manager.ensure(ctx, nsTmplSet)
-
-							// then
-							require.NoError(t, err)
-							assert.True(t, createdOrUpdated)
-							AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
-								HasFinalizer().
-								HasConditions(Provisioning())
-							if testRun.enabledFeatures == "" {
-								AssertThatCluster(t, fakeClient).
-									HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-									HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
-									HasNoResource("feature-1-for-"+spacename, &quotav1.ClusterResourceQuota{}).
-									HasNoResource("feature-2-for-"+spacename, &quotav1.ClusterResourceQuota{}).
-									HasNoResource("feature-3-for-"+spacename, &quotav1.ClusterResourceQuota{})
-							} else {
-								clusterAssertion := AssertThatCluster(t, fakeClient).
-									HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
-									HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{})
-								// Check all expected features which should be already created by this and previous iterations
-								for _, expectedFeature := range expectedFeatureToBeAlreadyCreated {
-									clusterAssertion.HasResource(fmt.Sprintf("%s-for-%s", expectedFeature, spacename), &quotav1.ClusterResourceQuota{})
-								}
-								// Check that the rest of the features are not (yet) created
-								for _, tierFeature := range allTierFeatures {
-									if !slices.Contains(expectedFeatureToBeAlreadyCreated, tierFeature) {
-										clusterAssertion.HasNoResource(fmt.Sprintf("%s-for-%s", tierFeature, spacename), &quotav1.ClusterResourceQuota{})
-									}
-								}
-							}
-						})
+				// check that only the resources for the enabled features were deployed
+				enabledFeatures := strings.Split(testRun.enabledFeatures, ",")
+				for _, f := range allTierFeatures {
+					if slices.Contains(enabledFeatures, f) {
+						clusterAssertion.HasResource(fmt.Sprintf("%s-for-%s", f, spacename), &quotav1.ClusterResourceQuota{})
+					} else {
+						clusterAssertion.HasNoResource(fmt.Sprintf("%s-for-%s", f, spacename), &quotav1.ClusterResourceQuota{})
 					}
-				})
+				}
 			})
 		}
 	})
@@ -298,72 +135,23 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
 
 		// when
-		createdOrUpdated, err := manager.ensure(ctx, nsTmplSet)
+		err := manager.ensure(ctx, nsTmplSet)
 
 		// then
 		require.NoError(t, err)
-		assert.False(t, createdOrUpdated)
 		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasSpecNamespaces("dev").
 			HasNoConditions()
 	})
 
-	t.Run("should create only one CRQ when the template contains two CRQs", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
-
-		// when
-		createdOrUpdated, err := manager.ensure(ctx, nsTmplSet)
-
-		// then
-		require.NoError(t, err)
-		assert.True(t, createdOrUpdated)
-		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
-			HasFinalizer().
-			HasConditions(Provisioning())
-		AssertThatCluster(t, fakeClient).
-			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-			HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-		t.Run("should create the second CRQ when the first one is already created but still not ClusterRoleBinding", func(t *testing.T) {
-			// when
-			createdOrUpdated, err := manager.ensure(ctx, nsTmplSet)
-
-			// then
-			require.NoError(t, err)
-			assert.True(t, createdOrUpdated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
-				HasFinalizer().
-				HasConditions(Provisioning())
-			AssertThatCluster(t, fakeClient).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-				HasResource("for-empty", &quotav1.ClusterResourceQuota{}).
-				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-			t.Run("should create ClusterRoleBinding when both CRQs are created", func(t *testing.T) {
-				// when
-				createdOrUpdated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, createdOrUpdated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
-					HasFinalizer().
-					HasConditions(Provisioning())
-				AssertThatCluster(t, fakeClient).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-					HasResource("for-empty", &quotav1.ClusterResourceQuota{}).
-					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-			})
-		})
-	})
-
 	t.Run("should not do anything when all cluster resources are already created", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"), withConditions(Provisioned()))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced",
+			withNamespaces("abcde11", "dev"),
+			withClusterResources("abcde11"),
+			withPreviouslyAppliedClusterResources("abcde11"),
+			withConditions(Provisioned()))
 		crq := newClusterResourceQuota(spacename, "advanced")
 		crb := newTektonClusterRoleBinding(spacename, "advanced")
 		idlerDev := newIdler(spacename, spacename+"-dev", "advanced")
@@ -371,11 +159,10 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, idlerDev, idlerStage)
 
 		// when
-		createdOrUpdated, err := manager.ensure(ctx, nsTmplSet)
+		err := manager.ensure(ctx, nsTmplSet)
 
 		// then
 		require.NoError(t, err)
-		assert.False(t, createdOrUpdated)
 		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(Provisioned())
@@ -388,7 +175,6 @@ func TestEnsureClusterResourcesOK(t *testing.T) {
 }
 
 func TestEnsureClusterResourcesFail(t *testing.T) {
-
 	// given
 	logger := zap.New(zap.UseDevMode(true))
 	log.SetLogger(logger)
@@ -400,35 +186,17 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
 	t.Cleanup(restore)
 
-	t.Run("fail to list cluster resources", func(t *testing.T) {
-		// given
-		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
-		fakeClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-			return errors.New("unable to list cluster resources")
-		}
-
-		// when
-		_, err := manager.ensure(ctx, nsTmplSet)
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unable to list cluster resources")
-		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
-			HasFinalizer().
-			HasConditions(UnableToProvisionClusterResources("unable to list cluster resources"))
-	})
-
 	t.Run("fail to get template containing cluster resources", func(t *testing.T) {
 		// given
 		nsTmplSet := newNSTmplSet(namespaceName, spacename, "fail", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
 		manager, fakeClient := prepareClusterResourcesManager(t, nsTmplSet)
 
 		// when
-		_, err := manager.ensure(ctx, nsTmplSet)
+		err := manager.ensure(ctx, nsTmplSet)
 
 		// then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to retrieve TierTemplate for the cluster resources with the name 'fail-clusterresources-abcde11'")
+		assert.Contains(t, err.Error(), "failed to retrieve the TierTemplate for the to-be-applied cluster resources with the name 'fail-clusterresources-abcde11'")
 		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(UnableToProvisionClusterResources(
@@ -443,93 +211,48 @@ func TestEnsureClusterResourcesFail(t *testing.T) {
 		}
 
 		// when
-		_, err := manager.ensure(ctx, nsTmplSet)
+		err := manager.ensure(ctx, nsTmplSet)
 
 		// then
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to create missing cluster resource of GVK 'quota.openshift.io/v1, Kind=ClusterResourceQuota'")
+		assert.Contains(t, err.Error(), "some error")
 		AssertThatNSTemplateSet(t, namespaceName, spacename, fakeClient).
 			HasFinalizer().
 			HasConditions(UnableToProvisionClusterResources(
-				"failed to apply cluster resource of type 'quota.openshift.io/v1, Kind=ClusterResourceQuota': unable to create resource of kind: ClusterResourceQuota, version: v1: unable to create resource of kind: ClusterResourceQuota, version: v1: some error"))
+				"failed to apply changes to the cluster resource for-johnsmith-space, quota.openshift.io/v1, Kind=ClusterResourceQuota: failed to apply cluster resource: unable to create resource of kind: ClusterResourceQuota, version: v1: unable to create resource of kind: ClusterResourceQuota, version: v1: some error"))
 	})
 }
 
 func TestDeleteClusterResources(t *testing.T) {
-
 	// given
 	logger := zap.New(zap.UseDevMode(true))
 	log.SetLogger(logger)
 	ctx := log.IntoContext(context.TODO(), logger)
+	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
+	t.Cleanup(restore)
 	spacename := "johnsmith"
 	namespaceName := "toolchain-member"
 	crq := newClusterResourceQuota(spacename, "advanced")
 	crb := newTektonClusterRoleBinding(spacename, "advanced")
-	nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "code"), withDeletionTs(), withClusterResources("abcde11"))
+	nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev", "code"), withDeletionTs(), withClusterResources("abcde11"), withPreviouslyAppliedClusterResources("abcde11"))
 
-	t.Run("delete only ClusterResourceQuota", func(t *testing.T) {
+	t.Run("deletes all cluster resources", func(t *testing.T) {
 		// given
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
 
 		// when
-		deleted, err := manager.delete(ctx, nsTmplSet)
+		err := manager.delete(ctx, nsTmplSet)
 
 		// then
 		require.NoError(t, err)
-		assert.True(t, deleted)
 		AssertThatCluster(t, cl).
 			HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-			HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-		t.Run("delete ClusterRoleBinding since CRQ is already deleted", func(t *testing.T) {
-			// when
-			deleted, err := manager.delete(ctx, nsTmplSet)
-
-			// then
-			require.NoError(t, err)
-			assert.True(t, deleted)
-			AssertThatCluster(t, cl).
-				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-		})
-	})
-
-	t.Run("should delete only one ClusterResourceQuota even when tier contains more ", func(t *testing.T) {
-		// given
-		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-		crq := newClusterResourceQuota(spacename, "withemptycrq")
-		emptyCrq := newClusterResourceQuota("empty", "withemptycrq")
-		emptyCrq.Labels[toolchainv1alpha1.SpaceLabelKey] = spacename
-		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq, crb)
-
-		// when
-		deleted, err := manager.delete(ctx, nsTmplSet)
-
-		// then
-		require.NoError(t, err)
-		assert.True(t, deleted)
-		AssertThatCluster(t, cl).
-			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-			HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-		t.Run("delete the for-empty CRQ since it's the last one to be deleted", func(t *testing.T) {
-			// when
-			deleted, err := manager.delete(ctx, nsTmplSet)
-
-			// then
-			require.NoError(t, err)
-			assert.True(t, deleted)
-			AssertThatCluster(t, cl).
-				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-				HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-		})
+			HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 	})
 
 	t.Run("delete the second ClusterResourceQuota since the first one has deletion timestamp set", func(t *testing.T) {
 		// given
-		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
+		nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"), withPreviouslyAppliedClusterResources("abcde11"))
 		crq := newClusterResourceQuota(spacename, "withemptycrq", withFinalizer())
 		deletionTS := metav1.NewTime(time.Now())
 		crq.SetDeletionTimestamp(&deletionTS)
@@ -538,11 +261,10 @@ func TestDeleteClusterResources(t *testing.T) {
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, emptyCrq)
 
 		// when
-		deleted, err := manager.delete(ctx, nsTmplSet)
+		err := manager.delete(ctx, nsTmplSet)
 
 		// then
 		require.NoError(t, err)
-		assert.True(t, deleted)
 		AssertThatCluster(t, cl).
 			HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}, HasDeletionTimestamp()).
 			HasNoResource("for-empty", &quotav1.ClusterResourceQuota{})
@@ -556,17 +278,17 @@ func TestDeleteClusterResources(t *testing.T) {
 			withNamespaces("abcde11", "dev", "code"),
 			withDeletionTs(),
 			withClusterResources("abcde11"),
+			withPreviouslyAppliedClusterResources("abcde11"),
 			withNSTemplateSetFeatureAnnotation("feature-2"))
 		crq := newClusterResourceQuota(spacename, "advanced", withFeatureAnnotation("feature-2"), withName("feature-2-for-"+spacename))
 
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 		// when
-		deleted, err := manager.delete(ctx, nsTmplSet)
+		err := manager.delete(ctx, nsTmplSet)
 
 		// then
 		require.NoError(t, err)
-		assert.True(t, deleted)
 		AssertThatCluster(t, cl).
 			HasNoResource(crq.Name, &quotav1.ClusterResourceQuota{})
 	})
@@ -576,11 +298,10 @@ func TestDeleteClusterResources(t *testing.T) {
 		manager, cl := prepareClusterResourcesManager(t, nsTmplSet)
 
 		// when
-		deleted, err := manager.delete(ctx, nsTmplSet)
+		err := manager.delete(ctx, nsTmplSet)
 
 		// then
 		require.NoError(t, err)
-		assert.False(t, deleted)
 		AssertThatCluster(t, cl).
 			HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{})
 	})
@@ -593,11 +314,10 @@ func TestDeleteClusterResources(t *testing.T) {
 		}
 
 		// when
-		deleted, err := manager.delete(ctx, nsTmplSet)
+		err := manager.delete(ctx, nsTmplSet)
 
 		// then
 		require.Error(t, err)
-		assert.False(t, deleted)
 		assert.Equal(t, "failed to delete cluster resource 'for-johnsmith': mock error", err.Error())
 		AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
 			HasFinalizer(). // finalizer was not added and nothing else was done
@@ -606,7 +326,6 @@ func TestDeleteClusterResources(t *testing.T) {
 }
 
 func TestPromoteClusterResources(t *testing.T) {
-
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
 	t.Cleanup(restore)
 
@@ -614,289 +333,163 @@ func TestPromoteClusterResources(t *testing.T) {
 	logger := zap.New(zap.UseDevMode(true))
 	log.SetLogger(logger)
 	ctx := log.IntoContext(context.TODO(), logger)
-	spacename := "johnsmith"
+	spaceName := "johnsmith"
 	namespaceName := "toolchain-member"
-	crb := newTektonClusterRoleBinding(spacename, "advanced")
+	crb := newTektonClusterRoleBinding(spaceName, "advanced")
 
 	t.Run("success", func(t *testing.T) {
-
 		t.Run("upgrade from advanced to team tier by changing only the CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "team", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-			codeNs := newNamespace("advanced", spacename, "code")
-			crq := newClusterResourceQuota(spacename, "advanced")
-			crb := newTektonClusterRoleBinding(spacename, "advanced")
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, codeNs)
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(emptyCrq),
+					test.WithParams(spacename),
+				), "advanced", "clusterresources", "previousrevision")
+			require.NoError(t, err)
+
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "team",
+				withNamespaces("abcde11", "dev"),
+				withClusterResources("abcde11"),
+				withPreviouslyAppliedClusterResourcesInTier("advanced", "previousrevision"))
+			codeNs := newNamespace("advanced", spaceName, "code")
+			crq := newClusterResourceQuota(spaceName, "advanced")
+			emptyCrq := newClusterResourceQuota("empty", "advanced")
+			crb := newTektonClusterRoleBinding(spaceName, "advanced")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, codeNs, previousTierTemplate, emptyCrq)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "team-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "team"),
-					Containing(`"limits.cpu":"4","limits.memory":"15Gi"`)).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
-
-			t.Run("upgrade from advanced to team tier by changing only the CRB since CRQ is already changed", func(t *testing.T) {
-				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, cl).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/tier", "team"),
-						Containing(`"limits.cpu":"4","limits.memory":"15Gi"`)).
-					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-						WithLabel("toolchain.dev.openshift.com/tier", "team"))
-			})
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}).
+				HasNoResource("for-empty", &rbacv1.ClusterRoleBinding{})
 		})
 
-		t.Run("upgrade from base to advanced tier by changing only the tier label - the templateref label doesn't change", func(t *testing.T) {
+		t.Run("promote from 1 tier to another", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-			codeNs := newNamespace("advanced", spacename, "code")
-			crq := newClusterResourceQuota(spacename, "advanced")
-			crq.Labels["toolchain.dev.openshift.com/tier"] = "base"
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(advancedCrq, clusterTektonRb, emptyCrq),
+					test.WithParams(spacename),
+				), "withemptycrq", "clusterresources", "previousrevision")
+			require.NoError(t, err)
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced",
+				withNamespaces("dev"),
+				withClusterResources("abcde11"),
+				withPreviouslyAppliedClusterResourcesInTier("withemptycrq", "previousrevision"))
+			codeNs := newNamespace("advanced", spaceName, "code")
+			crq := newClusterResourceQuota(spaceName, "withemptycrq")
+			crq.Labels["disappearingLabel"] = "value"
 			crq.Spec.Quota.Hard["limits.cpu"] = resource.MustParse("100m")
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, codeNs)
-
-			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
-
-			// then
-			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-				HasFinalizer().
-				HasConditions(Updating())
-			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
-					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`))
-		})
-
-		t.Run("promote from withemptycrq to advanced tier by removing the redundant CRQ", func(t *testing.T) {
-			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("dev"), withClusterResources("abcde11"))
-			codeNs := newNamespace("advanced", spacename, "code")
-			crq := newClusterResourceQuota(spacename, "withemptycrq")
-			crb := newTektonClusterRoleBinding(spacename, "withemptycrq")
-			emptyCrq := newClusterResourceQuota(spacename, "withemptycrq")
+			crb := newTektonClusterRoleBinding(spaceName, "withemptycrq")
+			crb.Labels["disappearingLabel"] = "value"
+			emptyCrq := newClusterResourceQuota(spaceName, "withemptycrq")
 			emptyCrq.Name = "for-empty"
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, emptyCrq, crq, crb, codeNs)
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, emptyCrq, crq, crb, codeNs, previousTierTemplate)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
 				HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "withemptycrq-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "withemptycrq")).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "withemptycrq-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "withemptycrq"))
-
-			t.Run("promote from withemptycrq to advanced tier by changing only the CRQ since redundant CRQ is already removed", func(t *testing.T) {
-				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, cl).
-					HasNoResource("for-empty", &quotav1.ClusterResourceQuota{}).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
-						WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-						WithLabel("toolchain.dev.openshift.com/templateref", "withemptycrq-clusterresources-abcde11"),
-						WithLabel("toolchain.dev.openshift.com/tier", "withemptycrq"))
-
-			})
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{},
+					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`),
+					WithoutLabel("disappearingLabel")).
+				HasResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+					WithoutLabel("disappearingLabel"))
 		})
 
-		t.Run("downgrade from advanced to basic tier by removing CRQ", func(t *testing.T) {
-			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev"))
-			// create namespace (and assume it is complete since it has the expected revision number)
-			crq := newClusterResourceQuota(spacename, "advanced")
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
+		t.Run("promoting to no tier (nil cluster resources in spec) deletes all cluster resources", func(t *testing.T) {
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(advancedCrq, clusterTektonRb),
+					test.WithParams(spacename),
+				), "advanced", "clusterresources", "previousrevision")
+			require.NoError(t, err)
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "withemptycrq", withPreviouslyAppliedClusterResourcesInTier("advanced", "previousrevision"))
+			crq := newClusterResourceQuota(spaceName, "advanced")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, previousTierTemplate)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}). // no cluster resources in 'basic` tier
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-			t.Run("downgrade from advanced to basic tier by removing CRB since CRQ is already removed", func(t *testing.T) {
-				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, cl).
-					HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}). // no cluster resources in 'basic` tier
-					HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-			})
+				HasNoResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}). // resources were deleted
+				HasNoResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 
-		t.Run("delete redundant cluster resources when ClusterResources field is nil in NSTemplateSet", func(t *testing.T) {
-			// given 'advanced' NSTemplate only has a cluster resource
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "withemptycrq") // no cluster resources, so the "advancedCRQ" should be deleted even if the tier contains the "advancedCRQ"
-			crq := newClusterResourceQuota(spacename, "advanced")
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
-
-			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
-
-			// then
-			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-				HasFinalizer().
-				HasConditions(Updating())
-			AssertThatCluster(t, cl).
-				HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}). // resources were deleted
-				HasNoResource("tekton-view-for-"+spacename, &rbacv1.ClusterRole{}).
-				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-		})
-
-		t.Run("upgrade from basic to advanced by creating only CRQ", func(t *testing.T) {
+		t.Run("promote to a new tier with a new feature enabled", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withClusterResources("abcde11"))
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet)
-
-			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
-
-			// then
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(advancedCrq, clusterTektonRb),
+					test.WithParams(spacename),
+				), "team", "clusterresources", "previousrevision")
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-				HasFinalizer().
-				HasConditions(Provisioning())
-			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
-					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)).
-				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-			t.Run("upgrade from basic to advanced by creating CRB since CRQ is already created", func(t *testing.T) {
-				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-					HasFinalizer().
-					HasConditions(Provisioning())
-				AssertThatCluster(t, cl).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
-						Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)).
-					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-						WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
-			})
-		})
-
-		t.Run("upgrade from team to advanced with enabled features by updating existing CRQ", func(t *testing.T) {
-			// given
 			nsTmplSet := newNSTmplSet(namespaceName,
-				spacename,
+				spaceName,
 				"advanced",
 				withClusterResources("abcde11"),
+				withPreviouslyAppliedClusterResourcesInTier("team", "previousrevision"),
 				withNSTemplateSetFeatureAnnotation("feature-1"))
-			devNs := newNamespace("team", spacename, "dev")
-			crq := newClusterResourceQuota(spacename, "team")
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, devNs)
+			devNs := newNamespace("team", spaceName, "dev")
+			crq := newClusterResourceQuota(spaceName, "team")
+			crq.Spec.Quota.Hard["limits.cpu"] = resource.MustParse("100m")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, devNs, previousTierTemplate)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced"),
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{},
 					Containing(`"limits.cpu":"2","limits.memory":"10Gi"`)).
-				HasNoResource("feature-1-for-"+spacename, &quotav1.ClusterResourceQuota{})
-
-			t.Run("upgrade from team to advanced by creating featured CRQ since regular CRQ is already created", func(t *testing.T) {
-				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-					HasFinalizer().
-					HasConditions(Updating())
-				AssertThatCluster(t, cl).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-					HasResource("feature-1-for-"+spacename, &quotav1.ClusterResourceQuota{})
-			})
+				HasResource("feature-1-for-"+spaceName, &quotav1.ClusterResourceQuota{})
 		})
 
-		t.Run("downgrade from advanced to team with featured CRQ to be deleted", func(t *testing.T) {
+		t.Run("promote to a new tier with feature enabled", func(t *testing.T) {
 			// given
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(advancedCrq, clusterTektonRb, crqFeature1),
+					test.WithParams(spacename),
+				), "advanced", "clusterresources", "previousrevision")
+			require.NoError(t, err)
 			nsTmplSet := newNSTmplSet(namespaceName,
-				spacename,
+				spaceName,
 				"team",
 				withClusterResources("abcde11"),
+				withPreviouslyAppliedClusterResourcesInTier("advanced", "previousrevision"),
 				withNSTemplateSetFeatureAnnotation("feature-1"))
-			devNs := newNamespace("advanced", spacename, "dev")
-			crq := newClusterResourceQuota(spacename, "advanced", withFeatureAnnotation("feature-1"), withName("feature-1-for-"+spacename))
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, devNs)
+			devNs := newNamespace("advanced", spaceName, "dev")
+			crq := newClusterResourceQuota(spaceName, "advanced", withFeatureAnnotation("feature-1"), withName("feature-1-for-"+spaceName))
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, devNs, previousTierTemplate)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
 				HasConditions(Updating())
 			AssertThatCluster(t, cl).
@@ -906,184 +499,132 @@ func TestPromoteClusterResources(t *testing.T) {
 		t.Run("with another user", func(t *testing.T) {
 			// given
 			anotherNsTmplSet := newNSTmplSet(namespaceName, "another-user", "basic")
-			advancedCRQ := newClusterResourceQuota(spacename, "advanced")
+			advancedCRQ := newClusterResourceQuota(spaceName, "advanced")
 			anotherCRQ := newClusterResourceQuota("another-user", "basic")
 			anotherCrb := newTektonClusterRoleBinding("another", "basic")
 
-			idlerDev := newIdler(spacename, spacename+"-dev", "advanced")
-			idlerStage := newIdler(spacename, spacename+"-stage", "advanced")
+			idlerDev := newIdler(spaceName, spaceName+"-dev", "advanced")
+			idlerStage := newIdler(spaceName, spaceName+"-stage", "advanced")
 			anotherIdlerDev := newIdler("another", "another-dev", "advanced")
 			anotherIdlerStage := newIdler("another", "another-stage", "advanced")
 
 			t.Run("no redundant cluster resources to be deleted for the given user", func(t *testing.T) {
 				// given
-				nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withConditions(Provisioned()), withClusterResources("abcde11"))
+				nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced", withConditions(Provisioned()), withClusterResources("abcde11"), withPreviouslyAppliedClusterResources("abcde11"))
 				manager, cl := prepareClusterResourcesManager(t, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ, anotherCrb, crb, idlerDev, idlerStage, anotherIdlerDev, anotherIdlerStage)
 
 				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
+				err := manager.ensure(ctx, nsTmplSet)
 
 				// then
 				require.NoError(t, err)
-				assert.False(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 					HasFinalizer().
 					HasConditions(Provisioned())
 				AssertThatCluster(t, cl).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
+					HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}).
 					HasResource("for-another-user", &quotav1.ClusterResourceQuota{}).
-					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+					HasResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
 					HasResource("another-tekton-view", &rbacv1.ClusterRoleBinding{}).
-					HasResource(spacename+"-dev", &toolchainv1alpha1.Idler{}).
-					HasResource(spacename+"-stage", &toolchainv1alpha1.Idler{}).
+					HasResource(spaceName+"-dev", &toolchainv1alpha1.Idler{}).
+					HasResource(spaceName+"-stage", &toolchainv1alpha1.Idler{}).
 					HasResource("another-dev", &toolchainv1alpha1.Idler{}).
 					HasResource("another-stage", &toolchainv1alpha1.Idler{})
 			})
 
-			t.Run("cluster resources should be deleted since it doesn't contain clusterResources template", func(t *testing.T) {
+			t.Run("promoting to no tier should delete only the resources belonging to the nstemplateset", func(t *testing.T) {
 				// given
-				nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withConditions(Provisioned()))
-				manager, cl := prepareClusterResourcesManager(t, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ, anotherCrb, crb)
+				previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+					test.CreateTemplate(
+						test.WithObjects(advancedCrq, clusterTektonRb, crqFeature1),
+						test.WithParams(spacename),
+					), "advanced", "clusterresources", "previousrevision")
+				require.NoError(t, err)
+				nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced", withConditions(Provisioned()), withPreviouslyAppliedClusterResources("previousrevision"))
+				manager, cl := prepareClusterResourcesManager(t, anotherNsTmplSet, anotherCRQ, nsTmplSet, advancedCRQ, anotherCrb, crb, previousTierTemplate)
 
-				// when - let remove everything
-				var err error
-				updated := true
-				for ; updated; updated, err = manager.ensure(ctx, nsTmplSet) {
-					require.NoError(t, err)
-				}
+				err = manager.ensure(ctx, nsTmplSet)
 
 				// then
 				require.NoError(t, err)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+				AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 					HasFinalizer().
 					HasConditions(Updating())
 				AssertThatCluster(t, cl).
-					HasNoResource("for-"+spacename, &quotav1.ClusterResourceQuota{}).
-					HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
+					HasNoResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}).
+					HasNoResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{}).
 					HasResource("for-another-user", &quotav1.ClusterResourceQuota{}).
 					HasResource("another-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-			})
-		})
-
-		t.Run("delete only one redundant cluster resource during one call", func(t *testing.T) {
-			// given 'advanced' NSTemplate only has a cluster resource
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic") // no cluster resources, so the "advancedCRQ" should be deleted
-			advancedCRQ := newClusterResourceQuota(spacename, "withemptycrq")
-			anotherCRQ := newClusterResourceQuota(spacename, "withemptycrq")
-			crb := newTektonClusterRoleBinding(spacename, "withemptycrq")
-			anotherCRQ.Name = "for-empty"
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, advancedCRQ, anotherCRQ, crb)
-
-			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
-
-			// then
-			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
-				HasFinalizer().
-				HasConditions(Updating()) //
-			quotas := &quotav1.ClusterResourceQuotaList{}
-			err = cl.List(context.TODO(), quotas, &client.ListOptions{})
-			require.NoError(t, err)
-			assert.Len(t, quotas.Items, 1)
-			AssertThatCluster(t, cl).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-			t.Run("it should delete the second for-empty CRQ since it's the last one", func(t *testing.T) {
-				// when - should delete the second ClusterResourceQuota
-				updated, err = manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				err = cl.List(context.TODO(), quotas, &client.ListOptions{})
-				require.NoError(t, err)
-				assert.Empty(t, quotas.Items)
-				AssertThatCluster(t, cl).
-					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-				t.Run("it should delete the CRB since both CRQs are already removed", func(t *testing.T) {
-					// when - should delete the second ClusterResourceQuota
-					updated, err = manager.ensure(ctx, nsTmplSet)
-
-					// then
-					require.NoError(t, err)
-					assert.True(t, updated)
-					err = cl.List(context.TODO(), quotas, &client.ListOptions{})
-					require.NoError(t, err)
-					assert.Empty(t, quotas.Items)
-					roleBindings := &rbacv1.ClusterRoleBindingList{}
-					err = cl.List(context.TODO(), roleBindings, &client.ListOptions{})
-					require.NoError(t, err)
-					assert.Empty(t, roleBindings.Items)
-				})
 			})
 		})
 	})
 
 	t.Run("failure", func(t *testing.T) {
-
-		t.Run("promotion to another tier fails because it cannot list current resources", func(t *testing.T) {
+		t.Run("promotion to another tier fails because it cannot create resources", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev"), withConditions(Updating()))
-			crq := newClusterResourceQuota(spacename, "fail")
-			crb := newTektonClusterRoleBinding(spacename, "fail")
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
-			cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(advancedCrq),
+					test.WithParams(spacename),
+				), "fail", "clusterresources", "previousrevision")
+			require.NoError(t, err)
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced",
+				withNamespaces("abcde11", "dev"),
+				withConditions(Updating()),
+				withClusterResources("abcde11"),
+				withPreviouslyAppliedClusterResourcesInTier("fail", "previousrevision"))
+			crq := newClusterResourceQuota(spaceName, "fail")
+			crb := newTektonClusterRoleBinding(spaceName, "fail")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, previousTierTemplate)
+			cl.MockCreate = func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 				return fmt.Errorf("some error")
 			}
 
 			// when
-			_, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.Error(t, err)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
-				HasConditions(UpdateFailed("some error"))
+				HasConditions(UpdateFailed("failed to apply changes to the cluster resource johnsmith-dev, toolchain.dev.openshift.com/v1alpha1, Kind=Idler: failed to apply cluster resource: unable to create resource of kind: Idler, version: v1alpha1: unable to create resource of kind: Idler, version: v1alpha1: some error"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "fail-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "fail")).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "fail-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "fail"))
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}).
+				HasResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 
 		t.Run("fail to downgrade from advanced to basic tier", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "basic", withNamespaces("abcde11", "dev"))
-			crq := newClusterResourceQuota(spacename, "advanced")
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(advancedCrq),
+					test.WithParams(spacename),
+				), "advanced", "clusterresources", "previousrevision")
+			require.NoError(t, err)
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "basic", withNamespaces("abcde11", "dev"), withPreviouslyAppliedClusterResourcesInTier("advanced", "previousrevision"))
+			crq := newClusterResourceQuota(spaceName, "advanced")
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, previousTierTemplate)
 			cl.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 				return fmt.Errorf("some error")
 			}
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.Error(t, err)
-			assert.False(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
 				HasConditions(UpdateFailed(
-					"failed to delete an existing redundant cluster resource of name 'for-johnsmith' and gvk 'quota.openshift.io/v1, Kind=ClusterResourceQuota': some error"))
+					"failed to delete the cluster resource for-johnsmith, quota.openshift.io/v1, Kind=ClusterResourceQuota: some error"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced")).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"),
-					WithLabel("toolchain.dev.openshift.com/tier", "advanced"))
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}).
+				HasResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 	})
 }
 
 func TestUpdateClusterResources(t *testing.T) {
-
 	restore := test.SetEnvVarAndRestore(t, commonconfig.WatchNamespaceEnvVar, "my-member-operator-namespace")
 	t.Cleanup(restore)
 
@@ -1091,66 +632,48 @@ func TestUpdateClusterResources(t *testing.T) {
 	logger := zap.New(zap.UseDevMode(true))
 	log.SetLogger(logger)
 	ctx := log.IntoContext(context.TODO(), logger)
-	spacename := "johnsmith"
+	spaceName := "johnsmith"
 	namespaceName := "toolchain-member"
-	crb := newTektonClusterRoleBinding(spacename, "advanced")
-	crq := newClusterResourceQuota(spacename, "advanced")
+	crb := newTektonClusterRoleBinding(spaceName, "advanced")
+	crq := newClusterResourceQuota(spaceName, "advanced")
 
 	t.Run("success", func(t *testing.T) {
-
 		t.Run("update from abcde11 revision to abcde12 revision as part of the advanced tier by updating CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde12", "dev"), withClusterResources("abcde12"))
-			codeNs := newNamespace("advanced", spacename, "dev")
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced", withNamespaces("abcde12", "dev"), withClusterResources("abcde12"), withPreviouslyAppliedClusterResources("abcde11"))
+			codeNs := newNamespace("advanced", spaceName, "dev")
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb, codeNs)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err := manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12")).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"))
-
-			t.Run("update from abcde11 revision to abcde12 revision by deleting CRB since CRQ is already changed", func(t *testing.T) {
-				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
-				AssertThatCluster(t, cl).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde12")).
-					HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-			})
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}).
+				HasNoResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 
 		t.Run("update from abcde11 revision to abcde12 revision as part of the advanced tier by deleting featured CRQ", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName,
-				spacename,
+				spaceName,
 				"advanced",
 				withNamespaces("abcde12", "dev"),
 				withClusterResources("abcde12"),
+				withPreviouslyAppliedClusterResources("abcde11"),
 				withNSTemplateSetFeatureAnnotation("feature-1"))
-			codeNs := newNamespace("advanced", spacename, "dev")
-			crqFeatured := newClusterResourceQuota(spacename, "advanced", withName("feature-1-for-"+spacename), withFeatureAnnotation("feature-1"))
+			codeNs := newNamespace("advanced", spaceName, "dev")
+			crqFeatured := newClusterResourceQuota(spaceName, "advanced", withName("feature-1-for-"+spaceName), withFeatureAnnotation("feature-1"))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crqFeatured, codeNs)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err := manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).HasConditions(Updating())
 			AssertThatCluster(t, cl).
 				HasNoResource(crqFeatured.Name, &quotav1.ClusterResourceQuota{})
 		})
@@ -1158,26 +681,26 @@ func TestUpdateClusterResources(t *testing.T) {
 		t.Run("update from abcde12 revision to abcde11 by restoring featured CRQ", func(t *testing.T) {
 			// given
 			nsTmplSet := newNSTmplSet(namespaceName,
-				spacename,
+				spaceName,
 				"advanced",
 				withNamespaces("abcde11", "dev"),
 				withClusterResources("abcde11"),
+				withPreviouslyAppliedClusterResources("abcde12"),
 				withNSTemplateSetFeatureAnnotation("feature-1"))
-			codeNs := newNamespace("advanced", spacename, "dev")
-			crqFeatured := newClusterResourceQuota(spacename,
+			codeNs := newNamespace("advanced", spaceName, "dev")
+			crqFeatured := newClusterResourceQuota(spaceName,
 				"advanced",
-				withName("feature-1-for-"+spacename),
+				withName("feature-1-for-"+spaceName),
 				withTemplateRefUsingRevision("abcde12"),
 				withFeatureAnnotation("feature-1"))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crqFeatured, codeNs)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err := manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).HasConditions(Updating())
 			AssertThatCluster(t, cl).
 				HasResource(crqFeatured.Name, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"))
@@ -1185,82 +708,69 @@ func TestUpdateClusterResources(t *testing.T) {
 
 		t.Run("update from abcde12 revision to abcde11 revision as part of the advanced tier by updating CRQ", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"))
-			crq := newClusterResourceQuota(spacename, "advanced", withTemplateRefUsingRevision("abcde12"))
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced", withNamespaces("abcde11", "dev"), withClusterResources("abcde11"), withPreviouslyAppliedClusterResources("abcde12"))
+			crq := newClusterResourceQuota(spaceName, "advanced", withTemplateRefUsingRevision("abcde12"))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err := manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).HasConditions(Updating())
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
-
-			t.Run("update from abcde12 revision to abcde11 revision as part of the advanced tier by creating CRB", func(t *testing.T) {
-				// when
-				updated, err := manager.ensure(ctx, nsTmplSet)
-
-				// then
-				require.NoError(t, err)
-				assert.True(t, updated)
-				AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
-				AssertThatCluster(t, cl).
-					HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
-						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-					HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
-						WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"))
-			})
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{}).
+				HasResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 	})
 
 	t.Run("failure", func(t *testing.T) {
-
 		t.Run("update to abcde11 fails because it cannot list current resources", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withClusterResources("abcde11"), withConditions(Updating()))
-			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq)
-			cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+				test.CreateTemplate(
+					test.WithObjects(advancedCrq),
+					test.WithParams(spacename),
+				), "advanced", "clusterresources", "previousrevision")
+			require.NoError(t, err)
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced", withClusterResources("abcde11"), withConditions(Updating()), withPreviouslyAppliedClusterResources("previousrevision"))
+			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, previousTierTemplate)
+			cl.MockCreate = func(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 				return fmt.Errorf("some error")
 			}
 
 			// when
-			_, err := manager.ensure(ctx, nsTmplSet)
+			err = manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.Error(t, err)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
-				HasConditions(UpdateFailed("some error"))
+				HasConditions(UpdateFailed("failed to apply changes to the cluster resource johnsmith-tekton-view, rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding: failed to apply cluster resource: unable to create resource of kind: ClusterRoleBinding, version: v1: unable to create resource of kind: ClusterRoleBinding, version: v1: some error"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-				HasNoResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{})
+				HasNoResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{})
 		})
 
 		t.Run("update to abcde13 fails because it find the template", func(t *testing.T) {
 			// given
-			nsTmplSet := newNSTmplSet(namespaceName, spacename, "advanced", withClusterResources("abcde13"), withConditions(Updating()))
+			nsTmplSet := newNSTmplSet(namespaceName, spaceName, "advanced", withClusterResources("abcde13"), withConditions(Updating()))
 			manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crq, crb)
 
 			// when
-			updated, err := manager.ensure(ctx, nsTmplSet)
+			err := manager.ensure(ctx, nsTmplSet)
 
 			// then
 			require.Error(t, err)
-			assert.False(t, updated)
-			AssertThatNSTemplateSet(t, namespaceName, spacename, cl).
+			AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).
 				HasFinalizer().
 				HasConditions(UpdateFailed(
 					"unable to retrieve the TierTemplate 'advanced-clusterresources-abcde13' from 'Host' cluster: tiertemplates.toolchain.dev.openshift.com \"advanced-clusterresources-abcde13\" not found"))
 			AssertThatCluster(t, cl).
-				HasResource("for-"+spacename, &quotav1.ClusterResourceQuota{},
+				HasResource("for-"+spaceName, &quotav1.ClusterResourceQuota{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11")).
-				HasResource(spacename+"-tekton-view", &rbacv1.ClusterRoleBinding{},
+				HasResource(spaceName+"-tekton-view", &rbacv1.ClusterRoleBinding{},
 					WithLabel("toolchain.dev.openshift.com/templateref", "advanced-clusterresources-abcde11"))
 		})
 	})
@@ -1274,76 +784,33 @@ func TestDeleteFeatureFromNSTemplateSet(t *testing.T) {
 	logger := zap.New(zap.UseDevMode(true))
 	log.SetLogger(logger)
 	ctx := log.IntoContext(context.TODO(), logger)
-	spacename := "johnsmith"
+	spaceName := "johnsmith"
 	namespaceName := "toolchain-member"
 
+	previousTierTemplate, err := createTierTemplate(scheme.Codecs.UniversalDeserializer(),
+		test.CreateTemplate(
+			test.WithObjects(advancedCrq, crqFeature1),
+			test.WithParams(spacename),
+		), "advanced", "clusterresources", "previousrevision")
+	require.NoError(t, err)
+
 	nsTmplSet := newNSTmplSet(namespaceName,
-		spacename,
+		spaceName,
 		"advanced",
 		withNamespaces("abcde11", "dev"),
-		withClusterResources("abcde11")) // The NSTemplateSet does not have the feature annotation (anymore)
-	codeNs := newNamespace("advanced", spacename, "dev")
-	crqFeatured := newClusterResourceQuota(spacename, "advanced", withName("feature-1-for-"+spacename), withFeatureAnnotation("feature-1"))
-	manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crqFeatured, codeNs)
+		withClusterResources("abcde11"),
+		withPreviouslyAppliedClusterResources("previousrevision"),
+	) // The NSTemplateSet does not have the feature annotation (anymore)
+	codeNs := newNamespace("advanced", spaceName, "dev")
+	crqFeatured := newClusterResourceQuota(spaceName, "advanced", withName("feature-1-for-"+spaceName), withFeatureAnnotation("feature-1"))
+	manager, cl := prepareClusterResourcesManager(t, nsTmplSet, crqFeatured, codeNs, previousTierTemplate)
 
 	// when
-	updated, err := manager.ensure(ctx, nsTmplSet)
+	err = manager.ensure(ctx, nsTmplSet)
 
 	// then
 	require.NoError(t, err)
-	assert.True(t, updated)
-	AssertThatNSTemplateSet(t, namespaceName, spacename, cl).HasConditions(Updating())
+	AssertThatNSTemplateSet(t, namespaceName, spaceName, cl).HasConditions(Updating())
 	AssertThatCluster(t, cl).
 		HasNoResource(crqFeatured.Name, &quotav1.ClusterResourceQuota{}) // The featured object is now deleted because the feature was disabled in the NSTemplateSet
-}
-
-func TestRetainObjectsOfSameGVK(t *testing.T) {
-	// given
-	clusterRole := runtime.RawExtension{Object: &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind":       "ClusterRole",
-			"apiVersion": "rbac.authorization.k8s.io/v1",
-		}}}
-
-	namespace := runtime.RawExtension{Object: &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind":       "Namespace",
-			"apiVersion": "v1",
-		}}}
-	clusterResQuota := runtime.RawExtension{Object: &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind":       "ClusterResourceQuota",
-			"apiVersion": "quota.openshift.io/v1",
-		}}}
-	clusterRoleBinding := runtime.RawExtension{Object: &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind":       "ClusterRoleBinding",
-			"apiVersion": "rbac.authorization.k8s.io/v1",
-		}}}
-
-	t.Run("verify retainObjectsOfSameGVK function for ClusterRole", func(t *testing.T) {
-		// given
-		retain := retainObjectsOfSameGVK(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
-
-		t.Run("should return false since the GVK doesn't match", func(t *testing.T) {
-			for _, obj := range []runtime.RawExtension{namespace, clusterResQuota, clusterRoleBinding} {
-
-				// when
-				ok := retain(obj)
-
-				// then
-				assert.False(t, ok)
-
-			}
-		})
-
-		t.Run("should return true since the GVK matches", func(t *testing.T) {
-
-			// when
-			ok := retain(clusterRole)
-
-			// then
-			assert.True(t, ok)
-		})
-	})
 }

--- a/controllers/nstemplateset/nstemplateset_controller_test.go
+++ b/controllers/nstemplateset/nstemplateset_controller_test.go
@@ -1750,6 +1750,22 @@ func withClusterResources(revision string) nsTmplSetOption {
 	}
 }
 
+func withPreviouslyAppliedClusterResources(revision string) nsTmplSetOption {
+	return func(nsTmplSet *toolchainv1alpha1.NSTemplateSet) {
+		nsTmplSet.Status.ClusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
+			TemplateRef: NewTierTemplateName(nsTmplSet.Spec.TierName, "clusterresources", revision),
+		}
+	}
+}
+
+func withPreviouslyAppliedClusterResourcesInTier(tierName, revision string) nsTmplSetOption {
+	return func(nsTmplSet *toolchainv1alpha1.NSTemplateSet) {
+		nsTmplSet.Status.ClusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
+			TemplateRef: NewTierTemplateName(tierName, "clusterresources", revision),
+		}
+	}
+}
+
 func withSpaceRoles(roles map[string][]string) nsTmplSetOption {
 	return func(nsTmplSet *toolchainv1alpha1.NSTemplateSet) {
 		nsTmplSet.Spec.SpaceRoles = make([]toolchainv1alpha1.NSTemplateSetSpaceRole, 0, len(roles))

--- a/test/cluster_assertion.go
+++ b/test/cluster_assertion.go
@@ -50,6 +50,13 @@ func WithLabel(key, value string) ResourceOption {
 	}
 }
 
+func WithoutLabel(key string) ResourceOption {
+	return func(t test.T, obj client.Object) {
+		_, exists := obj.GetLabels()[key]
+		assert.False(t, exists)
+	}
+}
+
 func Containing(value string) ResourceOption {
 	return func(t test.T, obj client.Object) {
 		content, err := json.Marshal(obj)

--- a/test/nstemplateset_assertion.go
+++ b/test/nstemplateset_assertion.go
@@ -160,8 +160,16 @@ func (a *NSTemplateSetAssertion) HasTierName(tierName string) *NSTemplateSetAsse
 func (a *NSTemplateSetAssertion) HasClusterResourcesTemplateRef(templateRef string) *NSTemplateSetAssertion {
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)
-	assert.NotNil(a.t, a.nsTmplSet.Spec.ClusterResources.TemplateRef)
+	assert.NotNil(a.t, a.nsTmplSet.Spec.ClusterResources)
 	assert.Equal(a.t, a.nsTmplSet.Spec.ClusterResources.TemplateRef, templateRef)
+	return a
+}
+
+func (a *NSTemplateSetAssertion) HasLastAppliedClusterResourcesTemplateRef(templateRef string) *NSTemplateSetAssertion {
+	err := a.loadNSTemplateSet()
+	require.NoError(a.t, err)
+	assert.NotNil(a.t, a.nsTmplSet.Status.ClusterResources)
+	assert.Equal(a.t, a.nsTmplSet.Status.ClusterResources.TemplateRef, templateRef)
 	return a
 }
 


### PR DESCRIPTION
When applying cluster-scoped resourcest the NSTemplateSet controller currently does the following:

1. It applies only a single resource from the list at a time. I.e. as soon as it detects that it has created or updated a cluster-scoped resource, it exits and reschedules itself to continue.
2. It uses labels on the cluster-scoped resources to mark them as part of the nstemplateset and uses those labels to determine the list of resources to consider during a reconcile.

This PR changes those 2 aspects such that:

1. All the cluster-scoped resources are applied in one go during a single reconciliation.
2. The membership of the resources is determined by comparing the current template ref (`spec.clusterresources.templateref`) with the last-applied templateref (`status.clusterresources.templateref`).

Those 2 changes required quite massive changes it the unit tests. I took the opportunity to slightly clean those up, too (removing a couple of redundant tests).

This change is getting us closer to unifying the way we deploy the cluster- and namespace-scoped resources.

Note that the e2e tests are currently not passing, so I'm opening this just as a draft PR to gather some preliminary thoughts and suggestions.