### PR TITLE
SANDBOX-1392: API-Pair Drop dependency on Che instance

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_memberoperatorconfigs.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberoperatorconfigs.yaml
@@ -68,44 +68,6 @@ spec:
                       the autoscaler buffer
                     type: boolean
                 type: object
-              che:
-                description: Keeps parameters concerned with Che/CRW
-                properties:
-                  keycloakRouteName:
-                    description: Defines the Che/CRW Keycloak route name
-                    type: string
-                  namespace:
-                    description: Defines the Che/CRW operator namespace
-                    type: string
-                  required:
-                    description: Defines a flag that indicates whether the Che/CRW
-                      operator is required to be installed on the cluster. May be
-                      used in monitoring.
-                    type: boolean
-                  routeName:
-                    description: Defines the Che/CRW route name
-                    type: string
-                  secret:
-                    description: Defines all secrets related to Che configuration
-                    properties:
-                      cheAdminPasswordKey:
-                        description: The key for the Che admin password in the secret
-                          values map
-                        type: string
-                      cheAdminUsernameKey:
-                        description: The key for the Che admin username in the secret
-                          values map
-                        type: string
-                      ref:
-                        description: Reference is the name of the secret resource
-                          to look up
-                        type: string
-                    type: object
-                  userDeletionEnabled:
-                    description: Defines a flag to turn the Che user deletion logic
-                      on/off
-                    type: boolean
-                type: object
               console:
                 description: Keeps parameters concerned with the console
                 properties:

--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -289,8 +289,7 @@ spec:
                     type: object
                 type: object
               routes:
-                description: Routes/URLs of the cluster, such as Console and Che Dashboard
-                  URLs
+                description: Routes/URLs of the cluster, such as Console
                 properties:
                   conditions:
                     description: |-

--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -50,48 +50,6 @@ spec:
             description: MemberStatusStatus defines the observed state of the toolchain
               member status
             properties:
-              che:
-                description: Che is the status of Che/CRW, such as installed and whether
-                  the member configuration is correct
-                properties:
-                  conditions:
-                    description: |-
-                      Conditions is an array of current Che status conditions
-                      Supported condition types: ConditionReady
-                    items:
-                      properties:
-                        lastTransitionTime:
-                          description: Last time the condition transit from one status
-                            to another.
-                          format: date-time
-                          type: string
-                        lastUpdatedTime:
-                          description: Last time the condition was updated
-                          format: date-time
-                          type: string
-                        message:
-                          description: Human readable message indicating details about
-                            last transition.
-                          type: string
-                        reason:
-                          description: (brief) reason for the condition's last transition.
-                          type: string
-                        status:
-                          description: Status of the condition, one of True, False,
-                            Unknown.
-                          type: string
-                        type:
-                          description: Type of condition
-                          type: string
-                      required:
-                      - status
-                      - type
-                      type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - type
-                    x-kubernetes-list-type: map
-                type: object
               conditions:
                 description: |-
                   Conditions is an array of current toolchain status conditions

--- a/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_memberstatuses.yaml
@@ -334,10 +334,6 @@ spec:
                 description: Routes/URLs of the cluster, such as Console and Che Dashboard
                   URLs
                 properties:
-                  cheDashboardURL:
-                    description: CheDashboardURL is the Che Dashboard URL of the cluster
-                      if Che is installed
-                    type: string
                   conditions:
                     description: |-
                       Conditions is an array of current member operator status conditions


### PR DESCRIPTION
This PR is to remove the `che` related unused code from crds

Related PRs:
- Api : https://github.com/codeready-toolchain/api/pull/488
- Host-operator : https://github.com/codeready-toolchain/host-operator/pull/1206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Removed Che/CRW configuration from the public configuration schema and removed related status entries, including the Che dashboard URL route.
  - Cleans up deprecated Che exposure in the public API.
  - Breaking change: users and automation referencing these fields should update configurations, scripts, and monitoring accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->