### PR TITLE
Update vm validation webhook

### DIFF
--- a/pkg/webhook/validatingwebhook/validate_vm_request.go
+++ b/pkg/webhook/validatingwebhook/validate_vm_request.go
@@ -138,7 +138,10 @@ func validateCloudInitUsername(unstructuredRequestObj *unstructured.Unstructured
 // validateTerminationGracePeriodSeconds checks that the terminationGracePeriodSeconds is not greater than the max allowed value
 func validateTerminationGracePeriodSeconds(unstructuredRequestObj *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(unstructuredRequestObj.Object, "spec", "template", "spec", "terminationGracePeriodSeconds")
-	if err != nil || !found {
+	if err != nil {
+		return errors.Wrap(err, "failed to get terminationGracePeriodSeconds from VirtualMachine")
+	}
+	if !found {
 		return nil
 	}
 

--- a/pkg/webhook/validatingwebhook/validate_vm_request.go
+++ b/pkg/webhook/validatingwebhook/validate_vm_request.go
@@ -14,6 +14,7 @@ import (
 )
 
 const manualRunStrategy = "Manual"
+const maxTerminationGracePeriodSeconds = int64(180)
 
 type VMRequestValidator struct {
 	Client runtimeClient.Client
@@ -78,6 +79,12 @@ func (v VMRequestValidator) validate(body []byte) []byte {
 		}
 	}
 
+	// validate terminationGracePeriodSeconds for both CREATE and UPDATE
+	if err := validateTerminationGracePeriodSeconds(unstructuredRequestObj); err != nil {
+		log.Error(err, "terminationGracePeriodSeconds validation failed", "VirtualMachine", unstructuredRequestObj)
+		return denyAdmissionRequest(admReview, errors.Errorf("this is a Dev Sandbox enforced restriction. %s", err.Error()))
+	}
+
 	// the user is configuring a VM without the 'runStrategy' configured or with it configured to Manual, allowing the request.
 	return allowAdmissionRequest(admReview)
 }
@@ -126,6 +133,30 @@ func validateCloudInitUsername(unstructuredRequestObj *unstructured.Unstructured
 	}
 
 	return errors.New("no username configured in cloudInit volume")
+}
+
+// validateTerminationGracePeriodSeconds checks that the terminationGracePeriodSeconds is not greater than the max allowed value
+func validateTerminationGracePeriodSeconds(unstructuredRequestObj *unstructured.Unstructured) error {
+	val, found, err := unstructured.NestedFieldNoCopy(unstructuredRequestObj.Object, "spec", "template", "spec", "terminationGracePeriodSeconds")
+	if err != nil || !found {
+		return nil
+	}
+
+	var gracePeriod int64
+	switch v := val.(type) {
+	case int64:
+		gracePeriod = v
+	case float64:
+		gracePeriod = int64(v)
+	default:
+		return errors.New("terminationGracePeriodSeconds has an invalid type")
+	}
+
+	if gracePeriod > maxTerminationGracePeriodSeconds {
+		return errors.Errorf("terminationGracePeriodSeconds cannot be greater than %d", maxTerminationGracePeriodSeconds)
+	}
+
+	return nil
 }
 
 // hasUsername checks if the userData contains a 'user' field

--- a/pkg/webhook/validatingwebhook/validate_vm_request.go
+++ b/pkg/webhook/validatingwebhook/validate_vm_request.go
@@ -145,13 +145,8 @@ func validateTerminationGracePeriodSeconds(unstructuredRequestObj *unstructured.
 		return nil
 	}
 
-	var gracePeriod int64
-	switch v := val.(type) {
-	case int64:
-		gracePeriod = v
-	case float64:
-		gracePeriod = int64(v)
-	default:
+	gracePeriod, ok := val.(int64)
+	if !ok {
 		return errors.New("terminationGracePeriodSeconds has an invalid type")
 	}
 

--- a/pkg/webhook/validatingwebhook/validate_vm_request_test.go
+++ b/pkg/webhook/validatingwebhook/validate_vm_request_test.go
@@ -532,7 +532,7 @@ func TestValidateTerminationGracePeriodSeconds(t *testing.T) {
 		require.EqualError(t, err, "terminationGracePeriodSeconds cannot be greater than 180")
 	})
 
-	t.Run("NestedFieldNoCopy error - allowed", func(t *testing.T) {
+	t.Run("NestedFieldNoCopy error - denied", func(t *testing.T) {
 		// given - spec.template.spec is set to a string instead of a map, causing NestedFieldNoCopy to return an error
 		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 		require.NoError(t, unstructured.SetNestedField(obj.Object, "not-a-map", "spec", "template", "spec"))
@@ -541,7 +541,7 @@ func TestValidateTerminationGracePeriodSeconds(t *testing.T) {
 		err := validateTerminationGracePeriodSeconds(obj)
 
 		// then
-		require.NoError(t, err)
+		require.EqualError(t, err, "failed to get terminationGracePeriodSeconds from VirtualMachine: .spec.template.spec.terminationGracePeriodSeconds accessor error: not-a-map is of the type string, expected map[string]interface{}")
 	})
 
 	t.Run("invalid type - denied", func(t *testing.T) {

--- a/pkg/webhook/validatingwebhook/validate_vm_request_test.go
+++ b/pkg/webhook/validatingwebhook/validate_vm_request_test.go
@@ -145,6 +145,65 @@ func TestHandleValidateVMAdmissionRequest(t *testing.T) {
 			test.VerifyRequestAllowed(t, body, "b6ae2ab4-782b-11ee-b962-0242ac120002")
 		})
 	})
+
+	t.Run("terminationGracePeriodSeconds validation", func(t *testing.T) {
+
+		t.Run("sandbox user trying to CREATE a VM with terminationGracePeriodSeconds greater than 180 is denied", func(t *testing.T) {
+			// when
+			resp, err := http.Post(ts.URL, "application/json", bytes.NewBuffer(newCreateVMAdmissionRequest(t, VMAdmReviewTmplParams{"CREATE", "johnsmith"}, createVMAdmissionRequestJSONWithGracePeriod("Manual", true, 300))))
+
+			// then
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			defer func() {
+				require.NoError(t, resp.Body.Close())
+			}()
+			require.NoError(t, err)
+			test.VerifyRequestBlocked(t, body, "this is a Dev Sandbox enforced restriction. terminationGracePeriodSeconds cannot be greater than 180", "b6ae2ab4-782b-11ee-b962-0242ac120002")
+		})
+
+		t.Run("sandbox user trying to UPDATE a VM with terminationGracePeriodSeconds greater than 180 is denied", func(t *testing.T) {
+			// when
+			resp, err := http.Post(ts.URL, "application/json", bytes.NewBuffer(newCreateVMAdmissionRequest(t, VMAdmReviewTmplParams{"UPDATE", "johnsmith"}, createVMAdmissionRequestJSONWithGracePeriod("Manual", true, 300))))
+
+			// then
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			defer func() {
+				require.NoError(t, resp.Body.Close())
+			}()
+			require.NoError(t, err)
+			test.VerifyRequestBlocked(t, body, "this is a Dev Sandbox enforced restriction. terminationGracePeriodSeconds cannot be greater than 180", "b6ae2ab4-782b-11ee-b962-0242ac120002")
+		})
+
+		t.Run("sandbox user trying to CREATE a VM with terminationGracePeriodSeconds equal to 180 is allowed", func(t *testing.T) {
+			// when
+			resp, err := http.Post(ts.URL, "application/json", bytes.NewBuffer(newCreateVMAdmissionRequest(t, VMAdmReviewTmplParams{"CREATE", "johnsmith"}, createVMAdmissionRequestJSONWithGracePeriod("Manual", true, 180))))
+
+			// then
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			defer func() {
+				require.NoError(t, resp.Body.Close())
+			}()
+			require.NoError(t, err)
+			test.VerifyRequestAllowed(t, body, "b6ae2ab4-782b-11ee-b962-0242ac120002")
+		})
+
+		t.Run("sandbox user trying to CREATE a VM without terminationGracePeriodSeconds is allowed", func(t *testing.T) {
+			// when
+			resp, err := http.Post(ts.URL, "application/json", bytes.NewBuffer(newCreateVMAdmissionRequest(t, VMAdmReviewTmplParams{"CREATE", "johnsmith"}, createVMAdmissionRequestJSONWithGracePeriod("Manual", true, -1))))
+
+			// then
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			defer func() {
+				require.NoError(t, resp.Body.Close())
+			}()
+			require.NoError(t, err)
+			test.VerifyRequestAllowed(t, body, "b6ae2ab4-782b-11ee-b962-0242ac120002")
+		})
+	})
 }
 
 func newVMRequestValidator(t *testing.T) *VMRequestValidator {
@@ -182,6 +241,12 @@ type VMAdmReviewTmplParams struct {
 // runStrategy is the RunStrategy to set in the VM spec; if empty, the field is omitted.
 // withCloudInitUsername is a boolean flag to indicate if the username should be included in the cloudInit userData; if false, the user field is omitted.
 func createVMAdmissionRequestJSON(runStrategy string, withCloudInitUsername bool) string {
+	return createVMAdmissionRequestJSONWithGracePeriod(runStrategy, withCloudInitUsername, -1)
+}
+
+// createVMAdmissionRequestJSONWithGracePeriod is like createVMAdmissionRequestJSON but also allows setting
+// terminationGracePeriodSeconds in spec.template.spec. Pass -1 to omit the field.
+func createVMAdmissionRequestJSONWithGracePeriod(runStrategy string, withCloudInitUsername bool, terminationGracePeriodSeconds int) string {
 	runStrategyField := ""
 	if runStrategy != "" {
 		runStrategyField = fmt.Sprintf(`"runStrategy": "%s",`, runStrategy)
@@ -189,6 +254,10 @@ func createVMAdmissionRequestJSON(runStrategy string, withCloudInitUsername bool
 	userField := ""
 	if withCloudInitUsername {
 		userField = "user: cloud-user\\n"
+	}
+	terminationGracePeriodField := ""
+	if terminationGracePeriodSeconds >= 0 {
+		terminationGracePeriodField = fmt.Sprintf(`"terminationGracePeriodSeconds": %d,`, terminationGracePeriodSeconds)
 	}
 	return fmt.Sprintf(`{
     "kind": "AdmissionReview",
@@ -235,6 +304,7 @@ func createVMAdmissionRequestJSON(runStrategy string, withCloudInitUsername bool
                 %s
                 "template": {
                     "spec": {
+                        %s
                         "volumes": [
                             {
                                 "name": "cloudinitdisk",
@@ -256,7 +326,7 @@ func createVMAdmissionRequestJSON(runStrategy string, withCloudInitUsername bool
             "fieldValidation": "Ignore"
         }
     }
-}`, runStrategyField, userField)
+}`, runStrategyField, terminationGracePeriodField, userField)
 }
 
 func TestValidateCloudInitUsername(t *testing.T) {
@@ -398,6 +468,92 @@ func TestValidateCloudInitUsername(t *testing.T) {
 
 		// then
 		require.EqualError(t, err, "no username configured in cloudInit volume")
+	})
+}
+
+func TestValidateTerminationGracePeriodSeconds(t *testing.T) {
+
+	t.Run("not set - allowed", func(t *testing.T) {
+		// given
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+		// when
+		err := validateTerminationGracePeriodSeconds(obj)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("set to 180 - allowed", func(t *testing.T) {
+		// given
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		require.NoError(t, unstructured.SetNestedField(obj.Object, int64(180), "spec", "template", "spec", "terminationGracePeriodSeconds"))
+
+		// when
+		err := validateTerminationGracePeriodSeconds(obj)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("set to 0 - allowed", func(t *testing.T) {
+		// given
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		require.NoError(t, unstructured.SetNestedField(obj.Object, int64(0), "spec", "template", "spec", "terminationGracePeriodSeconds"))
+
+		// when
+		err := validateTerminationGracePeriodSeconds(obj)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("set to 181 - denied", func(t *testing.T) {
+		// given
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		require.NoError(t, unstructured.SetNestedField(obj.Object, int64(181), "spec", "template", "spec", "terminationGracePeriodSeconds"))
+
+		// when
+		err := validateTerminationGracePeriodSeconds(obj)
+
+		// then
+		require.EqualError(t, err, "terminationGracePeriodSeconds cannot be greater than 180")
+	})
+
+	t.Run("set to 3600 - denied", func(t *testing.T) {
+		// given
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		require.NoError(t, unstructured.SetNestedField(obj.Object, int64(3600), "spec", "template", "spec", "terminationGracePeriodSeconds"))
+
+		// when
+		err := validateTerminationGracePeriodSeconds(obj)
+
+		// then
+		require.EqualError(t, err, "terminationGracePeriodSeconds cannot be greater than 180")
+	})
+
+	t.Run("NestedFieldNoCopy error - allowed", func(t *testing.T) {
+		// given - spec.template.spec is set to a string instead of a map, causing NestedFieldNoCopy to return an error
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		require.NoError(t, unstructured.SetNestedField(obj.Object, "not-a-map", "spec", "template", "spec"))
+
+		// when
+		err := validateTerminationGracePeriodSeconds(obj)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid type - denied", func(t *testing.T) {
+		// given
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		require.NoError(t, unstructured.SetNestedField(obj.Object, "not-a-number", "spec", "template", "spec", "terminationGracePeriodSeconds"))
+
+		// when
+		err := validateTerminationGracePeriodSeconds(obj)
+
+		// then
+		require.EqualError(t, err, "terminationGracePeriodSeconds has an invalid type")
 	})
 }
 


### PR DESCRIPTION
Prevents setting terminationGracePeriodSeconds to anything above the default 180 value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admission now enforces a maximum terminationGracePeriodSeconds of 180 seconds for CREATE and UPDATE operations; requests that omit the field remain allowed, values above the limit are denied.

* **Tests**
  * Added tests covering terminationGracePeriodSeconds: absent, boundary (0/180), excessive, invalid types, and end-to-end admission outcomes for CREATE/UPDATE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->