### PR TITLE
idler: catch the case when other owners are being deleted

### DIFF
--- a/controllers/idler/owners.go
+++ b/controllers/idler/owners.go
@@ -54,11 +54,11 @@ func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, pod *corev1.Pod) (str
 
 	timeoutSeconds := getTimeout(i.idler, *pod)
 	var topOwnerKind, topOwnerName string
-	attemptSuccessful := false
+	attempted := false
 	var errToReturn error
 	for _, ownerWithGVR := range owners {
 		if util.IsBeingDeleted(ownerWithGVR.Object) {
-			attemptSuccessful = false
+			attempted = false
 			continue
 		}
 		owner := ownerWithGVR.Object
@@ -81,7 +81,7 @@ func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, pod *corev1.Pod) (str
 			continue // Skip unknown owner types
 		}
 
-		attemptSuccessful = true
+		attempted = true
 		// Store the first processed owner's info and preserve its error
 		if topOwnerKind == "" {
 			topOwnerKind = ownerKind
@@ -99,10 +99,10 @@ func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, pod *corev1.Pod) (str
 		}
 		logger.Info("Scaling the first known owner down either failed or the pod has been running for longer than 105% of the idler timeout. Scaling the next known owner.")
 	}
-	// attemptSuccessful helps us to catch the case when idling of the top-level owner (eg. VM) didn't have any effect
+	// attempted helps us to catch the case when idling of the top-level owner (eg. VM) didn't have any effect
 	// and all other known owners are already being deleted - in this case, and when it's running for more than 110%
 	// of the idler timeout, we should return empty string to trigger deletion of the pod
-	if !attemptSuccessful && time.Now().After(pod.Status.StartTime.Add(time.Duration(float64(timeoutSeconds)*1.10)*time.Second)) {
+	if !attempted && time.Now().After(pod.Status.StartTime.Add(time.Duration(float64(timeoutSeconds)*1.10)*time.Second)) {
 		return "", "", errToReturn
 	}
 

--- a/controllers/idler/owners.go
+++ b/controllers/idler/owners.go
@@ -52,10 +52,13 @@ func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, pod *corev1.Pod) (str
 		logger.Error(err, "failed to find all owners, try to idle the workload with information that is available")
 	}
 
+	timeoutSeconds := getTimeout(i.idler, *pod)
 	var topOwnerKind, topOwnerName string
+	attemptSuccessful := false
 	var errToReturn error
 	for _, ownerWithGVR := range owners {
 		if util.IsBeingDeleted(ownerWithGVR.Object) {
+			attemptSuccessful = false
 			continue
 		}
 		owner := ownerWithGVR.Object
@@ -78,6 +81,7 @@ func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, pod *corev1.Pod) (str
 			continue // Skip unknown owner types
 		}
 
+		attemptSuccessful = true
 		// Store the first processed owner's info and preserve its error
 		if topOwnerKind == "" {
 			topOwnerKind = ownerKind
@@ -90,11 +94,16 @@ func (i *ownerIdler) scaleOwnerToZero(ctx context.Context, pod *corev1.Pod) (str
 		}
 
 		// If no error occurred and the pod doesn't run for longer than 105% of the idler timeout, return immediately after the first owner was idled
-		timeoutSeconds := getTimeout(i.idler, *pod)
 		if err == nil && !time.Now().After(pod.Status.StartTime.Add(time.Duration(float64(timeoutSeconds)*1.05)*time.Second)) {
 			return topOwnerKind, topOwnerName, nil
 		}
 		logger.Info("Scaling the first known owner down either failed or the pod has been running for longer than 105% of the idler timeout. Scaling the next known owner.")
+	}
+	// attemptSuccessful helps us to catch the case when idling of the top-level owner (eg. VM) didn't have any effect
+	// and all other known owners are already being deleted - in this case, and when it's running for more than 110%
+	// of the idler timeout, we should return empty string to trigger deletion of the pod
+	if !attemptSuccessful && time.Now().After(pod.Status.StartTime.Add(time.Duration(float64(timeoutSeconds)*1.10)*time.Second)) {
+		return "", "", errToReturn
 	}
 
 	// Return the first processed owner's info (or empty if none were processed), and the list of errors (if any happened)

--- a/controllers/idler/owners_test.go
+++ b/controllers/idler/owners_test.go
@@ -450,6 +450,46 @@ func TestAppNameTypeForControllers(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("first owner idled but remaining owners being deleted and pod exceeds 110% timeout triggers pod deletion", func(t *testing.T) {
+		for kind, createTestConfig := range testConfigs {
+			t.Run(kind, func(t *testing.T) {
+				// given
+				ownerIdler, fakeClients, testConfig, _, pod := setup(t, createTestConfig, true)
+				pod.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Duration(float64(3600)*1.15) * time.Second)}
+				allOwners, err := ownerIdler.ownerFetcher.GetOwners(context.TODO(), pod)
+				require.NoError(t, err)
+
+				// mark all owners except the first as being deleted
+				for i := 1; i < len(allOwners); i++ {
+					owner := allOwners[i].Object
+					now := metav1.Now()
+					owner.SetDeletionTimestamp(&now)
+					util.AddFinalizer(owner, "dummy-finalizer")
+					_, err := fakeClients.DynamicClient.
+						Resource(*allOwners[i].GVR).
+						Namespace(owner.GetNamespace()).
+						Update(context.TODO(), owner, metav1.UpdateOptions{})
+					require.NoError(t, err)
+				}
+
+				// when
+				appType, appName, err := ownerIdler.scaleOwnerToZero(context.TODO(), pod)
+
+				// then
+				require.NoError(t, err)
+				if len(allOwners) > 1 {
+					// For multi-owner chains: the first owner was processed but all remaining are being deleted
+					require.Empty(t, appType)
+					require.Empty(t, appName)
+				} else {
+					// For single-owner chains: the one owner was processed successfully, so normal return.
+					require.Equal(t, kind, appType)
+					require.Equal(t, testConfig.expectedAppName, appName)
+				}
+			})
+		}
+	})
 }
 
 func assertOtherOwners(t *testing.T, ownerIdler *ownerIdler, pod *corev1.Pod, secondOwnerIdled bool) {


### PR DESCRIPTION
This is to cover the case when idling of the top-level owner didn't have any effect and all other owners are already being deleted. When this persists for more than 110% of the timeout, then it will try to delete the pod.
https://redhat-internal.slack.com/archives/C0AEFNZ5KHB/p1776136788506989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idle pod deletion fallback logic to better handle scenarios where pod owners are already being deleted and pods exceed timeout thresholds.

* **Tests**
  * Added test coverage for pod deletion when owners are in deletion state and pod exceeds idle timeout duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->