### PR TITLE
SANDBOX-1282 | refactor: replace "wrapf" calls with stdlib wrap calls

### DIFF
--- a/controllers/nstemplateset/nstemplatetier.go
+++ b/controllers/nstemplateset/nstemplatetier.go
@@ -14,7 +14,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	templatev1 "github.com/openshift/api/template/v1"
-	"github.com/pkg/errors"
 	errs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -80,7 +79,7 @@ func getToolchainTierTemplate(ctx context.Context, getHostClient host.ClientGett
 		Name:      templateRef,
 	}, tierTemplate)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to retrieve the TierTemplate '%s' from 'Host' cluster", templateRef)
+		return nil, fmt.Errorf("unable to retrieve the TierTemplate '%s' from 'Host' cluster: %w", templateRef, err)
 	}
 	return tierTemplate, nil
 }

--- a/controllers/nstemplateset/space_roles.go
+++ b/controllers/nstemplateset/space_roles.go
@@ -3,6 +3,7 @@ package nstemplateset
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -110,7 +111,7 @@ func (r *spaceRolesManager) getSpaceRolesObjects(ctx context.Context, ns *corev1
 				Username:  username,
 			})
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to process space roles template '%s' for the user '%s' in namespace '%s'", spaceRole.TemplateRef, username, ns.Name)
+				return nil, fmt.Errorf("failed to process space roles template '%s' for the user '%s' in namespace '%s': %w", spaceRole.TemplateRef, username, ns.Name, err)
 			}
 			spaceRoleObjects = append(spaceRoleObjects, objs...)
 		}

--- a/controllers/nstemplateset/tier_template_revision.go
+++ b/controllers/nstemplateset/tier_template_revision.go
@@ -6,7 +6,6 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/member-operator/pkg/host"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -24,7 +23,7 @@ func getTierTemplateRevision(ctx context.Context, getHostClient host.ClientGette
 		Name:      templateRef,
 	}, tierTemplateRevision)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to retrieve the TierTemplateRevision '%s' from 'Host' cluster", templateRef)
+		return nil, fmt.Errorf("unable to retrieve the TierTemplateRevision '%s' from 'Host' cluster: %w", templateRef, err)
 	}
 	return tierTemplateRevision, nil
 }

--- a/pkg/webhook/mutatingwebhook/vm_mutate.go
+++ b/pkg/webhook/mutatingwebhook/vm_mutate.go
@@ -66,13 +66,13 @@ func vmMutator(admReview admissionv1.AdmissionReview) *admissionv1.AdmissionResp
 	vmPatchItems, cloudInitConfigErr = ensureVolumeConfig(unstructuredRequestObj, vmPatchItems)
 	if cloudInitConfigErr != nil {
 		vmLogger.Error(cloudInitConfigErr, "failed to update volume configuration for VirtualMachine", "AdmissionReview", admReview, "Patch-Items", vmPatchItems)
-		return responseWithError(admReview.Request.UID, errors.Wrapf(cloudInitConfigErr, "failed to update volume configuration for VirtualMachine"))
+		return responseWithError(admReview.Request.UID, fmt.Errorf("failed to update volume configuration for VirtualMachine: %w", cloudInitConfigErr))
 	}
 
 	patchContent, err := json.Marshal(vmPatchItems)
 	if err != nil {
 		vmLogger.Error(err, "failed to marshal patch items for VirtualMachine", "AdmissionReview", admReview, "Patch-Items", vmPatchItems)
-		return responseWithError(admReview.Request.UID, errors.Wrapf(err, "failed to marshal patch items for VirtualMachine"))
+		return responseWithError(admReview.Request.UID, fmt.Errorf("failed to marshal patch items for VirtualMachine: %w", err))
 	}
 	resp.Patch = patchContent
 
@@ -84,7 +84,7 @@ func ensureVolumeConfig(unstructuredRequestObj *unstructured.Unstructured, patch
 	volumes, volumesFound, err := unstructured.NestedSlice(unstructuredRequestObj.Object, "spec", "template", "spec", "volumes")
 	if err != nil {
 		vmLogger.Error(err, "failed to decode VirtualMachine resource", "VirtualMachine", unstructuredRequestObj)
-		return patchItems, errors.Wrapf(err, "failed to decode VirtualMachine")
+		return patchItems, fmt.Errorf("failed to decode VirtualMachine: %w", err)
 	}
 
 	if !volumesFound {
@@ -120,7 +120,7 @@ func ensureVolumeConfig(unstructuredRequestObj *unstructured.Unstructured, patch
 					// userData is defined, append the ssh key
 					updatedUserData, err := addSSHKeysToUserData(userData.(string), sshKeys)
 					if err != nil {
-						return patchItems, errors.Wrapf(err, "failed to add ssh key to userData")
+						return patchItems, fmt.Errorf("failed to add ssh key to userData: %w", err)
 					}
 					cloudInitConfig["userData"] = updatedUserData
 				} else {

--- a/pkg/webhook/validatingwebhook/validate_rolebinding_request.go
+++ b/pkg/webhook/validatingwebhook/validate_rolebinding_request.go
@@ -12,7 +12,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	userv1 "github.com/openshift/api/user/v1"
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,7 +50,7 @@ func (v RoleBindingRequestValidator) validate(ctx context.Context, body []byte) 
 		//sanitize the body
 		escapedBody := html.EscapeString(string(body))
 		log.Error(err, "unable to deserialize the admission review object", "body", escapedBody)
-		return denyAdmissionRequest(admReview, errors.Wrapf(err, "unable to deserialize the admission review object - body: %v", escapedBody))
+		return denyAdmissionRequest(admReview, fmt.Errorf("unable to deserialize the admission review object - body: %v: %w", escapedBody, err))
 	}
 	// let's unmarshal the object to be sure that it's a rolebinding
 	rb := rbac.RoleBinding{}
@@ -60,7 +59,7 @@ func (v RoleBindingRequestValidator) validate(ctx context.Context, body []byte) 
 			err = fmt.Errorf("request Object is not a rolebinding")
 		}
 		log.Error(err, "unable unmarshal rolebinding json object", "AdmissionReview", admReview)
-		return denyAdmissionRequest(admReview, errors.Wrapf(err, "unable to unmarshal object or object is not a rolebinding - raw request object: %v", admReview.Request.Object.Raw))
+		return denyAdmissionRequest(admReview, fmt.Errorf("unable to unmarshal object or object is not a rolebinding - raw request object: %v: %w", admReview.Request.Object.Raw, err))
 	}
 	requestingUsername := admReview.Request.UserInfo.Username
 	// allow admission request if the user is a system user
@@ -84,7 +83,7 @@ func (v RoleBindingRequestValidator) validate(ctx context.Context, body []byte) 
 			//check if the requesting user is a sandbox user
 			if requestingUser.GetLabels()[toolchainv1alpha1.ProviderLabelKey] == toolchainv1alpha1.ProviderLabelValue {
 				log.Info("sandbox user is trying to create a rolebinding giving wider access", "AdmissionReview", admReview)
-				return denyAdmissionRequest(admReview, errors.Wrapf(fmt.Errorf("please create a rolebinding for a specific user or service account to avoid this error"), "this is a Dev Sandbox enforced restriction. you are trying to create a rolebinding giving access to a larger audience, i.e : %v and requesting user: %+v", sub.Name, requestingUser.Labels))
+				return denyAdmissionRequest(admReview, fmt.Errorf("this is a Dev Sandbox enforced restriction. you are trying to create a rolebinding giving access to a larger audience, i.e : %v and requesting user: %+v: %w", sub.Name, requestingUser.Labels, fmt.Errorf("please create a rolebinding for a specific user or service account to avoid this error")))
 			}
 			//At this point, it is clear the user isn't a sandbox user, allow request
 			break

--- a/pkg/webhook/validatingwebhook/validate_ssp_request.go
+++ b/pkg/webhook/validatingwebhook/validate_ssp_request.go
@@ -2,6 +2,7 @@ package validatingwebhook
 
 import (
 	"context"
+	"fmt"
 	"html"
 	"io"
 	"net/http"
@@ -49,7 +50,7 @@ func (v SSPRequestValidator) validate(ctx context.Context, body []byte) []byte {
 		// sanitize the body
 		escapedBody := html.EscapeString(string(body))
 		log.Error(err, "unable to deserialize the admission review object", "body", escapedBody)
-		return denyAdmissionRequest(admReview, errors.Wrapf(err, "unable to deserialize the admission review object - body: %v", escapedBody))
+		return denyAdmissionRequest(admReview, fmt.Errorf("unable to deserialize the admission review object - body: %v: %w", escapedBody, err))
 	}
 	//check if the requesting user is a sandbox user
 	requestingUser := &userv1.User{}

--- a/pkg/webhook/validatingwebhook/validate_vm_request.go
+++ b/pkg/webhook/validatingwebhook/validate_vm_request.go
@@ -1,6 +1,7 @@
 package validatingwebhook
 
 import (
+	"fmt"
 	"html"
 	"io"
 	"net/http"
@@ -49,7 +50,7 @@ func (v VMRequestValidator) validate(body []byte) []byte {
 		// sanitize the body
 		escapedBody := html.EscapeString(string(body))
 		log.Error(err, "unable to deserialize the admission review object", "body", escapedBody)
-		return denyAdmissionRequest(admReview, errors.Wrapf(err, "unable to deserialize the admission review object - body: %v", escapedBody))
+		return denyAdmissionRequest(admReview, fmt.Errorf("unable to deserialize the admission review object - body: %v: %w", escapedBody, err))
 	}
 
 	unstructuredRequestObj := &unstructured.Unstructured{}


### PR DESCRIPTION
There is no need to keep the legacy "wrapf" calls to wrap errors anymore, so the idea is to remove them in favor of the wrapping calls of the stdlib.

## Related PRs

- https://github.com/codeready-toolchain/host-operator/pull/1257
- https://github.com/codeready-toolchain/member-operator/pull/744
- https://github.com/codeready-toolchain/toolchain-common/pull/526
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1275

## Jira ticket
[[SANDBOX-1282]](https://redhat.atlassian.net/browse/SANDBOX-1282)