### PR TITLE
chore: update govulncheck config

### DIFF
--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -1,13 +1,85 @@
 ignored-vulnerabilities:
-  # Incorrect parsing of IPv6 host literals in net/url
-  # Found in: net/url@go1.24.13
-  # Fixed in: net/url@go1.25.8
-  - id: GO-2026-4601
-    info: https://pkg.go.dev/vuln/GO-2026-4601
-    silence-until: 2026-04-12
-  # FileInfo can escape from a Root in os
-  # Found in: os@go1.24.13
-  # Fixed in: os@go1.25.8
-  - id: GO-2026-4602
-    info: https://pkg.go.dev/vuln/GO-2026-4602
-    silence-until: 2026-04-12
+    # Incorrect parsing of IPv6 host literals in net/url
+    # Found in: net/url@go1.24.13
+    # Fixed in: net/url@go1.25.8
+    - id: GO-2026-4601
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4601
+    # FileInfo can escape from a Root in os
+    # Found in: os@go1.24.13
+    # Fixed in: os@go1.25.8
+    - id: GO-2026-4602
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4602
+    # Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection retention and DoS in crypto/tls
+    # Found in: crypto/tls@go1.24.13
+    # Fixed in: crypto/tls@go1.25.9
+    - id: GO-2026-4870
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4870
+    # Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 in golang.org/x/net
+    # Found in: golang.org/x/net/http2@v0.47.0
+    # Fixed in: golang.org/x/net/http2@v0.53.0
+    - id: GO-2026-4918
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4918
+    # Inefficient policy validation in crypto/x509
+    # Found in: crypto/x509@go1.24.13
+    # Fixed in: crypto/x509@go1.25.9
+    - id: GO-2026-4946
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4946
+    # Unexpected work during chain building in crypto/x509
+    # Found in: crypto/x509@go1.24.13
+    # Fixed in: crypto/x509@go1.25.9
+    - id: GO-2026-4947
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4947
+    # Panic in Dial and LookupPort when handling NUL byte on Windows in net
+    # Found in: net@go1.24.13
+    # Fixed in: net@go1.25.10
+    - id: GO-2026-4971
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4971
+    # Quadratic string concatenation in consumePhrase in net/mail
+    # Found in: net/mail@go1.24.13
+    # Fixed in: net/mail@go1.25.10
+    - id: GO-2026-4977
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4977
+    # Quadratic string concatentation in consumeComment in net/mail
+    # Found in: net/mail@go1.24.13
+    # Fixed in: net/mail@go1.25.10
+    - id: GO-2026-4986
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-4986
+    # Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
+    # Found in: golang.org/x/net/idna@v0.47.0
+    # Fixed in: golang.org/x/net/idna@v0.55.0
+    - id: GO-2026-5026
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-5026
+    # Inefficient candidate hostname parsing in crypto/x509
+    # Found in: crypto/x509@go1.24.13
+    # Fixed in: crypto/x509@go1.25.11
+    - id: GO-2026-5037
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-5037
+    # Quadratic complexity in WordDecoder.DecodeHeader in mime
+    # Found in: mime@go1.24.13
+    # Fixed in: mime@go1.25.11
+    - id: GO-2026-5038
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-5038
+    # Arbitrary inputs are included in errors without any escaping in net/textproto
+    # Found in: net/textproto@go1.24.13
+    # Fixed in: net/textproto@go1.25.11
+    - id: GO-2026-5039
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-5039
+    # Invoking Encrypted Client Hello privacy leak in crypto/tls
+    # Found in: crypto/tls@go1.24.13
+    # Fixed in: crypto/tls@go1.25.12
+    - id: GO-2026-5856
+      silence-until: 2026-08-15
+      info: https://pkg.go.dev/vuln/GO-2026-5856


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated vulnerability scan exception records and associated information links.
  - Extended the review date for existing and newly tracked vulnerability entries through August 15, 2026.
  - Added coverage for additional vulnerability advisories.
  - No user-facing functionality or behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->