### PR TITLE
fix: create GOCACHE before chown in CI tools image

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -12,15 +12,9 @@ ENV LANG=en_US.utf8 \
     GOLANG_VERSION=go1.26.5 \
     GOLANG_SHA256=5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053
 
-RUN useradd -u 1001 -g 0 -m -d /home/ciuser ciuser
-
-RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/ \
-    && chown -R 1001:0 ${GOPATH} ${GOCACHE} \
-    && chmod -R g+rwX ${GOPATH} ${GOCACHE}
-
-USER 1001 
-
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/member-operator
+
+RUN useradd -u 1001 -g 0 -m -d /home/ciuser ciuser
 
 RUN yum install -y \
     findutils \
@@ -77,6 +71,12 @@ RUN curl -Lo ${GOLANG_VERSION}.linux-amd64.tar.gz https://dl.google.com/go/${GOL
 
 # Increase shared memory for browsers (recommended for Playwright)
 RUN mkdir -p /dev/shm && chmod 1777 /dev/shm
+
+RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/ ${GOCACHE} \
+    && chown -R 1001:0 ${GOPATH} ${GOCACHE} \
+    && chmod -R g+rwX ${GOPATH} ${GOCACHE}
+
+USER 1001
 
 WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}
 


### PR DESCRIPTION
The Go 1.26.5 Dockerfile chowned /tmp/.cache before creating it, which breaks the OpenShift CI root image build (root is built from master HEAD). Install packages as root, then create and chown GOPATH/GOCACHE before switching to USER 1001.

Fixes what was broken by https://github.com/codeready-toolchain/member-operator/pull/763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the container setup process for more reliable tool installation and workspace initialization.
  * Enhanced workspace cache preparation and permissions to support smoother builds and development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->